### PR TITLE
 Fix bad check on allocation return value

### DIFF
--- a/GraphBLAS/Source/GB_ek_slice.c
+++ b/GraphBLAS/Source/GB_ek_slice.c
@@ -46,7 +46,7 @@ bool GB_ek_slice        // true if successful, false if out of memory
     GB_CALLOC_MEMORY (kfirst_slice, ntasks, sizeof (int64_t)) ;
     GB_CALLOC_MEMORY (klast_slice, ntasks, sizeof (int64_t)) ;
 
-    if (pstart_slice == NULL || kfirst_slice == NULL | klast_slice == NULL)
+    if (pstart_slice == NULL || kfirst_slice == NULL || klast_slice == NULL)
     {
         GB_ek_slice_free (&pstart_slice, &kfirst_slice, &klast_slice, ntasks) ;
         return (false) ;


### PR DESCRIPTION
Mainly to clean up the compiler warning on missing parans.