### PR TITLE
SPEX: Link to gmp after mpfr.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -180,15 +180,6 @@ jobs:
           ccache -p
           ccache -s
 
-      - name: disable SPEX
-        # SPEX currently doesn't link correctly with the mpfr library in MINGW64 and MINGW32.
-        # So, disable building it for the time being.
-        # Remove this step once the issue is fixed upstream.
-        # See also: https://github.com/msys2/MINGW-packages/pull/14146
-        if: startsWith(matrix.msystem, 'MINGW')
-        run: |
-          sed -i -E "s|(^.*\( cd SPEX)|#\1|g" Makefile
-
       - name: build
         run: |
           make CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release \

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -143,7 +143,7 @@ if ( NOT NSTATIC )
 endif ( )
 
 # libm:
-if ( NOT MSVC )
+if ( NOT WIN32 )
     target_link_libraries ( spex PUBLIC m )
     if ( NOT NSTATIC )
         target_link_libraries ( spex_static PUBLIC m )

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -129,16 +129,17 @@ if ( NOT NSTATIC )
     target_link_libraries ( spex_static PUBLIC ${COLAMD_STATIC} )
 endif ( )
 
-# GMP:
-target_link_libraries ( spex PUBLIC ${GMP_LIBRARIES} )
-if ( NOT NSTATIC )
-    target_link_libraries ( spex_static PUBLIC ${GMP_STATIC} )
-endif ( )
-
 # MPFR:
 target_link_libraries ( spex PUBLIC ${MPFR_LIBRARIES} )
 if ( NOT NSTATIC )
     target_link_libraries ( spex_static PUBLIC ${MPFR_STATIC} )
+endif ( )
+
+# GMP:
+# must occur after MPFR
+target_link_libraries ( spex PUBLIC ${GMP_LIBRARIES} )
+if ( NOT NSTATIC )
+    target_link_libraries ( spex_static PUBLIC ${GMP_STATIC} )
 endif ( )
 
 # libm:


### PR DESCRIPTION
This fixes #193 for me.

It turns out this isn't an issue with the mpfr library in MSYS2 after all. But their `mpfr` library depends on the `gmp` library.
For `lld`, the order in which libraries are appearing in the linker command doesn't matter. However for GNU `ld`, libraries that provide symbols must occur after libraries that use those symbols in the linker command. 
(I wonder why that was working on Linux with `gcc` and `ld`. Does the mpfr library not depend on the gmp library on that platform?)

This PR moves `gmp` after `mpfr` in the linker command. It also reverts the change that disabled SPEX in the CI for MINGW64 and MINGW32.

I included an additional change that isn't related. But it happened to be close to where the other changes were done: It isn't necessary to link to `libm` on Windows. `mingw` provides a dummy `libm` that doesn't export anything (to avoid linking errors in cases like this one). However, since `libm` is already linked to only conditionally, I adjusted the condition to not link to it on Windows.