### PR TITLE
Tweaks to the MacOS build config

### DIFF
--- a/SuiteSparse_config/SuiteSparse_config.mk
+++ b/SuiteSparse_config/SuiteSparse_config.mk
@@ -374,6 +374,7 @@ SUITESPARSE_VERSION = 5.7.2
         LAPACK ?= -framework Accelerate
         # OpenMP is not yet supported by default in clang
         CFOPENMP =
+        LDLIBS += -rpath $(INSTALL_LIB)
     endif
 
     #---------------------------------------------------------------------------
@@ -463,7 +464,7 @@ else
         SO_TARGET = $(LIBRARY).$(VERSION).dylib
         SO_OPTS  += -dynamiclib -compatibility_version $(SO_VERSION) \
                     -current_version $(VERSION) \
-                    -Wl,-install_name -Wl,$(SO_MAIN) \
+                    -Wl,-install_name -Wl,@rpath/$(SO_MAIN) \
                     -shared -undefined dynamic_lookup
         # When a Mac *.dylib file is moved, this command is required
         # to change its internal name to match its location in the filesystem:

--- a/metis-5.1.0/CMakeLists.txt
+++ b/metis-5.1.0/CMakeLists.txt
@@ -3,6 +3,7 @@ project(METIS)
 
 set(GKLIB_PATH "GKlib" CACHE PATH "path to GKlib")
 set(SHARED FALSE CACHE BOOL "build a shared library")
+set(CMAKE_MACOSX_RPATH TRUE)
 
 if(MSVC)
   set(METIS_INSTALL FALSE)


### PR DESCRIPTION
This change uses rpath more effectively - it should serve while you transition to CMake