### PR TITLE
CI: Skip building SPEX on MINGW64 and MINGW32.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -197,8 +197,7 @@ jobs:
                               -DCMAKE_CXX_COMPILER_LAUNCHER='ccache' \
                               -DCMAKE_Fortran_COMPILER_LAUNCHER='ccache' \
                               -DENABLE_CUDA=OFF \
-                              -DBLA_VENDOR=OpenBLAS \
-                              -DGBNCPUFEAT=ON"
+                              -DBLA_VENDOR=OpenBLAS"
 
       - name: ccache status
         continue-on-error: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -180,6 +180,15 @@ jobs:
           ccache -p
           ccache -s
 
+      - name: disable SPEX
+        # SPEX currently doesn't link correctly with the mpfr library in MINGW64 and MINGW32.
+        # So, disable building it for the time being.
+        # Remove this step once the issue is fixed upstream.
+        # See also: https://github.com/msys2/MINGW-packages/pull/14146
+        if: startsWith(matrix.msystem, 'MINGW')
+        run: |
+          sed -i -E "s|(^.*\( cd SPEX)|#\1|g" Makefile
+
       - name: build
         run: |
           make CMAKE_OPTIONS="-G\"MSYS Makefiles\" \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,9 +30,9 @@ jobs:
             cxx: "clang++"
           # Clang seems to generally require less cache size (smaller object files?).
           - compiler: gcc
-            ccache-max: 400M
+            ccache-max: 600M
           - compiler: clang
-            ccache-max: 200M
+            ccache-max: 500M
 
     env:
       CC: ${{ matrix.cc }}


### PR DESCRIPTION
This addresses #181. The commit cb9cae8 (CI: Skip building SPEX on MINGW64 and MINGW32.) can probably be reverted when the issue with mpfr has been fixed in MSYS2.
I manually edited the `Makefile` and commented out all lines related to SPEX with a `sed` replacement rule. Is there a more "default" way of selecting which parts of SuiteSparse should be built (or skipped)?

Additionally, this PR increases the ccache size on Ubuntu (which didn't build at the time the CI rule was originally written). I underestimated the size that we were going to need.

In a last change, I removed `-DGBNCPUFEAT=ON` from the build flags on MinGW. IIUC, this is no longer needed now that MinGW is correctly detected by GraphBLAS.

PS: Is the `dev` branch the correct target for PRs now?