### PR TITLE
Run demos as part of CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,6 +84,10 @@ jobs:
                               -DCMAKE_Fortran_COMPILER_LAUNCHER='ccache' \
                               -DBLA_VENDOR=OpenBLAS"
 
+      - name: check
+        run: |
+          make demos
+
       - name: ccache status
         continue-on-error: true
         run: ccache -s
@@ -186,6 +190,12 @@ jobs:
                               -DCMAKE_CXX_COMPILER_LAUNCHER='ccache' \
                               -DCMAKE_Fortran_COMPILER_LAUNCHER='ccache' \
                               -DBLA_VENDOR=OpenBLAS"
+
+      - name: check
+        # Building the demos requires a Fortran compiler.
+        if: matrix.msystem != 'CLANG32'
+        run: |
+          make demos
 
       - name: ccache status
         continue-on-error: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,8 +78,7 @@ jobs:
 
       - name: build
         run: |
-          make CMAKE_OPTIONS="-G\"Unix Makefiles\" \
-                              -DCMAKE_BUILD_TYPE=Release \
+          make CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release \
                               -DCMAKE_C_COMPILER_LAUNCHER='ccache' \
                               -DCMAKE_CXX_COMPILER_LAUNCHER='ccache' \
                               -DCMAKE_Fortran_COMPILER_LAUNCHER='ccache' \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -185,7 +185,6 @@ jobs:
                               -DCMAKE_C_COMPILER_LAUNCHER='ccache' \
                               -DCMAKE_CXX_COMPILER_LAUNCHER='ccache' \
                               -DCMAKE_Fortran_COMPILER_LAUNCHER='ccache' \
-                              -DENABLE_CUDA=OFF \
                               -DBLA_VENDOR=OpenBLAS"
 
       - name: ccache status

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -185,7 +185,8 @@ jobs:
 
       - name: build
         run: |
-          make CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release \
+          make CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=\"${MINGW_PREFIX}\" \
+                              -DCMAKE_BUILD_TYPE=Release \
                               -DCMAKE_C_COMPILER_LAUNCHER='ccache' \
                               -DCMAKE_CXX_COMPILER_LAUNCHER='ccache' \
                               -DCMAKE_Fortran_COMPILER_LAUNCHER='ccache' \
@@ -194,7 +195,9 @@ jobs:
       - name: check
         # Building the demos requires a Fortran compiler.
         if: matrix.msystem != 'CLANG32'
+        # Need to install the libraries for the tests
         run: |
+          make install
           make demos
 
       - name: ccache status


### PR DESCRIPTION
As described in #198, it might be useful to run the demos as part of the CI.
Currently, there is no automatic check whether the results are correct (within some tolerance) or even if they execute without crashing. But having the option to check the logs manually is still better than nothing imho.

For the Windows targets, it is necessary to install SuiteSparse before running the demos, or the demo executables would fail to find the necessary libraries. 
An alternative might have been to add the paths to all previously built libraries to the PATH variable. But that would probably be more fragile with respect to any potential changes to the build system.

Since the demos require a Fortran compiler to be built, they cannot be run for the MSYS2/CLANG32 environment.

I also took the opportunity to make the cmake configuration flags on Linux and MinGW more similar to each other.