### PR TITLE
Avoid C warnings

### DIFF
--- a/GraphBLAS/Source/GB_math.h
+++ b/GraphBLAS/Source/GB_math.h
@@ -564,6 +564,7 @@ inline float GB_frexpef (float x)
 {
     int exp ;
     float mantissa_ignored = frexpf (x, &exp) ;
+    (void) mantissa_ignored ; // to silence unused variable warnings
     return ((float) exp) ;
 }
 
@@ -577,6 +578,7 @@ inline double GB_frexpe (double x)
 {
     int exp ;
     double mantissa_ignored = frexp (x, &exp) ;
+    (void) mantissa_ignored ; // to silence unused variable warnings
     return ((double) exp) ;
 }
 

--- a/GraphBLAS/Source/GB_printf.h
+++ b/GraphBLAS/Source/GB_printf.h
@@ -79,6 +79,7 @@
     if (printf_result < 0)                                                  \
     {                                                                       \
         int err = errno ;                                                   \
+        (void)err ; /* to avoid unused variable warning */                  \
         return (GrB_INVALID_VALUE) ;                                        \
     }                                                                       \
 }

--- a/GraphBLAS/Source/Generator/GB_AxB_defs.h
+++ b/GraphBLAS/Source/Generator/GB_AxB_defs.h
@@ -124,9 +124,10 @@
 #define GB_IS_PLUS_PAIR_REAL_SEMIRING \
     GB_is_plus_pair_real_semiring
 
-// // 1 for performance-critical semirings, which get extra optimization
-// #define GB_IS_PERFORMANCE_CRITICAL_SEMIRING \
-//     GB_is_performance_critical_semiring
+/* // 1 for performance-critical semirings, which get extra optimization
+ #define GB_IS_PERFORMANCE_CRITICAL_SEMIRING \
+    GB_is_performance_critical_semiring
+*/
 
 // declare the cij scalar
 #if GB_IS_PLUS_PAIR_REAL_SEMIRING


### PR DESCRIPTION
Please double check that the generated files are working, as I was not able to regenerate all files with Octave (missing function contains).