### PR TITLE
Fix typo in comment for pattern of L in ldl code

### DIFF
--- a/LDL/Source/ldl.c
+++ b/LDL/Source/ldl.c
@@ -299,7 +299,7 @@ LDL_int LDL_numeric	/* returns n if successful, k if D (k,k) is zero */
 	Y [k] = 0.0 ;
 	for ( ; top < n ; top++)
 	{
-	    i = Pattern [top] ;	    /* Pattern [top:n-1] is pattern of L(:,k) */
+	    i = Pattern [top] ;	    /* Pattern [top:n-1] is pattern of L(k,:) */
 	    yi = Y [i] ;	    /* get and clear Y(i) */
 	    Y [i] = 0.0 ;
 	    p2 = Lp [i] + Lnz [i] ;


### PR DESCRIPTION
Pattern holds the column indices of the k-th row of L, not the row indices of the k-th column of L.

Follow-up on https://github.com/DrTimothyAldenDavis/SuiteSparse/pull/3, now with contributor agreement.