### PR TITLE
Support building with CMAKE_RELEASE_POSTFIX

### DIFF
--- a/AMD/cmake_modules/FindAMD.cmake
+++ b/AMD/cmake_modules/FindAMD.cmake
@@ -41,7 +41,7 @@ find_path ( AMD_INCLUDE_DIR
 
 # compiled libraries AMD
 find_library ( AMD_LIBRARY
-    NAMES amd
+    NAMES amd${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/AMD
     HINTS ${CMAKE_SOURCE_DIR}/../AMD

--- a/BTF/cmake_modules/FindBTF.cmake
+++ b/BTF/cmake_modules/FindBTF.cmake
@@ -41,7 +41,7 @@ find_path ( BTF_INCLUDE_DIR
 
 # compiled libraries BTF
 find_library ( BTF_LIBRARY
-    NAMES btf
+    NAMES btf${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/BTF
     HINTS ${CMAKE_SOURCE_DIR}/../BTF

--- a/CAMD/cmake_modules/FindCAMD.cmake
+++ b/CAMD/cmake_modules/FindCAMD.cmake
@@ -41,7 +41,7 @@ find_path ( CAMD_INCLUDE_DIR
 
 # compiled libraries CAMD
 find_library ( CAMD_LIBRARY
-    NAMES camd
+    NAMES camd${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/CAMD
     HINTS ${CMAKE_SOURCE_DIR}/../CAMD

--- a/CCOLAMD/cmake_modules/FindCCOLAMD.cmake
+++ b/CCOLAMD/cmake_modules/FindCCOLAMD.cmake
@@ -41,7 +41,7 @@ find_path ( CCOLAMD_INCLUDE_DIR
 
 # compiled libraries CCOLAMD
 find_library ( CCOLAMD_LIBRARY
-    NAMES ccolamd
+    NAMES ccolamd${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/CCOLAMD
     HINTS ${CMAKE_SOURCE_DIR}/../CCOLAMD

--- a/CHOLMOD/cmake_modules/FindCHOLMOD.cmake
+++ b/CHOLMOD/cmake_modules/FindCHOLMOD.cmake
@@ -41,7 +41,7 @@ find_path ( CHOLMOD_INCLUDE_DIR
 
 # compiled libraries CHOLMOD
 find_library ( CHOLMOD_LIBRARY
-    NAMES cholmod
+    NAMES cholmod${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/CHOLMOD
     HINTS ${CMAKE_SOURCE_DIR}/../CHOLMOD

--- a/CHOLMOD/cmake_modules/FindCHOLMOD_CUDA.cmake
+++ b/CHOLMOD/cmake_modules/FindCHOLMOD_CUDA.cmake
@@ -30,7 +30,7 @@
 
 # compiled libraries CHOLMOD_CUDA for CUDA
 find_library ( CHOLMOD_CUDA_LIBRARY
-    NAMES cholmod_cuda
+    NAMES cholmod_cuda${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse
     HINTS ${CMAKE_SOURCE_DIR}/../CHOLMOD/

--- a/COLAMD/cmake_modules/FindCOLAMD.cmake
+++ b/COLAMD/cmake_modules/FindCOLAMD.cmake
@@ -41,7 +41,7 @@ find_path ( COLAMD_INCLUDE_DIR
 
 # compiled libraries COLAMD
 find_library ( COLAMD_LIBRARY
-    NAMES colamd
+    NAMES colamd${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/COLAMD
     HINTS ${CMAKE_SOURCE_DIR}/../COLAMD

--- a/CXSparse/cmake_modules/FindCXSparse.cmake
+++ b/CXSparse/cmake_modules/FindCXSparse.cmake
@@ -41,7 +41,7 @@ find_path ( CXSPARSE_INCLUDE_DIR
 
 # compiled libraries CXSPARSE
 find_library ( CXSPARSE_LIBRARY
-    NAMES cxsparse
+    NAMES cxsparse${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/CXSparse
     HINTS ${CMAKE_SOURCE_DIR}/../CXSparse

--- a/GPUQREngine/cmake_modules/FindGPUQREngine.cmake
+++ b/GPUQREngine/cmake_modules/FindGPUQREngine.cmake
@@ -29,7 +29,7 @@
 
 # compiled libraries GPUQREngine
 find_library ( GPUQRENGINE_LIBRARY
-    NAMES gpuqrengine
+    NAMES gpuqrengine${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/GPUQREngine
     HINTS ${CMAKE_SOURCE_DIR}/../GPUQREngine

--- a/GraphBLAS/cmake_modules/FindGraphBLAS.cmake
+++ b/GraphBLAS/cmake_modules/FindGraphBLAS.cmake
@@ -63,7 +63,7 @@ find_path(
 # "build" for SuiteSparse:GraphBLAS
 find_library(
   GRAPHBLAS_LIBRARY
-  NAMES graphblas
+  NAMES graphblas${CMAKE_RELEASE_POSTFIX}
   HINTS ${CMAKE_SOURCE_DIR}/..
   HINTS ${CMAKE_SOURCE_DIR}/../GraphBLAS
   HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/GraphBLAS

--- a/KLU/cmake_modules/FindKLU.cmake
+++ b/KLU/cmake_modules/FindKLU.cmake
@@ -41,7 +41,7 @@ find_path ( KLU_INCLUDE_DIR
 
 # compiled libraries KLU
 find_library ( KLU_LIBRARY
-    NAMES klu
+    NAMES klu${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/KLU
     HINTS ${CMAKE_SOURCE_DIR}/../KLU

--- a/KLU/cmake_modules/FindKLU_CHOLMOD.cmake
+++ b/KLU/cmake_modules/FindKLU_CHOLMOD.cmake
@@ -41,7 +41,7 @@ find_path ( KLU_CHOLMOD_INCLUDE_DIR
 
 # compiled libraries KLU_CHOLMOD
 find_library ( KLU_CHOLMOD_LIBRARY
-    NAMES klu_cholmod
+    NAMES klu_cholmod${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/KLU/User
     HINTS ${CMAKE_SOURCE_DIR}/../KLU/User

--- a/LDL/cmake_modules/FindLDL.cmake
+++ b/LDL/cmake_modules/FindLDL.cmake
@@ -41,7 +41,7 @@ find_path ( LDL_INCLUDE_DIR
 
 # compiled libraries LDL
 find_library ( LDL_LIBRARY
-    NAMES ldl
+    NAMES ldl${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/LDL
     HINTS ${CMAKE_SOURCE_DIR}/../LDL

--- a/Mongoose/cmake_modules/FindMongoose.cmake
+++ b/Mongoose/cmake_modules/FindMongoose.cmake
@@ -41,7 +41,7 @@ find_path ( MONGOOSE_INCLUDE_DIR
 
 # compiled libraries Mongoose
 find_library ( MONGOOSE_LIBRARY
-    NAMES mongoose
+    NAMES mongoose${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/Mongoose
     HINTS ${CMAKE_SOURCE_DIR}/../Mongoose

--- a/RBio/cmake_modules/FindRBio.cmake
+++ b/RBio/cmake_modules/FindRBio.cmake
@@ -41,7 +41,7 @@ find_path ( RBIO_INCLUDE_DIR
 
 # compiled libraries RBio
 find_library ( RBIO_LIBRARY
-    NAMES rbio
+    NAMES rbio${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/RBio
     HINTS ${CMAKE_SOURCE_DIR}/../RBio

--- a/SPEX/cmake_modules/FindSPEX.cmake
+++ b/SPEX/cmake_modules/FindSPEX.cmake
@@ -41,7 +41,7 @@ find_path ( SPEX_INCLUDE_DIR
 
 # compiled libraries SPEX
 find_library ( SPEX_LIBRARY
-    NAMES spex
+    NAMES spex${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/SPEX
     HINTS ${CMAKE_SOURCE_DIR}/../SPEX

--- a/SPQR/cmake_modules/FindSPQR.cmake
+++ b/SPQR/cmake_modules/FindSPQR.cmake
@@ -41,7 +41,7 @@ find_path ( SPQR_INCLUDE_DIR
 
 # compiled libraries SPQR
 find_library ( SPQR_LIBRARY
-    NAMES spqr
+    NAMES spqr${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/SPQR
     HINTS ${CMAKE_SOURCE_DIR}/../SPQR

--- a/SPQR/cmake_modules/FindSPQR_CUDA.cmake
+++ b/SPQR/cmake_modules/FindSPQR_CUDA.cmake
@@ -30,7 +30,7 @@
 
 # compiled libraries SPQR_CUDA for CUDA
 find_library ( SPQR_CUDA_LIBRARY
-    NAMES spqr_cuda
+    NAMES spqr_cuda${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse
     HINTS ${CMAKE_SOURCE_DIR}/../SPQR/

--- a/SuiteSparse_GPURuntime/cmake_modules/FindSuiteSparse_GPURuntime.cmake
+++ b/SuiteSparse_GPURuntime/cmake_modules/FindSuiteSparse_GPURuntime.cmake
@@ -29,7 +29,7 @@
 
 # compiled libraries SuiteSparse_GPURuntime
 find_library ( SUITESPARSE_GPURUNTIME_LIBRARY
-    NAMES suitesparse_gpuruntime
+    NAMES suitesparse_gpuruntime${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/SuiteSparse_GPURuntime
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse_GPURuntime

--- a/SuiteSparse_config/cmake_modules/FindSuiteSparse_config.cmake
+++ b/SuiteSparse_config/cmake_modules/FindSuiteSparse_config.cmake
@@ -40,7 +40,7 @@ find_path ( SUITESPARSE_CONFIG_INCLUDE_DIR
 
 # compiled libraries SuiteSparse_config
 find_library ( SUITESPARSE_CONFIG_LIBRARY
-    NAMES suitesparseconfig
+    NAMES suitesparseconfig${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/SuiteSparse_config
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config

--- a/UMFPACK/cmake_modules/FindUMFPACK.cmake
+++ b/UMFPACK/cmake_modules/FindUMFPACK.cmake
@@ -41,7 +41,7 @@ find_path ( UMFPACK_INCLUDE_DIR
 
 # compiled libraries UMFPACK
 find_library ( UMFPACK_LIBRARY
-    NAMES umfpack
+    NAMES umfpack${CMAKE_RELEASE_POSTFIX}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/UMFPACK
     HINTS ${CMAKE_SOURCE_DIR}/../UMFPACK


### PR DESCRIPTION
Fedora builds 3 versions of suitesparse - 32-bit BLAS and 64-bit BLAS with and without trailing "_"'s on symbols.  I'd like to use CMAKE_RELEASE_POSTFIX to do this, but we need to change the name of the libraries that suitesparse looks for accordingly.