### PR TITLE
Add action rules for GitHub-hosted Ubuntu runners.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,88 @@ concurrency: ci-${{ github.ref }}
 
 jobs:
 
+  ubuntu:
+    # For available GitHub-hosted runners, see:
+    # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    runs-on: ubuntu-latest
+
+    strategy:
+      # Allow other runners in the matrix to continue if some fail
+      fail-fast: false
+
+      matrix:
+        compiler: [gcc, clang]
+        include:
+          - compiler: gcc
+            compiler-pkgs: "g++ gcc"
+            cc: "gcc"
+            cxx: "g++"
+          - compiler: clang
+            compiler-pkgs: "clang"
+            cc: "clang"
+            cxx: "clang++"
+          # Clang seems to generally require less cache size (smaller object files?).
+          - compiler: gcc
+            ccache-max: 400M
+          - compiler: clang
+            ccache-max: 200M
+
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v3
+
+      - name: install dependencies
+        env:
+          COMPILER_PKGS: ${{ matrix.compiler-pkgs }}
+        run: |
+          sudo apt -qq update
+          sudo apt install -y ${COMPILER_PKGS} autoconf automake ccache cmake \
+            dvipng gfortran libgmp-dev liblapack-dev libmetis-dev libmpfr-dev \
+            libopenblas-dev
+
+      - name: prepare ccache
+        # create human readable timestamp
+        id: ccache_cache_timestamp
+        run: |
+          echo "timestamp=$(date +"%Y-%m-%d_%H-%M-%S")" >> $GITHUB_OUTPUT
+
+      - name: restore ccache
+        # setup the github cache used to maintain the ccache from one job to the next
+        uses: actions/cache@v3
+        with:
+          path: ~/.ccache
+          key: ccache:ubuntu:${{ matrix.compiler }}:${{ github.ref }}:${{ steps.ccache_cache_timestamp.outputs.timestamp }}:${{ github.sha }}
+          restore-keys: |
+            ccache:ubuntu:${{ matrix.compiler }}:${{ github.ref }}
+
+      - name: configure ccache
+        env:
+          CCACHE_MAX: ${{ matrix.ccache-max }}
+        run: |
+          test -d ~/.ccache || mkdir ~/.ccache
+          echo "max_size = $CCACHE_MAX" >> ~/.ccache/ccache.conf
+          echo "compression = true" >> ~/.ccache/ccache.conf
+          ccache -s
+          echo "/usr/lib/ccache" >> $GITHUB_PATH
+
+      - name: build
+        run: |
+          make CMAKE_OPTIONS="-G\"Unix Makefiles\" \
+                              -DCMAKE_BUILD_TYPE=Release \
+                              -DCMAKE_C_COMPILER_LAUNCHER='ccache' \
+                              -DCMAKE_CXX_COMPILER_LAUNCHER='ccache' \
+                              -DCMAKE_Fortran_COMPILER_LAUNCHER='ccache' \
+                              -DBLA_VENDOR=OpenBLAS"
+
+      - name: ccache status
+        continue-on-error: true
+        run: ccache -s
+
+
   mingw:
     # For available GitHub-hosted runners, see: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
     runs-on: windows-latest
@@ -94,7 +176,7 @@ jobs:
         run: |
           which ccache
           test -d ${{ steps.ccache_cache_timestamp.outputs.ccachedir }} || mkdir -p ${{ steps.ccache_cache_timestamp.outputs.ccachedir }}
-          echo "max_size = 0.9G" > ${{ steps.ccache_cache_timestamp.outputs.ccachedir }}/ccache.conf
+          echo "max_size = 250M" > ${{ steps.ccache_cache_timestamp.outputs.ccachedir }}/ccache.conf
           echo "compression = true" >> ${{ steps.ccache_cache_timestamp.outputs.ccachedir }}/ccache.conf
           ccache -p
           ccache -s


### PR DESCRIPTION
This PR adds rules to build SuiteSparse on GitHub-hosted Ubuntu runners. 
It tries to build with GCC and Clang compilers.

Currently, it fails because there seems to be some mix-up with shared vs. static libraries. See, e.g.:
https://github.com/mmuetzel/SuiteSparse/actions/runs/3608879679/jobs/6081737279#step:7:859
```
-- Found AMD: /home/runner/work/SuiteSparse/SuiteSparse/AMD/build/libamd.a (found suitable version "3.0.2", minimum required is "3.0.2") 
-- AMD version:      3.0.2
-- AMD include dir:  /home/runner/work/SuiteSparse/SuiteSparse/AMD/Include
-- AMD dynamic:      /home/runner/work/SuiteSparse/SuiteSparse/AMD/build/libamd.a
-- AMD static:       /home/runner/work/SuiteSparse/SuiteSparse/AMD/build/libamd.a
```

Are you sure you prefer to not have the CI run on your development branch? Imho, it is totally fine if the CI fails for some period on a development branch. But it might be useful to see the current state, nevertheless.
I don't know your development cycle. But the CI might be useful to check what might need to be fixed before merging your development branch to the stable branch.


I also adjusted the size of the ccache for MinGW in the same commit. I hope that is fine.
