### PR TITLE
UMFPACK: update version in header to latest (5.7.9)

### DIFF
--- a/UMFPACK/Include/umfpack.h
+++ b/UMFPACK/Include/umfpack.h
@@ -95,7 +95,7 @@ extern "C" {
 /* Version, copyright, and license */
 /* -------------------------------------------------------------------------- */
 
-#define UMFPACK_VERSION "UMFPACK V5.7.8 (Nov 9, 2018)"
+#define UMFPACK_VERSION "UMFPACK V5.7.9 (Oct 20, 2019)"
 
 #define UMFPACK_COPYRIGHT \
 "UMFPACK:  Copyright (c) 2005-2013 by Timothy A. Davis.  All Rights Reserved.\n"
@@ -132,11 +132,11 @@ extern "C" {
  * above.
  */
 
-#define UMFPACK_DATE "Nov 9, 2018"
+#define UMFPACK_DATE "Oct 20, 2019"
 #define UMFPACK_VER_CODE(main,sub) ((main) * 1000 + (sub))
 #define UMFPACK_MAIN_VERSION 5
 #define UMFPACK_SUB_VERSION 7
-#define UMFPACK_SUBSUB_VERSION 8
+#define UMFPACK_SUBSUB_VERSION 9
 #define UMFPACK_VER UMFPACK_VER_CODE(UMFPACK_MAIN_VERSION,UMFPACK_SUB_VERSION)
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
Fixes reported version mismatch since 6ee9c7e3d3a6e8fa1322abce8cafd0dc0399d66a
(SuiteSparse v5.5.0) when the UMFPACK source was updated to 5.7.9 but version
in the header stayed at 5.7.8.

This version information is reported by UMFPACK at runtime, e.g.:

    UMFPACK V5.7.8 (Nov 9, 2018), Info:

And mismatch between the reported versions and the version in the source tree
(in ChangeLog) leads to confusion for users with regards to which UMFPACK
library is being used in build of software that links against UMFPACK.

I thought it's worth submitting this PR because SuiteSparse is released more frequently than UMFPACK, so the mismatch can be fixed in next SuiteSparse release.

To avoid the contributor agreement process, instead of merging this PR maybe just make the edit on your end.