### PR TITLE
Fix typo in LDL makefile

### DIFF
--- a/LDL/Makefile
+++ b/LDL/Makefile
@@ -59,7 +59,7 @@ demos: library
 	./build/ldlsimple > ./build/ldlsimple.out
 	- diff ./Demo/ldlsimple.out ./build/ldlsimple.out
 	./build/ldllsimple > ./build/ldllsimple.out
-	- diff ./Demo/ldlsimple.out ./build/ldllsimple.out
+	- diff ./Demo/ldllsimple.out ./build/ldllsimple.out
 	./build/ldlmain > ./build/ldlmain.out
 	- diff ./Demo/ldlmain.out ./build/ldlmain.out
 	./build/ldllmain > ./build/ldllmain.out


### PR DESCRIPTION
 * Please describe your pull request:
Fix a typo in `LDL/Makefile`, the wrong output file is tested in the second diff in the `demos` target.