### PR TITLE
SPQR documentation: compatibility fix for TeX Live 2022

### DIFF
--- a/SPQR/Doc/spqr_user_guide.tex
+++ b/SPQR/Doc/spqr_user_guide.tex
@@ -93,7 +93,7 @@ For Windows, you cannot use the \verb'lcc' compiler that ships with MATLAB; it
 is not a C++ compiler.  To compile SuiteSparseQR, you must obtain a C++
 compiler; Microsoft Visual Studio C++ Express Edition will work fine.  Install
 this compiler from \newline
-\htmladdnormallink{http://www.microsoft.com/express/vc/}{http://www.microsoft.com/express/vc/}
+\href{http://www.microsoft.com/express/vc/}{http://www.microsoft.com/express/vc/}
 and then type \verb'mex -setup' in the MATLAB Command Window.
 
 %-------------------------------------------------------------------------------
@@ -764,10 +764,10 @@ SuiteSparseQR can be compiled without these ordering methods.
 
 In addition to appearing as Collected Algorithm 8xx of the ACM, SuiteSparseQR
 is available at
-\htmladdnormallink{http://www.suitesparse.com}{http://www.suitesparse.com}
+\href{http://www.suitesparse.com}{http://www.suitesparse.com}
 and at MATLAB Central
 in the user-contributed File Exchange (
-\htmladdnormallink{http://www.mathworks.com/matlabcentral}{http://www.mathworks.com/matlabcentral}
+\href{http://www.mathworks.com/matlabcentral}{http://www.mathworks.com/matlabcentral}
 ).
 See SPQR/Doc/License.txt for the license.
 Alternative licenses are also


### PR DESCRIPTION
The \htmladdnormallink macro has been removed from hyperref as of TeX Live
2022. It was simply an alias for \href (with arguments swapped), so use the
latter instead.