### PR TITLE
UMFPACK: avoid warning with SunStudio compiler

### DIFF
--- a/UMFPACK/Source/umfpack_qsymbolic.c
+++ b/UMFPACK/Source/umfpack_qsymbolic.c
@@ -2690,8 +2690,8 @@ GLOBAL Int UMFPACK_qsymbolic
         Quser,
 
         /* no user provided ordering function */
-        (void *) NULL,
-        (void *) NULL,
+        NULL,
+        NULL,
 
         SymbolicHandle, Control, User_Info)) ;
 }


### PR DESCRIPTION
```
"../Source/umfpack_qsymbolic.c", line 2693: warning: argument #7 is incompatible with prototype:
        prototype: pointer to function(int, int, int, pointer to int, pointer to int, pointer to int, pointer to void, pointer to double) returning int : "../Source/umfpack_qsymbolic.c", line
 660
        argument : pointer to void
```

This is a very simple change. Let me know if you need a CLA.