### PR TITLE
CI: Run checks also on CLANG32.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -193,8 +193,6 @@ jobs:
                               -DBLA_VENDOR=OpenBLAS"
 
       - name: check
-        # Building the demos requires a Fortran compiler.
-        if: matrix.msystem != 'CLANG32'
         # Need to install the libraries for the tests
         run: |
           make install


### PR DESCRIPTION
I thought I remembered reading that a Fortran compiler was necessary for the demos. So, I skipped building them for CLANG32 without actually checking if it would work.

Remove the condition that skip building the demos on CLANG32.
