### PR TITLE
Mark 'cs' as potentially unused variable

### DIFF
--- a/CCOLAMD/Source/ccolamd.c
+++ b/CCOLAMD/Source/ccolamd.c
@@ -1560,7 +1560,7 @@ PUBLIC Int CCOLAMD_2	    /* returns TRUE if successful, FALSE otherwise */
     Int *dead_cols ;
     Int set1 ;
     Int set2 ;
-    Int cs ;
+    Int cs __attribute__((unused)) ;
 
     int ok ;
 


### PR DESCRIPTION
Newer versions of gcc throw a warning that the `cs` variable is unused.

```
ccolamd.c:1563:9: warning: variable 'cs' set but not used [-Wunused-but-set-variable]
     Int cs ;
         ^~
```

This PR marks the variable as potentially unused so that the compiler no longer complains about it.