### PR TITLE
Fix Linking error when run executables in SLIP_LU/Demo

### DIFF
--- a/SLIP_LU/Demo/Makefile
+++ b/SLIP_LU/Demo/Makefile
@@ -18,28 +18,29 @@ include ../../SuiteSparse_config/SuiteSparse_config.mk
 # CF = $(CFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -O
 I = -I../Include -I../Source -I../../SuiteSparse_config -I../../COLAMD/Include -I../../AMD/Include
 
-# LDFLAGS = -L../../lib
+LDFLAGS = -L../../lib
 
 LDLIBS += -lm -lgmp -lmpfr -lcolamd -lamd -lsliplu
 CS = $(LDLIBS)
 
+RPATH = -Wl,-rpath=../../lib
 
 all: lib example example2 SLIPLU
-	- ./example
-	- ./example2
-	- ./SLIPLU
+	-./example
+	-./example2
+	-./SLIPLU
 
 lib:
 	( cd ../Lib ; $(MAKE) )
 
 example: lib example.c Makefile
-	$(CC) $(LDFLAGS) $(CF) $(I) -o example example.c $(CS)
+	$(CC) $(LDFLAGS) $(CF) $(I) -o example example.c $(CS) $(RPATH)
 
 example2: lib example2.c Makefile
-	$(CC) $(LDFLAGS) $(CF) $(I) -o example2 example2.c demos.c $(CS)
+	$(CC) $(LDFLAGS) $(CF) $(I) -o example2 example2.c demos.c $(CS) $(RPATH)
 
 SLIPLU: lib SLIPLU.c demos.h demos.c Makefile
-	$(CC) $(LDFLAGS) $(CF) $(I) -o SLIPLU SLIPLU.c demos.c $(CS)
+	$(CC) $(LDFLAGS) $(CF) $(I) -o SLIPLU SLIPLU.c demos.c $(CS) $(RPATH)
 clean:
 	- $(RM) *.o
 


### PR DESCRIPTION
The linker can not find dynamic libraries in ../../lib w.r.t. the
'SLIP_LU/Demo' folder. By passing the '-L' option to GCC, which GCC
ultimately passes to the linker, all executables are linked correctly.
But when these executables invoked from Make, they have trouble find
dynamic libraries in the said folder, because the folder is not in the
list of search paths of the linker.

To solve this problem, an extra '-Wl, rpath=../../lib' option is passed
to GCC. This tells the linker to set the DT_RPATH attribute in the
.dynamic section of the resulted executables. When the executables are
invoked, they will first try to find dynamic libraries in the path
indicated by DT_RPATH before looking some standard library paths.