### PR TITLE
SLIP_LU: allow custom paths for gmp and mpfr

### DIFF
--- a/SLIP_LU/Lib/Makefile
+++ b/SLIP_LU/Lib/Makefile
@@ -20,9 +20,9 @@ include ../../SuiteSparse_config/SuiteSparse_config.mk
 # CFLAGS += -Wall -Wextra -Wpedantic -Werror
 
 # SLIP_LU depends on SuiteSparse_config, AMD, COLAMD, M, GMP, and MPFR
-LDLIBS += -lsuitesparseconfig -lamd -lcolamd -lm -lgmp -lmpfr
+LDLIBS += -L${GMP_ROOT}/lib -L${MPFR_ROOT}/lib -lsuitesparseconfig -lamd -lcolamd -lm -lgmp -lmpfr
 
-C = $(CC) $(CF) -I../Include -I../../COLAMD/Include -I../../AMD/Include -I../../SuiteSparse_config
+C = $(CC) $(CF) -I../Include -I../../COLAMD/Include -I../../AMD/Include -I../../SuiteSparse_config -I${GMP_ROOT}/include -I${MPFR_ROOT}/include
 
 all: install
 


### PR DESCRIPTION
If gmp and mpfr are not installed on the OS, there is no solution to get them used by SLIP_LU.
This PR allows to specify paths to mpfr and gmp with the variables MPFR_ROOT and GMP_ROOT.
