### PR TITLE
set install_name on mac

### DIFF
--- a/GraphBLAS/Tcov/Makefile
+++ b/GraphBLAS/Tcov/Makefile
@@ -35,7 +35,7 @@ ifeq ($(UNAME),Darwin)
     # Mac
     CFLAGS += -fno-common
     SO_NAME = libgraphblas_tcov.dylib
-    SO_OPTS += -dynamiclib -shared -undefined dynamic_lookup
+    SO_OPTS += -dynamiclib -shared -Wl,-install_name -Wl,$(SO_NAME) -undefined dynamic_lookup
 else
     # Linux
     SO_NAME = libgraphblas_tcov.so

--- a/GraphBLAS/alternative/Makefile
+++ b/GraphBLAS/alternative/Makefile
@@ -37,13 +37,13 @@ ifeq ($(UNAME),Darwin)
     SO_NAME = libgraphblas.dylib.$(VER1).$(VER2).$(VER3)
     SO_NAME0 = libgraphblas.dylib
     SO_NAME1 = libgraphblas.dylib.$(VER1)
-    SO_OPTS += -dynamiclib -shared -undefined dynamic_lookup
+    SO_OPTS += -dynamiclib -shared  -Wl,-install_name -Wl,$(SO_NAME1) -undefined dynamic_lookup
 else
     # Linux
     SO_NAME = libgraphblas.so.$(VER1).$(VER2).$(VER3)
     SO_NAME0 = libgraphblas.so
     SO_NAME1 = libgraphblas.so.$(VER1)
-    SO_OPTS += -shared -Wl,-soname -Wl,$(SO_NAME)
+    SO_OPTS += -shared -Wl,-soname -Wl,$(SO_NAME1)
 endif
 
 %.o: ../Source/%.c $(INC)

--- a/SuiteSparse_config/SuiteSparse_config.mk
+++ b/SuiteSparse_config/SuiteSparse_config.mk
@@ -464,6 +464,7 @@ else
         SO_TARGET = $(LIBRARY).$(VERSION).dylib
         SO_OPTS  += -dynamiclib -compatibility_version $(SO_VERSION) \
                     -current_version $(VERSION) \
+                    -Wl,-install_name -Wl,$(SO_MAIN) \
                     -shared -undefined dynamic_lookup
         # When a Mac *.dylib file is moved, this command is required
         # to change its internal name to match its location in the filesystem:


### PR DESCRIPTION
install_name is the mac equivalent of soname, and is required for dependants to find suitesparse libs after they are upgraded but still ABI compatible (i.e. SO_VERSION is unchanged). In short, everywhere soname is set on linux, install_name should be set on darwin.

Prevents errors like:

```
Library not loaded: @rpath/libsuitesparseconfig.4.5.3.dylib
  Referenced from: /Users/minrk/conda/envs/petsc/lib/libslepc.3.7.dylib
  Reason: image not found
```

which are caused when a lib is compiled against 4.5.3 and suitesparse is upgraded to e.g. 4.5.4, which is ABI compatible and should work without modification. The name in the "Library not loaded" line is set by install_name.

See https://github.com/conda-forge/suitesparse-feedstock/issues/22 for this issue tracked in the conda-forge community.