### PR TITLE
make the amd,camd and klu doc makefiles portable between bash and dash

### DIFF
--- a/AMD/Doc/Makefile
+++ b/AMD/Doc/Makefile
@@ -11,9 +11,9 @@ default:  AMD_UserGuide.pdf
 
 AMD_UserGuide.pdf: AMD_UserGuide.tex AMD_UserGuide.bib ../Include/amd.h \
     amd_version.tex
-	echo '\\begin{verbatim}' > amd_h.tex
+	printf '\\begin{verbatim}\n' > amd_h.tex
 	expand -8 ../Include/amd.h >> amd_h.tex
-	echo '\\end{verbatim}' >> amd_h.tex
+	printf '\\end{verbatim}\n' >> amd_h.tex
 	pdflatex AMD_UserGuide
 	bibtex AMD_UserGuide
 	pdflatex AMD_UserGuide

--- a/CAMD/Doc/Makefile
+++ b/CAMD/Doc/Makefile
@@ -11,9 +11,9 @@ default:  CAMD_UserGuide.pdf
 
 CAMD_UserGuide.pdf: CAMD_UserGuide.tex CAMD_UserGuide.bib ../Include/camd.h \
     camd_version.tex
-	echo '\\begin{verbatim}' > camd_h.tex
+	printf '\\begin{verbatim}\n' > camd_h.tex
 	expand -8 ../Include/camd.h >> camd_h.tex
-	echo '\\end{verbatim}' >> camd_h.tex
+	printf '\\end{verbatim}\n' >> camd_h.tex
 	pdflatex CAMD_UserGuide
 	bibtex CAMD_UserGuide
 	pdflatex CAMD_UserGuide

--- a/KLU/Doc/Makefile
+++ b/KLU/Doc/Makefile
@@ -8,15 +8,15 @@ dist:  KLU_UserGuide.pdf
 
 KLU_UserGuide.pdf: KLU_UserGuide.tex KLU_UserGuide.bib \
     ../Include/klu.h ../../BTF/Include/btf.h Makefile klu_version.tex
-	echo '\\begin{verbatim}' > klu_h.tex
+	printf '\\begin{verbatim}\n' > klu_h.tex
 	expand -8 ../Include/klu.h >> klu_h.tex
-	echo '\\end{verbatim}' >> klu_h.tex
-	echo '\\begin{verbatim}' > btf_h.tex
+	printf '\\end{verbatim}\n' >> klu_h.tex
+	printf '\\begin{verbatim}\n' > btf_h.tex
 	expand -8 ../../BTF/Include/btf.h >> btf_h.tex
-	echo '\\end{verbatim}' >> btf_h.tex
-	echo '\\begin{verbatim}' > klu_simple_c.tex
+	printf '\\end{verbatim}\n' >> btf_h.tex
+	printf '\\begin{verbatim}\n' > klu_simple_c.tex
 	expand -8 ../Demo/klu_simple.c >> klu_simple_c.tex
-	echo '\\end{verbatim}' >> klu_simple_c.tex
+	printf '\\end{verbatim}\n' >> klu_simple_c.tex
 	pdflatex KLU_UserGuide
 	bibtex KLU_UserGuide
 	pdflatex KLU_UserGuide


### PR DESCRIPTION
* Please describe your pull request:
I have been sitting on this since April 2020 https://github.com/cschwan/sage-on-gentoo/issues/574
The gist of it is that the makefile to produce the documentation for amd, camd and klu will fail if you use bash instead of dash. This is because the `echo` is not portable and its behaviour will vary depending on the shell used. See the section on echo at https://www.gnu.org/software/autoconf/manual/autoconf-2.60/html_node/Limitations-of-Builtins.html#Limitations-of-Builtins

This branch fixes this by using `printf` instead of `echo` which will work across bash and dash at least.