### PR TITLE
Fix dllimport/dllexport for libraries with MSVC

### DIFF
--- a/AMD/CMakeLists.txt
+++ b/AMD/CMakeLists.txt
@@ -84,6 +84,8 @@ set_target_properties ( amd PROPERTIES
     SOVERSION ${AMD_VERSION_MAJOR}
     PUBLIC_HEADER "Include/amd.h" )
 
+target_compile_definitions ( amd PRIVATE AMD_LIBRARY )
+
 #-------------------------------------------------------------------------------
 # static amd library properties
 #-------------------------------------------------------------------------------
@@ -95,6 +97,8 @@ if ( NOT NSTATIC )
         C_STANDARD_REQUIRED 11
         OUTPUT_NAME amd
         SOVERSION ${AMD_VERSION_MAJOR} )
+
+    target_compile_definitions ( amd_static PUBLIC AMD_STATIC )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -108,7 +112,7 @@ if ( NOT NSTATIC )
 endif ( )
 
 # libm:
-if ( NOT MSVC )
+if ( NOT WIN32 )
     target_link_libraries ( amd PUBLIC m )
     if ( NOT NSTATIC )
         target_link_libraries ( amd_static PUBLIC m )

--- a/AMD/Config/amd.h.in
+++ b/AMD/Config/amd.h.in
@@ -43,10 +43,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( AMD_LIBRARY )
@@ -62,7 +62,7 @@ extern "C" {
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define AMD_PUBLIC extern
 
 #endif

--- a/AMD/Config/amd.h.in
+++ b/AMD/Config/amd.h.in
@@ -42,7 +42,32 @@ extern "C" {
 
 #include "SuiteSparse_config.h"
 
-SUITESPARSE_PUBLIC int amd_order  /* returns AMD_OK, AMD_OK_BUT_JUMBLED,
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( AMD_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define AMD_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( AMD_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define AMD_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define AMD_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define AMD_PUBLIC extern
+
+#endif
+
+AMD_PUBLIC int amd_order  /* returns AMD_OK, AMD_OK_BUT_JUMBLED,
                                     * AMD_INVALID, or AMD_OUT_OF_MEMORY */
 (
     int32_t n,                     /* A is n-by-n.  n must be >= 0. */
@@ -53,7 +78,7 @@ SUITESPARSE_PUBLIC int amd_order  /* returns AMD_OK, AMD_OK_BUT_JUMBLED,
     double Info [ ]         /* output Info statistics, of size AMD_INFO */
 ) ;
 
-SUITESPARSE_PUBLIC int amd_l_order  /* see above for description */
+AMD_PUBLIC int amd_l_order  /* see above for description */
 (
     int64_t n,
     const int64_t Ap [ ],
@@ -89,7 +114,7 @@ SUITESPARSE_PUBLIC int amd_l_order  /* see above for description */
  * terms of time and memory usage.  If this condition does not hold, a copy
  * of the matrix is created (where these conditions do hold), and the copy is
  * ordered.
- * 
+ *
  * Row indices must be in the range 0 to
  * n-1.  Ap [0] must be zero, and thus nz = Ap [n] is the number of nonzeros
  * in A.  The array Ap is of size n+1, and the array Ai is of size nz = Ap [n].
@@ -156,7 +181,7 @@ SUITESPARSE_PUBLIC int amd_l_order  /* see above for description */
  * The Info array provides statistics about the ordering on output.  If it is
  * not present, the statistics are not returned.  This is not an error
  * condition.
- * 
+ *
  *      Info [AMD_STATUS]:  the return value of AMD, either AMD_OK,
  *          AMD_OK_BUT_JUMBLED, AMD_OUT_OF_MEMORY, or AMD_INVALID.
  *
@@ -217,7 +242,7 @@ SUITESPARSE_PUBLIC int amd_l_order  /* see above for description */
  *
  *      Info [14..19] are not used in the current version, but may be used in
  *          future versions.
- */    
+ */
 
 /* ------------------------------------------------------------------------- */
 /* direct interface to AMD */
@@ -231,7 +256,7 @@ SUITESPARSE_PUBLIC int amd_l_order  /* see above for description */
  * of the matrix for AMD to destroy).  Refer to AMD/Source/amd_2.c for a
  * description of each parameter. */
 
-SUITESPARSE_PUBLIC void amd_2
+AMD_PUBLIC void amd_2
 (
     int32_t n,
     int32_t Pe [ ],
@@ -240,7 +265,7 @@ SUITESPARSE_PUBLIC void amd_2
     int32_t iwlen,
     int32_t pfree,
     int32_t Nv [ ],
-    int32_t Next [ ], 
+    int32_t Next [ ],
     int32_t Last [ ],
     int32_t Head [ ],
     int32_t Elen [ ],
@@ -250,7 +275,7 @@ SUITESPARSE_PUBLIC void amd_2
     double Info [ ]
 ) ;
 
-SUITESPARSE_PUBLIC void amd_l2
+AMD_PUBLIC void amd_l2
 (
     int64_t n,
     int64_t Pe [ ],
@@ -259,7 +284,7 @@ SUITESPARSE_PUBLIC void amd_l2
     int64_t iwlen,
     int64_t pfree,
     int64_t Nv [ ],
-    int64_t Next [ ], 
+    int64_t Next [ ],
     int64_t Last [ ],
     int64_t Head [ ],
     int64_t Elen [ ],
@@ -281,7 +306,7 @@ SUITESPARSE_PUBLIC void amd_l2
  * of columns of the matrix.  For its use in AMD, these must both equal n.
  */
 
-SUITESPARSE_PUBLIC int amd_valid
+AMD_PUBLIC int amd_valid
 (
     int32_t n_row,                 /* # of rows */
     int32_t n_col,                 /* # of columns */
@@ -289,7 +314,7 @@ SUITESPARSE_PUBLIC int amd_valid
     const int32_t Ai [ ]           /* row indices, of size Ap [n_col] */
 ) ;
 
-SUITESPARSE_PUBLIC int amd_l_valid
+AMD_PUBLIC int amd_l_valid
 (
     int64_t n_row,
     int64_t n_col,
@@ -302,16 +327,16 @@ SUITESPARSE_PUBLIC int amd_l_valid
 /* ------------------------------------------------------------------------- */
 
 /* amd_defaults:  sets the default control settings */
-SUITESPARSE_PUBLIC void amd_defaults   (double Control [ ]) ;
-SUITESPARSE_PUBLIC void amd_l_defaults (double Control [ ]) ;
+AMD_PUBLIC void amd_defaults   (double Control [ ]) ;
+AMD_PUBLIC void amd_l_defaults (double Control [ ]) ;
 
 /* amd_control: prints the control settings */
-SUITESPARSE_PUBLIC void amd_control    (double Control [ ]) ;
-SUITESPARSE_PUBLIC void amd_l_control  (double Control [ ]) ;
+AMD_PUBLIC void amd_control    (double Control [ ]) ;
+AMD_PUBLIC void amd_l_control  (double Control [ ]) ;
 
 /* amd_info: prints the statistics */
-SUITESPARSE_PUBLIC void amd_info       (double Info [ ]) ;
-SUITESPARSE_PUBLIC void amd_l_info     (double Info [ ]) ;
+AMD_PUBLIC void amd_info       (double Info [ ]) ;
+AMD_PUBLIC void amd_l_info     (double Info [ ]) ;
 
 #define AMD_CONTROL 5          /* size of Control array */
 #define AMD_INFO 20            /* size of Info array */
@@ -327,7 +352,7 @@ SUITESPARSE_PUBLIC void amd_l_info     (double Info [ ]) ;
 /* contents of Info */
 #define AMD_STATUS 0           /* return value of amd_order and amd_l_order */
 #define AMD_N 1                /* A is n-by-n */
-#define AMD_NZ 2      /* number of nonzeros in A */ 
+#define AMD_NZ 2      /* number of nonzeros in A */
 #define AMD_SYMMETRY 3         /* symmetry of pattern (1 is sym., 0 is unsym.) */
 #define AMD_NZDIAG 4           /* # of entries on diagonal */
 #define AMD_NZ_A_PLUS_AT 5  /* nz in A+A' */

--- a/AMD/Include/amd.h
+++ b/AMD/Include/amd.h
@@ -43,10 +43,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( AMD_LIBRARY )
@@ -62,7 +62,7 @@ extern "C" {
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define AMD_PUBLIC extern
 
 #endif

--- a/AMD/Include/amd.h
+++ b/AMD/Include/amd.h
@@ -42,7 +42,32 @@ extern "C" {
 
 #include "SuiteSparse_config.h"
 
-SUITESPARSE_PUBLIC int amd_order  /* returns AMD_OK, AMD_OK_BUT_JUMBLED,
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( AMD_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define AMD_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( AMD_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define AMD_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define AMD_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define AMD_PUBLIC extern
+
+#endif
+
+AMD_PUBLIC int amd_order  /* returns AMD_OK, AMD_OK_BUT_JUMBLED,
                                     * AMD_INVALID, or AMD_OUT_OF_MEMORY */
 (
     int32_t n,                     /* A is n-by-n.  n must be >= 0. */
@@ -53,7 +78,7 @@ SUITESPARSE_PUBLIC int amd_order  /* returns AMD_OK, AMD_OK_BUT_JUMBLED,
     double Info [ ]         /* output Info statistics, of size AMD_INFO */
 ) ;
 
-SUITESPARSE_PUBLIC int amd_l_order  /* see above for description */
+AMD_PUBLIC int amd_l_order  /* see above for description */
 (
     int64_t n,
     const int64_t Ap [ ],
@@ -89,7 +114,7 @@ SUITESPARSE_PUBLIC int amd_l_order  /* see above for description */
  * terms of time and memory usage.  If this condition does not hold, a copy
  * of the matrix is created (where these conditions do hold), and the copy is
  * ordered.
- * 
+ *
  * Row indices must be in the range 0 to
  * n-1.  Ap [0] must be zero, and thus nz = Ap [n] is the number of nonzeros
  * in A.  The array Ap is of size n+1, and the array Ai is of size nz = Ap [n].
@@ -156,7 +181,7 @@ SUITESPARSE_PUBLIC int amd_l_order  /* see above for description */
  * The Info array provides statistics about the ordering on output.  If it is
  * not present, the statistics are not returned.  This is not an error
  * condition.
- * 
+ *
  *      Info [AMD_STATUS]:  the return value of AMD, either AMD_OK,
  *          AMD_OK_BUT_JUMBLED, AMD_OUT_OF_MEMORY, or AMD_INVALID.
  *
@@ -217,7 +242,7 @@ SUITESPARSE_PUBLIC int amd_l_order  /* see above for description */
  *
  *      Info [14..19] are not used in the current version, but may be used in
  *          future versions.
- */    
+ */
 
 /* ------------------------------------------------------------------------- */
 /* direct interface to AMD */
@@ -231,7 +256,7 @@ SUITESPARSE_PUBLIC int amd_l_order  /* see above for description */
  * of the matrix for AMD to destroy).  Refer to AMD/Source/amd_2.c for a
  * description of each parameter. */
 
-SUITESPARSE_PUBLIC void amd_2
+AMD_PUBLIC void amd_2
 (
     int32_t n,
     int32_t Pe [ ],
@@ -240,7 +265,7 @@ SUITESPARSE_PUBLIC void amd_2
     int32_t iwlen,
     int32_t pfree,
     int32_t Nv [ ],
-    int32_t Next [ ], 
+    int32_t Next [ ],
     int32_t Last [ ],
     int32_t Head [ ],
     int32_t Elen [ ],
@@ -250,7 +275,7 @@ SUITESPARSE_PUBLIC void amd_2
     double Info [ ]
 ) ;
 
-SUITESPARSE_PUBLIC void amd_l2
+AMD_PUBLIC void amd_l2
 (
     int64_t n,
     int64_t Pe [ ],
@@ -259,7 +284,7 @@ SUITESPARSE_PUBLIC void amd_l2
     int64_t iwlen,
     int64_t pfree,
     int64_t Nv [ ],
-    int64_t Next [ ], 
+    int64_t Next [ ],
     int64_t Last [ ],
     int64_t Head [ ],
     int64_t Elen [ ],
@@ -281,7 +306,7 @@ SUITESPARSE_PUBLIC void amd_l2
  * of columns of the matrix.  For its use in AMD, these must both equal n.
  */
 
-SUITESPARSE_PUBLIC int amd_valid
+AMD_PUBLIC int amd_valid
 (
     int32_t n_row,                 /* # of rows */
     int32_t n_col,                 /* # of columns */
@@ -289,7 +314,7 @@ SUITESPARSE_PUBLIC int amd_valid
     const int32_t Ai [ ]           /* row indices, of size Ap [n_col] */
 ) ;
 
-SUITESPARSE_PUBLIC int amd_l_valid
+AMD_PUBLIC int amd_l_valid
 (
     int64_t n_row,
     int64_t n_col,
@@ -302,16 +327,16 @@ SUITESPARSE_PUBLIC int amd_l_valid
 /* ------------------------------------------------------------------------- */
 
 /* amd_defaults:  sets the default control settings */
-SUITESPARSE_PUBLIC void amd_defaults   (double Control [ ]) ;
-SUITESPARSE_PUBLIC void amd_l_defaults (double Control [ ]) ;
+AMD_PUBLIC void amd_defaults   (double Control [ ]) ;
+AMD_PUBLIC void amd_l_defaults (double Control [ ]) ;
 
 /* amd_control: prints the control settings */
-SUITESPARSE_PUBLIC void amd_control    (double Control [ ]) ;
-SUITESPARSE_PUBLIC void amd_l_control  (double Control [ ]) ;
+AMD_PUBLIC void amd_control    (double Control [ ]) ;
+AMD_PUBLIC void amd_l_control  (double Control [ ]) ;
 
 /* amd_info: prints the statistics */
-SUITESPARSE_PUBLIC void amd_info       (double Info [ ]) ;
-SUITESPARSE_PUBLIC void amd_l_info     (double Info [ ]) ;
+AMD_PUBLIC void amd_info       (double Info [ ]) ;
+AMD_PUBLIC void amd_l_info     (double Info [ ]) ;
 
 #define AMD_CONTROL 5          /* size of Control array */
 #define AMD_INFO 20            /* size of Info array */
@@ -327,7 +352,7 @@ SUITESPARSE_PUBLIC void amd_l_info     (double Info [ ]) ;
 /* contents of Info */
 #define AMD_STATUS 0           /* return value of amd_order and amd_l_order */
 #define AMD_N 1                /* A is n-by-n */
-#define AMD_NZ 2      /* number of nonzeros in A */ 
+#define AMD_NZ 2      /* number of nonzeros in A */
 #define AMD_SYMMETRY 3         /* symmetry of pattern (1 is sym., 0 is unsym.) */
 #define AMD_NZDIAG 4           /* # of entries on diagonal */
 #define AMD_NZ_A_PLUS_AT 5  /* nz in A+A' */

--- a/AMD/Include/amd_internal.h
+++ b/AMD/Include/amd_internal.h
@@ -42,7 +42,6 @@
 #undef NDEBUG
 */
 
-#define SUITESPARSE_LIBRARY
 #include "amd.h"
 
 /* ------------------------------------------------------------------------- */
@@ -65,7 +64,7 @@
 #undef EMPTY
 #endif
 
-#define GLOBAL SUITESPARSE_PUBLIC
+#define GLOBAL AMD_PUBLIC
 #define PRIVATE static
 
 /* FLIP is a "negation about -1", and is used to mark an integer i that is

--- a/AMD/Source/amd.f
+++ b/AMD/Source/amd.f
@@ -11,6 +11,10 @@ C-----------------------------------------------------------------------
         SUBROUTINE AMD
      $          (N, PE, IW, LEN, IWLEN, PFREE, NV, NEXT,
      $          LAST, HEAD, ELEN, DEGREE, NCMPA, W)
+#ifdef AMD_LIBRARY
+!DEC$ ATTRIBUTES DLLEXPORT :: AMD
+!GCC$ ATTRIBUTES DLLEXPORT :: AMD
+#endif
 
         INTEGER N, IWLEN, PFREE, NCMPA, IW (IWLEN), PE (N),
      $          DEGREE (N), NV (N), NEXT (N), LAST (N), HEAD (N),

--- a/AMD/Source/amd.f
+++ b/AMD/Source/amd.f
@@ -11,7 +11,7 @@ C-----------------------------------------------------------------------
         SUBROUTINE AMD
      $          (N, PE, IW, LEN, IWLEN, PFREE, NV, NEXT,
      $          LAST, HEAD, ELEN, DEGREE, NCMPA, W)
-#ifdef AMD_LIBRARY
+#if defined ( _MSC_VER ) && defined ( AMD_LIBRARY )
 !DEC$ ATTRIBUTES DLLEXPORT :: AMD
 !GCC$ ATTRIBUTES DLLEXPORT :: AMD
 #endif

--- a/AMD/Source/amdbar.f
+++ b/AMD/Source/amdbar.f
@@ -11,7 +11,7 @@ C-----------------------------------------------------------------------
         SUBROUTINE AMDBAR
      $          (N, PE, IW, LEN, IWLEN, PFREE, NV, NEXT,
      $          LAST, HEAD, ELEN, DEGREE, NCMPA, W)
-#ifdef AMD_LIBRARY
+#if defined ( _MSC_VER ) && defined ( AMD_LIBRARY )
 !DEC$ ATTRIBUTES DLLEXPORT :: AMDBAR
 !GCC$ ATTRIBUTES DLLEXPORT :: AMDBAR
 #endif

--- a/AMD/Source/amdbar.f
+++ b/AMD/Source/amdbar.f
@@ -11,6 +11,10 @@ C-----------------------------------------------------------------------
         SUBROUTINE AMDBAR
      $          (N, PE, IW, LEN, IWLEN, PFREE, NV, NEXT,
      $          LAST, HEAD, ELEN, DEGREE, NCMPA, W)
+#ifdef AMD_LIBRARY
+!DEC$ ATTRIBUTES DLLEXPORT :: AMDBAR
+!GCC$ ATTRIBUTES DLLEXPORT :: AMDBAR
+#endif
 
         INTEGER N, IWLEN, PFREE, NCMPA, IW (IWLEN), PE (N),
      $          DEGREE (N), NV (N), NEXT (N), LAST (N), HEAD (N),

--- a/BTF/CMakeLists.txt
+++ b/BTF/CMakeLists.txt
@@ -72,6 +72,8 @@ set_target_properties ( btf PROPERTIES
     SOVERSION ${BTF_VERSION_MAJOR}
     PUBLIC_HEADER "Include/btf.h" )
 
+target_compile_definitions ( btf PRIVATE BTF_LIBRARY )
+
 #-------------------------------------------------------------------------------
 # static btf library properties
 #-------------------------------------------------------------------------------
@@ -84,6 +86,8 @@ set_target_properties ( btf_static PROPERTIES
     C_STANDARD_REQUIRED 11
     OUTPUT_NAME btf
     SOVERSION ${BTF_VERSION_MAJOR} )
+
+target_compile_definitions ( btf_static PUBLIC BTF_STATIC )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -97,7 +101,7 @@ if ( NOT NSTATIC )
 endif ( )
 
 # libm:
-if ( NOT MSVC )
+if ( NOT WIN32 )
     target_link_libraries ( btf PUBLIC m )
     if ( NOT NSTATIC )
         target_link_libraries ( btf_static PUBLIC m )

--- a/BTF/Config/btf.h.in
+++ b/BTF/Config/btf.h.in
@@ -97,7 +97,32 @@ extern "C" {
 
 #include "SuiteSparse_config.h"
 
-SUITESPARSE_PUBLIC
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( BTF_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define BTF_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( BTF_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define BTF_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define BTF_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define BTF_PUBLIC extern
+
+#endif
+
+BTF_PUBLIC
 int32_t btf_maxtrans    /* returns # of columns matched */
 (
     /* --- input, not modified: --- */
@@ -121,7 +146,7 @@ int32_t btf_maxtrans    /* returns # of columns matched */
 ) ;
 
 /* int64_t integer version */
-SUITESPARSE_PUBLIC 
+BTF_PUBLIC
 int64_t btf_l_maxtrans (int64_t, int64_t,
     int64_t *, int64_t *, double, double *,
     int64_t *, int64_t *) ;
@@ -149,7 +174,7 @@ int64_t btf_l_maxtrans (int64_t, int64_t,
  * number of strongly connected components found.
  */
 
-SUITESPARSE_PUBLIC 
+BTF_PUBLIC
 int32_t btf_strongcomp  /* return # of strongly connected components */
 (
     /* input, not modified: */
@@ -170,7 +195,7 @@ int32_t btf_strongcomp  /* return # of strongly connected components */
     int32_t Work [ ]    /* size 4n */
 ) ;
 
-SUITESPARSE_PUBLIC 
+BTF_PUBLIC
 int64_t btf_l_strongcomp (int64_t, int64_t *,
     int64_t *, int64_t *, int64_t *,
     int64_t *, int64_t *) ;
@@ -199,7 +224,7 @@ int64_t btf_l_strongcomp (int64_t, int64_t *,
  * number of strongly connected components found.
  */
 
-SUITESPARSE_PUBLIC 
+BTF_PUBLIC
 int32_t btf_order       /* returns number of blocks found */
 (
     /* --- input, not modified: --- */
@@ -220,7 +245,7 @@ int32_t btf_order       /* returns number of blocks found */
     int32_t Work [ ] /* size 5n */
 ) ;
 
-SUITESPARSE_PUBLIC 
+BTF_PUBLIC
 int64_t btf_l_order (int64_t, int64_t *, int64_t *, double , double *,
     int64_t *, int64_t *, int64_t *, int64_t *, int64_t *) ;
 

--- a/BTF/Config/btf.h.in
+++ b/BTF/Config/btf.h.in
@@ -98,10 +98,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( BTF_LIBRARY )
@@ -117,7 +117,7 @@ extern "C" {
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define BTF_PUBLIC extern
 
 #endif

--- a/BTF/Include/btf.h
+++ b/BTF/Include/btf.h
@@ -97,7 +97,32 @@ extern "C" {
 
 #include "SuiteSparse_config.h"
 
-SUITESPARSE_PUBLIC
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( BTF_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define BTF_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( BTF_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define BTF_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define BTF_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define BTF_PUBLIC extern
+
+#endif
+
+BTF_PUBLIC
 int32_t btf_maxtrans    /* returns # of columns matched */
 (
     /* --- input, not modified: --- */
@@ -121,7 +146,7 @@ int32_t btf_maxtrans    /* returns # of columns matched */
 ) ;
 
 /* int64_t integer version */
-SUITESPARSE_PUBLIC 
+BTF_PUBLIC
 int64_t btf_l_maxtrans (int64_t, int64_t,
     int64_t *, int64_t *, double, double *,
     int64_t *, int64_t *) ;
@@ -149,7 +174,7 @@ int64_t btf_l_maxtrans (int64_t, int64_t,
  * number of strongly connected components found.
  */
 
-SUITESPARSE_PUBLIC 
+BTF_PUBLIC
 int32_t btf_strongcomp  /* return # of strongly connected components */
 (
     /* input, not modified: */
@@ -170,7 +195,7 @@ int32_t btf_strongcomp  /* return # of strongly connected components */
     int32_t Work [ ]    /* size 4n */
 ) ;
 
-SUITESPARSE_PUBLIC 
+BTF_PUBLIC
 int64_t btf_l_strongcomp (int64_t, int64_t *,
     int64_t *, int64_t *, int64_t *,
     int64_t *, int64_t *) ;
@@ -199,7 +224,7 @@ int64_t btf_l_strongcomp (int64_t, int64_t *,
  * number of strongly connected components found.
  */
 
-SUITESPARSE_PUBLIC 
+BTF_PUBLIC
 int32_t btf_order       /* returns number of blocks found */
 (
     /* --- input, not modified: --- */
@@ -220,7 +245,7 @@ int32_t btf_order       /* returns number of blocks found */
     int32_t Work [ ] /* size 5n */
 ) ;
 
-SUITESPARSE_PUBLIC 
+BTF_PUBLIC
 int64_t btf_l_order (int64_t, int64_t *, int64_t *, double , double *,
     int64_t *, int64_t *, int64_t *, int64_t *, int64_t *) ;
 

--- a/BTF/Include/btf.h
+++ b/BTF/Include/btf.h
@@ -98,10 +98,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( BTF_LIBRARY )
@@ -117,7 +117,7 @@ extern "C" {
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define BTF_PUBLIC extern
 
 #endif

--- a/CAMD/CMakeLists.txt
+++ b/CAMD/CMakeLists.txt
@@ -72,6 +72,8 @@ set_target_properties ( camd PROPERTIES
     SOVERSION ${CAMD_VERSION_MAJOR}
     PUBLIC_HEADER "Include/camd.h" )
 
+target_compile_definitions ( camd PRIVATE CAMD_LIBRARY )
+
 #-------------------------------------------------------------------------------
 # static camd library properties
 #-------------------------------------------------------------------------------
@@ -84,6 +86,8 @@ set_target_properties ( camd_static PROPERTIES
     C_STANDARD_REQUIRED 11
     OUTPUT_NAME camd
     SOVERSION ${CAMD_VERSION_MAJOR} )
+
+target_compile_definitions ( camd_static PUBLIC CAMD_STATIC )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -96,7 +100,7 @@ if ( NOT NSTATIC )
 endif ( )
 
 # libm:
-if ( NOT MSVC )
+if ( NOT WIN32 )
     target_link_libraries ( camd PUBLIC m )
     if ( NOT NSTATIC )
         target_link_libraries ( camd_static PUBLIC m )

--- a/CAMD/Config/camd.h.in
+++ b/CAMD/Config/camd.h.in
@@ -30,7 +30,32 @@ extern "C" {
 
 #include "SuiteSparse_config.h"
 
-SUITESPARSE_PUBLIC int camd_order /* returns CAMD_OK, CAMD_OK_BUT_JUMBLED,
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( CAMD_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define CAMD_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( CAMD_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define CAMD_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define CAMD_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define CAMD_PUBLIC extern
+
+#endif
+
+CAMD_PUBLIC int camd_order /* returns CAMD_OK, CAMD_OK_BUT_JUMBLED,
                              * CAMD_INVALID, or CAMD_OUT_OF_MEMORY */
 (
     int32_t n,                  /* A is n-by-n.  n must be >= 0. */
@@ -42,7 +67,7 @@ SUITESPARSE_PUBLIC int camd_order /* returns CAMD_OK, CAMD_OK_BUT_JUMBLED,
     const int32_t C [ ]         /* Constraint set of A, of size n; can be NULL */
 ) ;
 
-SUITESPARSE_PUBLIC int camd_l_order   /* see above for description */
+CAMD_PUBLIC int camd_l_order   /* see above for description */
 (
     int64_t n,
     const int64_t Ap [ ],
@@ -221,7 +246,7 @@ SUITESPARSE_PUBLIC int camd_l_order   /* see above for description */
  * of the matrix for CAMD to destroy).  Refer to CAMD/Source/camd_2.c for a
  * description of each parameter. */
 
-SUITESPARSE_PUBLIC void camd_2
+CAMD_PUBLIC void camd_2
 (
     int32_t n,
     int32_t Pe [ ],
@@ -242,7 +267,7 @@ SUITESPARSE_PUBLIC void camd_2
     int32_t BucketSet [ ] 
 ) ;
 
-SUITESPARSE_PUBLIC void camd_l2
+CAMD_PUBLIC void camd_l2
 (
     int64_t n,
     int64_t Pe [ ],
@@ -276,7 +301,7 @@ SUITESPARSE_PUBLIC void camd_l2
  * of columns of the matrix.  For its use in CAMD, these must both equal n.
  */
 
-SUITESPARSE_PUBLIC int camd_valid
+CAMD_PUBLIC int camd_valid
 (
     int32_t n_row,              /* # of rows */
     int32_t n_col,              /* # of columns */
@@ -284,7 +309,7 @@ SUITESPARSE_PUBLIC int camd_valid
     const int32_t Ai [ ]        /* row indices, of size Ap [n_col] */
 ) ;
 
-SUITESPARSE_PUBLIC int camd_l_valid
+CAMD_PUBLIC int camd_l_valid
 (
     int64_t n_row,
     int64_t n_col,
@@ -299,13 +324,13 @@ SUITESPARSE_PUBLIC int camd_l_valid
 /* Returns TRUE if the constraint set is valid as input to camd_order,
  * FALSE otherwise. */
 
-SUITESPARSE_PUBLIC int camd_cvalid
+CAMD_PUBLIC int camd_cvalid
 (
    int32_t n,
    const int32_t C [ ]
 ) ;
 
-SUITESPARSE_PUBLIC int camd_l_cvalid
+CAMD_PUBLIC int camd_l_cvalid
 (
    int64_t n,
    const int64_t C [ ]
@@ -316,16 +341,16 @@ SUITESPARSE_PUBLIC int camd_l_cvalid
 /* ------------------------------------------------------------------------- */
 
 /* camd_defaults:  sets the default control settings */
-SUITESPARSE_PUBLIC void camd_defaults   (double Control [ ]) ;
-SUITESPARSE_PUBLIC void camd_l_defaults (double Control [ ]) ;
+CAMD_PUBLIC void camd_defaults   (double Control [ ]) ;
+CAMD_PUBLIC void camd_l_defaults (double Control [ ]) ;
 
 /* camd_control: prints the control settings */
-SUITESPARSE_PUBLIC void camd_control    (double Control [ ]) ;
-SUITESPARSE_PUBLIC void camd_l_control  (double Control [ ]) ;
+CAMD_PUBLIC void camd_control    (double Control [ ]) ;
+CAMD_PUBLIC void camd_l_control  (double Control [ ]) ;
 
 /* camd_info: prints the statistics */
-SUITESPARSE_PUBLIC void camd_info       (double Info [ ]) ;
-SUITESPARSE_PUBLIC void camd_l_info     (double Info [ ]) ;
+CAMD_PUBLIC void camd_info       (double Info [ ]) ;
+CAMD_PUBLIC void camd_l_info     (double Info [ ]) ;
 
 #define CAMD_CONTROL 5      /* size of Control array */
 #define CAMD_INFO 20        /* size of Info array */

--- a/CAMD/Config/camd.h.in
+++ b/CAMD/Config/camd.h.in
@@ -31,10 +31,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( CAMD_LIBRARY )
@@ -50,7 +50,7 @@ extern "C" {
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define CAMD_PUBLIC extern
 
 #endif

--- a/CAMD/Include/camd.h
+++ b/CAMD/Include/camd.h
@@ -30,7 +30,32 @@ extern "C" {
 
 #include "SuiteSparse_config.h"
 
-SUITESPARSE_PUBLIC int camd_order /* returns CAMD_OK, CAMD_OK_BUT_JUMBLED,
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( CAMD_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define CAMD_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( CAMD_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define CAMD_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define CAMD_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define CAMD_PUBLIC extern
+
+#endif
+
+CAMD_PUBLIC int camd_order /* returns CAMD_OK, CAMD_OK_BUT_JUMBLED,
                              * CAMD_INVALID, or CAMD_OUT_OF_MEMORY */
 (
     int32_t n,                  /* A is n-by-n.  n must be >= 0. */
@@ -42,7 +67,7 @@ SUITESPARSE_PUBLIC int camd_order /* returns CAMD_OK, CAMD_OK_BUT_JUMBLED,
     const int32_t C [ ]         /* Constraint set of A, of size n; can be NULL */
 ) ;
 
-SUITESPARSE_PUBLIC int camd_l_order   /* see above for description */
+CAMD_PUBLIC int camd_l_order   /* see above for description */
 (
     int64_t n,
     const int64_t Ap [ ],
@@ -221,7 +246,7 @@ SUITESPARSE_PUBLIC int camd_l_order   /* see above for description */
  * of the matrix for CAMD to destroy).  Refer to CAMD/Source/camd_2.c for a
  * description of each parameter. */
 
-SUITESPARSE_PUBLIC void camd_2
+CAMD_PUBLIC void camd_2
 (
     int32_t n,
     int32_t Pe [ ],
@@ -242,7 +267,7 @@ SUITESPARSE_PUBLIC void camd_2
     int32_t BucketSet [ ] 
 ) ;
 
-SUITESPARSE_PUBLIC void camd_l2
+CAMD_PUBLIC void camd_l2
 (
     int64_t n,
     int64_t Pe [ ],
@@ -276,7 +301,7 @@ SUITESPARSE_PUBLIC void camd_l2
  * of columns of the matrix.  For its use in CAMD, these must both equal n.
  */
 
-SUITESPARSE_PUBLIC int camd_valid
+CAMD_PUBLIC int camd_valid
 (
     int32_t n_row,              /* # of rows */
     int32_t n_col,              /* # of columns */
@@ -284,7 +309,7 @@ SUITESPARSE_PUBLIC int camd_valid
     const int32_t Ai [ ]        /* row indices, of size Ap [n_col] */
 ) ;
 
-SUITESPARSE_PUBLIC int camd_l_valid
+CAMD_PUBLIC int camd_l_valid
 (
     int64_t n_row,
     int64_t n_col,
@@ -299,13 +324,13 @@ SUITESPARSE_PUBLIC int camd_l_valid
 /* Returns TRUE if the constraint set is valid as input to camd_order,
  * FALSE otherwise. */
 
-SUITESPARSE_PUBLIC int camd_cvalid
+CAMD_PUBLIC int camd_cvalid
 (
    int32_t n,
    const int32_t C [ ]
 ) ;
 
-SUITESPARSE_PUBLIC int camd_l_cvalid
+CAMD_PUBLIC int camd_l_cvalid
 (
    int64_t n,
    const int64_t C [ ]
@@ -316,16 +341,16 @@ SUITESPARSE_PUBLIC int camd_l_cvalid
 /* ------------------------------------------------------------------------- */
 
 /* camd_defaults:  sets the default control settings */
-SUITESPARSE_PUBLIC void camd_defaults   (double Control [ ]) ;
-SUITESPARSE_PUBLIC void camd_l_defaults (double Control [ ]) ;
+CAMD_PUBLIC void camd_defaults   (double Control [ ]) ;
+CAMD_PUBLIC void camd_l_defaults (double Control [ ]) ;
 
 /* camd_control: prints the control settings */
-SUITESPARSE_PUBLIC void camd_control    (double Control [ ]) ;
-SUITESPARSE_PUBLIC void camd_l_control  (double Control [ ]) ;
+CAMD_PUBLIC void camd_control    (double Control [ ]) ;
+CAMD_PUBLIC void camd_l_control  (double Control [ ]) ;
 
 /* camd_info: prints the statistics */
-SUITESPARSE_PUBLIC void camd_info       (double Info [ ]) ;
-SUITESPARSE_PUBLIC void camd_l_info     (double Info [ ]) ;
+CAMD_PUBLIC void camd_info       (double Info [ ]) ;
+CAMD_PUBLIC void camd_l_info     (double Info [ ]) ;
 
 #define CAMD_CONTROL 5      /* size of Control array */
 #define CAMD_INFO 20        /* size of Info array */

--- a/CAMD/Include/camd.h
+++ b/CAMD/Include/camd.h
@@ -31,10 +31,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( CAMD_LIBRARY )
@@ -50,7 +50,7 @@ extern "C" {
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define CAMD_PUBLIC extern
 
 #endif

--- a/CAMD/Include/camd_internal.h
+++ b/CAMD/Include/camd_internal.h
@@ -62,7 +62,7 @@
 #undef EMPTY
 #endif
 
-#define GLOBAL SUITESPARSE_PUBLIC
+#define GLOBAL CAMD_PUBLIC
 #define PRIVATE static
 
 /* FLIP is a "negation about -1", and is used to mark an integer i that is
@@ -116,7 +116,6 @@
 /* integer type for CAMD: int32_t or int64_t */
 /* ------------------------------------------------------------------------- */
 
-#define SUITESPARSE_LIBRARY
 #include "camd.h"
 
 #if defined (DLONG) || defined (ZLONG)

--- a/CCOLAMD/CMakeLists.txt
+++ b/CCOLAMD/CMakeLists.txt
@@ -72,6 +72,8 @@ set_target_properties ( ccolamd PROPERTIES
     SOVERSION ${CCOLAMD_VERSION_MAJOR}
     PUBLIC_HEADER "Include/ccolamd.h" )
 
+target_compile_definitions ( ccolamd PRIVATE CCOLAMD_LIBRARY )
+
 #-------------------------------------------------------------------------------
 # static ccolamd library properties
 #-------------------------------------------------------------------------------
@@ -84,6 +86,8 @@ set_target_properties ( ccolamd_static PROPERTIES
     OUTPUT_NAME ccolamd
     C_STANDARD_REQUIRED 11
     SOVERSION ${CCOLAMD_VERSION_MAJOR} )
+
+target_compile_definitions ( ccolamd_static PUBLIC CCOLAMD_STATIC )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -96,7 +100,7 @@ if ( NOT NSTATIC )
 endif ( )
 
 # libm:
-if ( NOT MSVC )
+if ( NOT WIN32 )
     target_link_libraries ( ccolamd PUBLIC m )
     if ( NOT NSTATIC )
         target_link_libraries ( ccolamd_static PUBLIC m )

--- a/CCOLAMD/Config/ccolamd.h.in
+++ b/CCOLAMD/Config/ccolamd.h.in
@@ -24,10 +24,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( CCOLAMD_LIBRARY )
@@ -43,7 +43,7 @@ extern "C" {
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define CCOLAMD_PUBLIC extern
 
 #endif

--- a/CCOLAMD/Config/ccolamd.h.in
+++ b/CCOLAMD/Config/ccolamd.h.in
@@ -23,6 +23,31 @@ extern "C" {
 
 #include "SuiteSparse_config.h"
 
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( CCOLAMD_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define CCOLAMD_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( CCOLAMD_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define CCOLAMD_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define CCOLAMD_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define CCOLAMD_PUBLIC extern
+
+#endif
+
 /* ========================================================================== */
 /* === CCOLAMD version ====================================================== */
 /* ========================================================================== */
@@ -78,7 +103,7 @@ extern "C" {
 /* stats [3]: ccolamd status:  zero OK, > 0 warning or notice, < 0 error */
 #define CCOLAMD_STATUS 3
 
-/* stats [4..6]: error info, or info on jumbled columns */ 
+/* stats [4..6]: error info, or info on jumbled columns */
 #define CCOLAMD_INFO1 4
 #define CCOLAMD_INFO2 5
 #define CCOLAMD_INFO3 6
@@ -112,7 +137,7 @@ extern "C" {
 /* === Prototypes of user-callable routines ================================= */
 /* ========================================================================== */
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 size_t ccolamd_recommended	/* returns recommended value of Alen, */
 				/* or 0 if input arguments are erroneous */
 (
@@ -121,7 +146,7 @@ size_t ccolamd_recommended	/* returns recommended value of Alen, */
     int n_col			/* number of columns in A */
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 size_t ccolamd_l_recommended	/* returns recommended value of Alen, */
 				/* or 0 if input arguments are erroneous */
 (
@@ -130,19 +155,19 @@ size_t ccolamd_l_recommended	/* returns recommended value of Alen, */
     int64_t n_col		/* number of columns in A */
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_set_defaults	/* sets default parameters */
 (				/* knobs argument is modified on output */
     double knobs [CCOLAMD_KNOBS]	/* parameter settings for ccolamd */
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_l_set_defaults	/* sets default parameters */
 (				/* knobs argument is modified on output */
     double knobs [CCOLAMD_KNOBS]	/* parameter settings for ccolamd */
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 int ccolamd			/* returns (1) if successful, (0) otherwise*/
 (				/* A and p arguments are modified on output */
     int n_row,			/* number of rows in A */
@@ -155,7 +180,7 @@ int ccolamd			/* returns (1) if successful, (0) otherwise*/
     int cmember [ ]		/* Constraint set of A, of size n_col */
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 int ccolamd_l      /* as ccolamd w/ int64_t integers */
 (
     int64_t n_row,
@@ -168,7 +193,7 @@ int ccolamd_l      /* as ccolamd w/ int64_t integers */
     int64_t cmember [ ]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 int csymamd			/* return (1) if OK, (0) otherwise */
 (
     int n,			/* number of rows and columns of A */
@@ -185,7 +210,7 @@ int csymamd			/* return (1) if OK, (0) otherwise */
     int stype			/* 0: use both parts, >0: upper, <0: lower */
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 int csymamd_l      /* as csymamd, w/ int64_t integers */
 (
     int64_t n,
@@ -200,25 +225,25 @@ int csymamd_l      /* as csymamd, w/ int64_t integers */
     int64_t stype
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_report
 (
     int stats [CCOLAMD_STATS]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_l_report
 (
     int64_t stats [CCOLAMD_STATS]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void csymamd_report
 (
     int stats [CCOLAMD_STATS]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void csymamd_l_report
 (
     int64_t stats [CCOLAMD_STATS]
@@ -234,7 +259,7 @@ void csymamd_l_report
  * be called directly by the user.
  */
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 int ccolamd2
 (				/* A and p arguments are modified on output */
     int n_row,			/* number of rows in A */
@@ -255,7 +280,7 @@ int ccolamd2
     int cmember [ ]		/* Constraint set of A */
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 int ccolamd2_l     /* as ccolamd2, w/ int64_t integers */
 (
     int64_t n_row,
@@ -275,7 +300,7 @@ int ccolamd2_l     /* as ccolamd2, w/ int64_t integers */
     int64_t cmember [ ]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_apply_order
 (
     int Front [ ],
@@ -285,7 +310,7 @@ void ccolamd_apply_order
     int nfr
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_l_apply_order
 (
     int64_t Front [ ],
@@ -295,7 +320,7 @@ void ccolamd_l_apply_order
     int64_t nfr
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_fsize
 (
     int nn,
@@ -306,7 +331,7 @@ void ccolamd_fsize
     int Npiv [ ]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_l_fsize
 (
     int64_t nn,
@@ -317,7 +342,7 @@ void ccolamd_l_fsize
     int64_t Npiv [ ]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_postorder
 (
     int nn,
@@ -332,7 +357,7 @@ void ccolamd_postorder
     int cmember [ ]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_l_postorder
 (
     int64_t nn,
@@ -347,7 +372,7 @@ void ccolamd_l_postorder
     int64_t cmember [ ]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 int ccolamd_post_tree
 (
     int root,
@@ -358,7 +383,7 @@ int ccolamd_post_tree
     int Stack [ ]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 int64_t ccolamd_l_post_tree
 (
     int64_t root,

--- a/CCOLAMD/Include/ccolamd.h
+++ b/CCOLAMD/Include/ccolamd.h
@@ -24,10 +24,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( CCOLAMD_LIBRARY )
@@ -43,7 +43,7 @@ extern "C" {
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define CCOLAMD_PUBLIC extern
 
 #endif

--- a/CCOLAMD/Include/ccolamd.h
+++ b/CCOLAMD/Include/ccolamd.h
@@ -23,6 +23,31 @@ extern "C" {
 
 #include "SuiteSparse_config.h"
 
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( CCOLAMD_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define CCOLAMD_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( CCOLAMD_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define CCOLAMD_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define CCOLAMD_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define CCOLAMD_PUBLIC extern
+
+#endif
+
 /* ========================================================================== */
 /* === CCOLAMD version ====================================================== */
 /* ========================================================================== */
@@ -78,7 +103,7 @@ extern "C" {
 /* stats [3]: ccolamd status:  zero OK, > 0 warning or notice, < 0 error */
 #define CCOLAMD_STATUS 3
 
-/* stats [4..6]: error info, or info on jumbled columns */ 
+/* stats [4..6]: error info, or info on jumbled columns */
 #define CCOLAMD_INFO1 4
 #define CCOLAMD_INFO2 5
 #define CCOLAMD_INFO3 6
@@ -112,7 +137,7 @@ extern "C" {
 /* === Prototypes of user-callable routines ================================= */
 /* ========================================================================== */
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 size_t ccolamd_recommended	/* returns recommended value of Alen, */
 				/* or 0 if input arguments are erroneous */
 (
@@ -121,7 +146,7 @@ size_t ccolamd_recommended	/* returns recommended value of Alen, */
     int n_col			/* number of columns in A */
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 size_t ccolamd_l_recommended	/* returns recommended value of Alen, */
 				/* or 0 if input arguments are erroneous */
 (
@@ -130,19 +155,19 @@ size_t ccolamd_l_recommended	/* returns recommended value of Alen, */
     int64_t n_col		/* number of columns in A */
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_set_defaults	/* sets default parameters */
 (				/* knobs argument is modified on output */
     double knobs [CCOLAMD_KNOBS]	/* parameter settings for ccolamd */
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_l_set_defaults	/* sets default parameters */
 (				/* knobs argument is modified on output */
     double knobs [CCOLAMD_KNOBS]	/* parameter settings for ccolamd */
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 int ccolamd			/* returns (1) if successful, (0) otherwise*/
 (				/* A and p arguments are modified on output */
     int n_row,			/* number of rows in A */
@@ -155,7 +180,7 @@ int ccolamd			/* returns (1) if successful, (0) otherwise*/
     int cmember [ ]		/* Constraint set of A, of size n_col */
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 int ccolamd_l      /* as ccolamd w/ int64_t integers */
 (
     int64_t n_row,
@@ -168,7 +193,7 @@ int ccolamd_l      /* as ccolamd w/ int64_t integers */
     int64_t cmember [ ]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 int csymamd			/* return (1) if OK, (0) otherwise */
 (
     int n,			/* number of rows and columns of A */
@@ -185,7 +210,7 @@ int csymamd			/* return (1) if OK, (0) otherwise */
     int stype			/* 0: use both parts, >0: upper, <0: lower */
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 int csymamd_l      /* as csymamd, w/ int64_t integers */
 (
     int64_t n,
@@ -200,25 +225,25 @@ int csymamd_l      /* as csymamd, w/ int64_t integers */
     int64_t stype
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_report
 (
     int stats [CCOLAMD_STATS]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_l_report
 (
     int64_t stats [CCOLAMD_STATS]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void csymamd_report
 (
     int stats [CCOLAMD_STATS]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void csymamd_l_report
 (
     int64_t stats [CCOLAMD_STATS]
@@ -234,7 +259,7 @@ void csymamd_l_report
  * be called directly by the user.
  */
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 int ccolamd2
 (				/* A and p arguments are modified on output */
     int n_row,			/* number of rows in A */
@@ -255,7 +280,7 @@ int ccolamd2
     int cmember [ ]		/* Constraint set of A */
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 int ccolamd2_l     /* as ccolamd2, w/ int64_t integers */
 (
     int64_t n_row,
@@ -275,7 +300,7 @@ int ccolamd2_l     /* as ccolamd2, w/ int64_t integers */
     int64_t cmember [ ]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_apply_order
 (
     int Front [ ],
@@ -285,7 +310,7 @@ void ccolamd_apply_order
     int nfr
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_l_apply_order
 (
     int64_t Front [ ],
@@ -295,7 +320,7 @@ void ccolamd_l_apply_order
     int64_t nfr
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_fsize
 (
     int nn,
@@ -306,7 +331,7 @@ void ccolamd_fsize
     int Npiv [ ]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_l_fsize
 (
     int64_t nn,
@@ -317,7 +342,7 @@ void ccolamd_l_fsize
     int64_t Npiv [ ]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_postorder
 (
     int nn,
@@ -332,7 +357,7 @@ void ccolamd_postorder
     int cmember [ ]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 void ccolamd_l_postorder
 (
     int64_t nn,
@@ -347,7 +372,7 @@ void ccolamd_l_postorder
     int64_t cmember [ ]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 int ccolamd_post_tree
 (
     int root,
@@ -358,7 +383,7 @@ int ccolamd_post_tree
     int Stack [ ]
 ) ;
 
-SUITESPARSE_PUBLIC 
+CCOLAMD_PUBLIC
 int64_t ccolamd_l_post_tree
 (
     int64_t root,

--- a/CCOLAMD/Source/ccolamd.c
+++ b/CCOLAMD/Source/ccolamd.c
@@ -703,7 +703,7 @@ typedef struct CColamd_Row_struct
     Int thickness ;     /* number of original rows represented by this row */
                         /* that are not yet pivotal */
     Int front ;         /* -1 if an original row */
-    			/* k if this row represents the kth frontal matrix */
+                        /* k if this row represents the kth frontal matrix */
                         /* where k goes from 0 to at most n_col-1 */
 
 } CColamd_Row ;
@@ -717,8 +717,8 @@ typedef struct CColamd_Row_struct
 #define MIN(a,b) (((a) < (b)) ? (a) : (b))
 
 /* Routines are either PUBLIC (user-callable) or PRIVATE (not user-callable) */
-#define GLOBAL SUITESPARSE_PUBLIC
-#define PUBLIC SUITESPARSE_PUBLIC
+#define GLOBAL CCOLAMD_PUBLIC
+#define PUBLIC CCOLAMD_PUBLIC
 #define PRIVATE static 
 
 #define DENSE_DEGREE(alpha,n) \

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -284,6 +284,8 @@ set_target_properties ( cholmod PROPERTIES
     SOVERSION ${CHOLMOD_VERSION_MAJOR}
     PUBLIC_HEADER "Include/cholmod.h" )
 
+target_compile_definitions ( cholmod PRIVATE CHOLMOD_LIBRARY )
+
 if ( SUITESPARSE_CUDA )
     set_target_properties ( cholmod PROPERTIES CUDA_SEPARABLE_COMPILATION on )
     set_target_properties ( cholmod PROPERTIES POSITION_INDEPENDENT_CODE on )
@@ -301,6 +303,8 @@ set_target_properties ( cholmod_static PROPERTIES
     C_STANDARD_REQUIRED 11
     OUTPUT_NAME cholmod
     SOVERSION ${CHOLMOD_VERSION_MAJOR} )
+
+target_compile_definitions ( cholmod_static PUBLIC CHOLMOD_STATIC )
 
 if ( SUITESPARSE_CUDA )
     set_target_properties ( cholmod_static PROPERTIES CUDA_SEPARABLE_COMPILATION on )
@@ -333,7 +337,7 @@ if ( OPENMP_FOUND )
 endif ( )
 
 # libm:
-if ( NOT MSVC )
+if ( NOT WIN32 )
     target_link_libraries ( cholmod PUBLIC m )
     if ( NOT NSTATIC )
         target_link_libraries ( cholmod_static PUBLIC m )

--- a/CHOLMOD/Config/cholmod.h.in
+++ b/CHOLMOD/Config/cholmod.h.in
@@ -148,10 +148,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( CHOLMOD_LIBRARY )
@@ -167,7 +167,7 @@ extern "C" {
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define CHOLMOD_PUBLIC extern
 
 #endif

--- a/CHOLMOD/Config/cholmod.h.in
+++ b/CHOLMOD/Config/cholmod.h.in
@@ -147,6 +147,31 @@ extern "C" {
 
 #include "SuiteSparse_config.h"
 
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( CHOLMOD_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define CHOLMOD_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( CHOLMOD_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define CHOLMOD_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define CHOLMOD_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define CHOLMOD_PUBLIC extern
+
+#endif
+
 /* ========================================================================== */
 /* === Include/cholmod_config.h ============================================= */
 /* ========================================================================== */
@@ -1234,39 +1259,39 @@ typedef struct cholmod_common_struct
 /* cholmod_start:  first call to CHOLMOD */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_start
 (
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_start (cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_finish:  last call to CHOLMOD */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_finish
 (
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_finish (cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_defaults:  restore default parameters */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_defaults
 (
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_defaults (cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
@@ -1287,7 +1312,7 @@ size_t cholmod_l_maxrank (size_t, cholmod_common *) ;
 /* cholmod_allocate_work:  allocate workspace in Common */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_allocate_work
 (
     /* ---- input ---- */
@@ -1298,20 +1323,20 @@ int cholmod_allocate_work
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_allocate_work (size_t, size_t, size_t, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_free_work:  free workspace in Common */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_free_work
 (
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_free_work (cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
@@ -1329,20 +1354,20 @@ int cholmod_l_free_work (cholmod_common *) ;
     } \
 }
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_clear_flag
 (
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_l_clear_flag (cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_error:  called when CHOLMOD encounters an error */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_error
 (
     /* ---- input ---- */
@@ -1354,14 +1379,14 @@ int cholmod_error
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_error (int, const char *, int, const char *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_dbound:  for internal use in CHOLMOD only */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_dbound	/* returns modified diagonal entry of D or L */
 (
     /* ---- input ---- */
@@ -1370,28 +1395,28 @@ double cholmod_dbound	/* returns modified diagonal entry of D or L */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_l_dbound (double, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_hypot:  compute sqrt (x*x + y*y) accurately */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_hypot
 (
     /* ---- input ---- */
     double x, double y
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_l_hypot (double, double) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_divcomplex:  complex division, c = a/b */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_divcomplex		/* return 1 if divide-by-zero, 0 otherise */
 (
     /* ---- input ---- */
@@ -1401,7 +1426,7 @@ int cholmod_divcomplex		/* return 1 if divide-by-zero, 0 otherise */
     double *cr, double *ci	/* real and imaginary parts of c */
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_divcomplex (double, double, double, double, double *, double *) ;
 
 
@@ -1470,11 +1495,11 @@ typedef struct cholmod_descendant_score_t
 descendantScore ;
 
 /* For sorting descendant supernodes with qsort */
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_score_comp (struct cholmod_descendant_score_t *i,
 			struct cholmod_descendant_score_t *j) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_score_comp (struct cholmod_descendant_score_t *i,
 			  struct cholmod_descendant_score_t *j) ;
 
@@ -1482,7 +1507,7 @@ int cholmod_l_score_comp (struct cholmod_descendant_score_t *i,
 /* cholmod_allocate_sparse:  allocate a sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_allocate_sparse
 (
     /* ---- input ---- */
@@ -1497,7 +1522,7 @@ cholmod_sparse *cholmod_allocate_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_allocate_sparse (size_t, size_t, size_t, int, int,
     int, int, cholmod_common *) ;
 
@@ -1505,7 +1530,7 @@ cholmod_sparse *cholmod_l_allocate_sparse (size_t, size_t, size_t, int, int,
 /* cholmod_free_sparse:  free a sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_free_sparse
 (
     /* ---- in/out --- */
@@ -1514,14 +1539,14 @@ int cholmod_free_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_free_sparse (cholmod_sparse **, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_reallocate_sparse:  change the size (# entries) of sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_reallocate_sparse
 (
     /* ---- input ---- */
@@ -1532,14 +1557,14 @@ int cholmod_reallocate_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_reallocate_sparse ( size_t, cholmod_sparse *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_nnz:  return number of nonzeros in a sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_nnz
 (
     /* ---- input ---- */
@@ -1548,14 +1573,14 @@ int64_t cholmod_nnz
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_l_nnz (cholmod_sparse *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_speye:  sparse identity matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_speye
 (
     /* ---- input ---- */
@@ -1566,14 +1591,14 @@ cholmod_sparse *cholmod_speye
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_speye (size_t, size_t, int, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_spzeros:  sparse zero matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_spzeros
 (
     /* ---- input ---- */
@@ -1585,7 +1610,7 @@ cholmod_sparse *cholmod_spzeros
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_spzeros (size_t, size_t, size_t, int,
     cholmod_common *) ;
 
@@ -1598,7 +1623,7 @@ cholmod_sparse *cholmod_l_spzeros (size_t, size_t, size_t, int,
  * (A').
  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_transpose
 (
     /* ---- input ---- */
@@ -1608,7 +1633,7 @@ cholmod_sparse *cholmod_transpose
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_transpose (cholmod_sparse *, int, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
@@ -1618,7 +1643,7 @@ cholmod_sparse *cholmod_l_transpose (cholmod_sparse *, int, cholmod_common *) ;
 /* Compute F = A', A (:,f)', or A (p,f)', where A is unsymmetric and F is
  * already allocated.  See cholmod_transpose for a simpler routine. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_transpose_unsym
 (
     /* ---- input ---- */
@@ -1633,7 +1658,7 @@ int cholmod_transpose_unsym
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_transpose_unsym (cholmod_sparse *, int, int64_t *,
     int64_t *, size_t, cholmod_sparse *, cholmod_common *) ;
 
@@ -1644,7 +1669,7 @@ int cholmod_l_transpose_unsym (cholmod_sparse *, int, int64_t *,
 /* Compute F = A' or A (p,p)', where A is symmetric and F is already allocated.
  * See cholmod_transpose for a simpler routine. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_transpose_sym
 (
     /* ---- input ---- */
@@ -1657,7 +1682,7 @@ int cholmod_transpose_sym
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_transpose_sym (cholmod_sparse *, int, int64_t *,
     cholmod_sparse *, cholmod_common *) ;
 
@@ -1668,7 +1693,7 @@ int cholmod_l_transpose_sym (cholmod_sparse *, int, int64_t *,
 /* Return A' or A(p,p)' if A is symmetric.  Return A', A(:,f)', or A(p,f)' if
  * A is unsymmetric. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_ptranspose
 (
     /* ---- input ---- */
@@ -1681,7 +1706,7 @@ cholmod_sparse *cholmod_ptranspose
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_ptranspose (cholmod_sparse *, int, int64_t *,
     int64_t *, size_t, cholmod_common *) ;
 
@@ -1689,7 +1714,7 @@ cholmod_sparse *cholmod_l_ptranspose (cholmod_sparse *, int, int64_t *,
 /* cholmod_sort:  sort row indices in each column of sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_sort
 (
     /* ---- in/out --- */
@@ -1698,14 +1723,14 @@ int cholmod_sort
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_sort (cholmod_sparse *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_band:  C = tril (triu (A,k1), k2) */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_band
 (
     /* ---- input ---- */
@@ -1717,7 +1742,7 @@ cholmod_sparse *cholmod_band
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_band (cholmod_sparse *, int64_t,
     int64_t, int, cholmod_common *) ;
 
@@ -1725,7 +1750,7 @@ cholmod_sparse *cholmod_l_band (cholmod_sparse *, int64_t,
 /* cholmod_band_inplace:  A = tril (triu (A,k1), k2) */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_band_inplace
 (
     /* ---- input ---- */
@@ -1738,7 +1763,7 @@ int cholmod_band_inplace
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_band_inplace (int64_t, int64_t, int,
     cholmod_sparse *, cholmod_common *) ;
 
@@ -1746,7 +1771,7 @@ int cholmod_l_band_inplace (int64_t, int64_t, int,
 /* cholmod_aat:  C = A*A' or A(:,f)*A(:,f)' */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_aat
 (
     /* ---- input ---- */
@@ -1760,7 +1785,7 @@ cholmod_sparse *cholmod_aat
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_aat (cholmod_sparse *, int64_t *, size_t,
     int, cholmod_common *) ;
 
@@ -1768,7 +1793,7 @@ cholmod_sparse *cholmod_l_aat (cholmod_sparse *, int64_t *, size_t,
 /* cholmod_copy_sparse:  C = A, create an exact copy of a sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_copy_sparse
 (
     /* ---- input ---- */
@@ -1777,14 +1802,14 @@ cholmod_sparse *cholmod_copy_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_copy_sparse (cholmod_sparse *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_copy:  C = A, with possible change of stype */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_copy
 (
     /* ---- input ---- */
@@ -1795,14 +1820,14 @@ cholmod_sparse *cholmod_copy
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_copy (cholmod_sparse *, int, int, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_add: C = alpha*A + beta*B */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_add
 (
     /* ---- input ---- */
@@ -1816,7 +1841,7 @@ cholmod_sparse *cholmod_add
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_add (cholmod_sparse *, cholmod_sparse *, double *,
     double *, int, int, cholmod_common *) ;
 
@@ -1824,7 +1849,7 @@ cholmod_sparse *cholmod_l_add (cholmod_sparse *, cholmod_sparse *, double *,
 /* cholmod_sparse_xtype: change the xtype of a sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_sparse_xtype
 (
     /* ---- input ---- */
@@ -1835,7 +1860,7 @@ int cholmod_sparse_xtype
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_sparse_xtype (int, cholmod_sparse *, cholmod_common *) ;
 
 
@@ -1978,7 +2003,7 @@ typedef struct cholmod_factor_struct
 /* cholmod_allocate_factor: allocate a factor (symbolic LL' or LDL') */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_allocate_factor
 (
     /* ---- input ---- */
@@ -1987,14 +2012,14 @@ cholmod_factor *cholmod_allocate_factor
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_l_allocate_factor (size_t, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_free_factor:  free a factor */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_free_factor
 (
     /* ---- in/out --- */
@@ -2003,14 +2028,14 @@ int cholmod_free_factor
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_free_factor (cholmod_factor **, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_reallocate_factor:  change the # entries in a factor */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_reallocate_factor
 (
     /* ---- input ---- */
@@ -2021,14 +2046,14 @@ int cholmod_reallocate_factor
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_reallocate_factor (size_t, cholmod_factor *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_change_factor:  change the type of factor (e.g., LDL' to LL') */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_change_factor
 (
     /* ---- input ---- */
@@ -2043,7 +2068,7 @@ int cholmod_change_factor
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_change_factor ( int, int, int, int, int, cholmod_factor *,
     cholmod_common *) ;
 
@@ -2055,7 +2080,7 @@ int cholmod_l_change_factor ( int, int, int, int, int, cholmod_factor *,
  * it can pack the columns of a factor even if they are not stored in their
  * natural order (non-monotonic). */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_pack_factor
 (
     /* ---- in/out --- */
@@ -2064,14 +2089,14 @@ int cholmod_pack_factor
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_pack_factor (cholmod_factor *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_reallocate_column:  resize a single column of a factor */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_reallocate_column
 (
     /* ---- input ---- */
@@ -2083,7 +2108,7 @@ int cholmod_reallocate_column
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_reallocate_column (size_t, size_t, cholmod_factor *,
     cholmod_common *) ;
 
@@ -2093,7 +2118,7 @@ int cholmod_l_reallocate_column (size_t, size_t, cholmod_factor *,
 
 /* Only operates on numeric factors, not symbolic ones */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_factor_to_sparse
 (
     /* ---- in/out --- */
@@ -2102,7 +2127,7 @@ cholmod_sparse *cholmod_factor_to_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_factor_to_sparse (cholmod_factor *,
 	cholmod_common *) ;
 
@@ -2110,7 +2135,7 @@ cholmod_sparse *cholmod_l_factor_to_sparse (cholmod_factor *,
 /* cholmod_copy_factor:  create a copy of a factor */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_copy_factor
 (
     /* ---- input ---- */
@@ -2119,14 +2144,14 @@ cholmod_factor *cholmod_copy_factor
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_l_copy_factor (cholmod_factor *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_factor_xtype: change the xtype of a factor */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_factor_xtype
 (
     /* ---- input ---- */
@@ -2137,7 +2162,7 @@ int cholmod_factor_xtype
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_factor_xtype (int, cholmod_factor *, cholmod_common *) ;
 
 
@@ -2166,7 +2191,7 @@ typedef struct cholmod_dense_struct
 /* cholmod_allocate_dense:  allocate a dense matrix (contents uninitialized) */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_allocate_dense
 (
     /* ---- input ---- */
@@ -2178,7 +2203,7 @@ cholmod_dense *cholmod_allocate_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_allocate_dense (size_t, size_t, size_t, int,
     cholmod_common *) ;
 
@@ -2186,7 +2211,7 @@ cholmod_dense *cholmod_l_allocate_dense (size_t, size_t, size_t, int,
 /* cholmod_zeros: allocate a dense matrix and set it to zero */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_zeros
 (
     /* ---- input ---- */
@@ -2197,14 +2222,14 @@ cholmod_dense *cholmod_zeros
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_zeros (size_t, size_t, int, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_ones: allocate a dense matrix and set it to all ones */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_ones
 (
     /* ---- input ---- */
@@ -2215,14 +2240,14 @@ cholmod_dense *cholmod_ones
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_ones (size_t, size_t, int, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_eye: allocate a dense matrix and set it to the identity matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_eye
 (
     /* ---- input ---- */
@@ -2233,14 +2258,14 @@ cholmod_dense *cholmod_eye
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_eye (size_t, size_t, int, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_free_dense:  free a dense matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_free_dense
 (
     /* ---- in/out --- */
@@ -2249,14 +2274,14 @@ int cholmod_free_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_free_dense (cholmod_dense **, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_ensure_dense:  ensure a dense matrix has a given size and type */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_ensure_dense
 (
     /* ---- input/output ---- */
@@ -2270,7 +2295,7 @@ cholmod_dense *cholmod_ensure_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_ensure_dense (cholmod_dense **, size_t, size_t, size_t,
     int, cholmod_common *) ;
 
@@ -2278,7 +2303,7 @@ cholmod_dense *cholmod_l_ensure_dense (cholmod_dense **, size_t, size_t, size_t,
 /* cholmod_sparse_to_dense:  create a dense matrix copy of a sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_sparse_to_dense
 (
     /* ---- input ---- */
@@ -2287,7 +2312,7 @@ cholmod_dense *cholmod_sparse_to_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_sparse_to_dense (cholmod_sparse *,
     cholmod_common *) ;
 
@@ -2295,7 +2320,7 @@ cholmod_dense *cholmod_l_sparse_to_dense (cholmod_sparse *,
 /* cholmod_dense_to_sparse:  create a sparse matrix copy of a dense matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_dense_to_sparse
 (
     /* ---- input ---- */
@@ -2305,7 +2330,7 @@ cholmod_sparse *cholmod_dense_to_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_dense_to_sparse (cholmod_dense *, int,
     cholmod_common *) ;
 
@@ -2313,7 +2338,7 @@ cholmod_sparse *cholmod_l_dense_to_sparse (cholmod_dense *, int,
 /* cholmod_copy_dense:  create a copy of a dense matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_copy_dense
 (
     /* ---- input ---- */
@@ -2322,14 +2347,14 @@ cholmod_dense *cholmod_copy_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_copy_dense (cholmod_dense *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_copy_dense2:  copy a dense matrix (pre-allocated) */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_copy_dense2
 (
     /* ---- input ---- */
@@ -2340,14 +2365,14 @@ int cholmod_copy_dense2
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_copy_dense2 (cholmod_dense *, cholmod_dense *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_dense_xtype: change the xtype of a dense matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_dense_xtype
 (
     /* ---- input ---- */
@@ -2358,7 +2383,7 @@ int cholmod_dense_xtype
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_dense_xtype (int, cholmod_dense *, cholmod_common *) ;
 
 
@@ -2435,7 +2460,7 @@ typedef struct cholmod_triplet_struct
 /* cholmod_allocate_triplet:  allocate a triplet matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_triplet *cholmod_allocate_triplet
 (
     /* ---- input ---- */
@@ -2448,7 +2473,7 @@ cholmod_triplet *cholmod_allocate_triplet
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_triplet *cholmod_l_allocate_triplet (size_t, size_t, size_t, int, int,
     cholmod_common *) ;
 
@@ -2456,7 +2481,7 @@ cholmod_triplet *cholmod_l_allocate_triplet (size_t, size_t, size_t, int, int,
 /* cholmod_free_triplet:  free a triplet matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_free_triplet
 (
     /* ---- in/out --- */
@@ -2465,14 +2490,14 @@ int cholmod_free_triplet
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_free_triplet (cholmod_triplet **, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_reallocate_triplet:  change the # of entries in a triplet matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_reallocate_triplet
 (
     /* ---- input ---- */
@@ -2483,14 +2508,14 @@ int cholmod_reallocate_triplet
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_reallocate_triplet (size_t, cholmod_triplet *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_sparse_to_triplet:  create a triplet matrix copy of a sparse matrix*/
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_triplet *cholmod_sparse_to_triplet
 (
     /* ---- input ---- */
@@ -2499,7 +2524,7 @@ cholmod_triplet *cholmod_sparse_to_triplet
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_triplet *cholmod_l_sparse_to_triplet (cholmod_sparse *,
     cholmod_common *) ;
 
@@ -2507,7 +2532,7 @@ cholmod_triplet *cholmod_l_sparse_to_triplet (cholmod_sparse *,
 /* cholmod_triplet_to_sparse:  create a sparse matrix copy of a triplet matrix*/
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_triplet_to_sparse
 (
     /* ---- input ---- */
@@ -2517,7 +2542,7 @@ cholmod_sparse *cholmod_triplet_to_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_triplet_to_sparse (cholmod_triplet *, size_t,
     cholmod_common *) ;
 
@@ -2525,7 +2550,7 @@ cholmod_sparse *cholmod_l_triplet_to_sparse (cholmod_triplet *, size_t,
 /* cholmod_copy_triplet:  create a copy of a triplet matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_triplet *cholmod_copy_triplet
 (
     /* ---- input ---- */
@@ -2534,14 +2559,14 @@ cholmod_triplet *cholmod_copy_triplet
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_triplet *cholmod_l_copy_triplet (cholmod_triplet *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_triplet_xtype: change the xtype of a triplet matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_triplet_xtype
 (
     /* ---- input ---- */
@@ -2552,7 +2577,7 @@ int cholmod_triplet_xtype
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_triplet_xtype (int, cholmod_triplet *, cholmod_common *) ;
 
 
@@ -2576,7 +2601,7 @@ int cholmod_l_triplet_xtype (int, cholmod_triplet *, cholmod_common *) ;
  * corrupted.
  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_malloc	/* returns pointer to the newly malloc'd block */
 (
     /* ---- input ---- */
@@ -2586,10 +2611,10 @@ void *cholmod_malloc	/* returns pointer to the newly malloc'd block */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_l_malloc (size_t, size_t, cholmod_common *) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_calloc	/* returns pointer to the newly calloc'd block */
 (
     /* ---- input ---- */
@@ -2599,10 +2624,10 @@ void *cholmod_calloc	/* returns pointer to the newly calloc'd block */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_l_calloc (size_t, size_t, cholmod_common *) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_free	/* always returns NULL */
 (
     /* ---- input ---- */
@@ -2614,10 +2639,10 @@ void *cholmod_free	/* always returns NULL */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_l_free (size_t, size_t, void *, cholmod_common *) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_realloc	/* returns pointer to reallocated block */
 (
     /* ---- input ---- */
@@ -2630,10 +2655,10 @@ void *cholmod_realloc	/* returns pointer to reallocated block */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_l_realloc (size_t, size_t, void *, size_t *, cholmod_common *) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_realloc_multiple
 (
     /* ---- input ---- */
@@ -2651,7 +2676,7 @@ int cholmod_realloc_multiple
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_realloc_multiple (size_t, int, int, void **, void **, void **,
     void **, size_t *, cholmod_common *) ;
 
@@ -2659,7 +2684,7 @@ int cholmod_l_realloc_multiple (size_t, int, int, void **, void **, void **,
 /* === version control ====================================================== */
 /* ========================================================================== */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_version     /* returns CHOLMOD_VERSION */
 (
     /* output, contents not defined on input.  Not used if NULL.
@@ -2670,7 +2695,7 @@ int cholmod_version     /* returns CHOLMOD_VERSION */
     int version [3]
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_version (int version [3]) ;
 
 /* Versions prior to 2.1.1 do not have the above function.  The following
@@ -2821,20 +2846,20 @@ int cholmod_l_version (int version [3]) ;
 /* cholmod_check_common:  check the Common object */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_check_common
 (
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_check_common (cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_print_common:  print the Common object */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_print_common
 (
     /* ---- input ---- */
@@ -2843,23 +2868,23 @@ int cholmod_print_common
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_print_common (const char *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_gpu_stats:  print the GPU / CPU statistics */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_gpu_stats   (cholmod_common *) ;
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_gpu_stats (cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_check_sparse:  check a sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_check_sparse
 (
     /* ---- input ---- */
@@ -2868,14 +2893,14 @@ int cholmod_check_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_check_sparse (cholmod_sparse *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_print_sparse */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_print_sparse
 (
     /* ---- input ---- */
@@ -2885,14 +2910,14 @@ int cholmod_print_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_print_sparse (cholmod_sparse *, const char *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_check_dense:  check a dense matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_check_dense
 (
     /* ---- input ---- */
@@ -2901,14 +2926,14 @@ int cholmod_check_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_check_dense (cholmod_dense *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_print_dense:  print a dense matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_print_dense
 (
     /* ---- input ---- */
@@ -2918,14 +2943,14 @@ int cholmod_print_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_print_dense (cholmod_dense *, const char *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_check_factor:  check a factor */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_check_factor
 (
     /* ---- input ---- */
@@ -2934,14 +2959,14 @@ int cholmod_check_factor
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_check_factor (cholmod_factor *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_print_factor:  print a factor */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_print_factor
 (
     /* ---- input ---- */
@@ -2951,14 +2976,14 @@ int cholmod_print_factor
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_print_factor (cholmod_factor *, const char *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_check_triplet:  check a sparse matrix in triplet form */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_check_triplet
 (
     /* ---- input ---- */
@@ -2967,14 +2992,14 @@ int cholmod_check_triplet
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_check_triplet (cholmod_triplet *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_print_triplet:  print a triplet matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_print_triplet
 (
     /* ---- input ---- */
@@ -2984,14 +3009,14 @@ int cholmod_print_triplet
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_print_triplet (cholmod_triplet *, const char *, cholmod_common *);
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_check_subset:  check a subset */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_check_subset
 (
     /* ---- input ---- */
@@ -3002,7 +3027,7 @@ int cholmod_check_subset
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_check_subset (int64_t *, int64_t, size_t,
     cholmod_common *) ;
 
@@ -3010,7 +3035,7 @@ int cholmod_l_check_subset (int64_t *, int64_t, size_t,
 /* cholmod_print_subset:  print a subset */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_print_subset
 (
     /* ---- input ---- */
@@ -3022,7 +3047,7 @@ int cholmod_print_subset
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_print_subset (int64_t *, int64_t, size_t,
     const char *, cholmod_common *) ;
 
@@ -3030,7 +3055,7 @@ int cholmod_l_print_subset (int64_t *, int64_t, size_t,
 /* cholmod_check_perm:  check a permutation */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_check_perm
 (
     /* ---- input ---- */
@@ -3041,14 +3066,14 @@ int cholmod_check_perm
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_check_perm (int64_t *, size_t, size_t, cholmod_common *);
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_print_perm:  print a permutation vector */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_print_perm
 (
     /* ---- input ---- */
@@ -3060,7 +3085,7 @@ int cholmod_print_perm
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_print_perm (int64_t *, size_t, size_t, const char *,
     cholmod_common *) ;
 
@@ -3068,7 +3093,7 @@ int cholmod_l_print_perm (int64_t *, size_t, size_t, const char *,
 /* cholmod_check_parent:  check an elimination tree */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_check_parent
 (
     /* ---- input ---- */
@@ -3078,14 +3103,14 @@ int cholmod_check_parent
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_check_parent (int64_t *, size_t, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_print_parent */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_print_parent
 (
     /* ---- input ---- */
@@ -3096,7 +3121,7 @@ int cholmod_print_parent
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_print_parent (int64_t *, size_t, const char *,
     cholmod_common *) ;
 
@@ -3104,7 +3129,7 @@ int cholmod_l_print_parent (int64_t *, size_t, const char *,
 /* cholmod_read_sparse: read a sparse matrix from a file */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_read_sparse
 (
     /* ---- input ---- */
@@ -3113,14 +3138,14 @@ cholmod_sparse *cholmod_read_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_read_sparse (FILE *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_read_triplet: read a triplet matrix from a file */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_triplet *cholmod_read_triplet
 (
     /* ---- input ---- */
@@ -3129,14 +3154,14 @@ cholmod_triplet *cholmod_read_triplet
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_triplet *cholmod_l_read_triplet (FILE *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_read_dense: read a dense matrix from a file */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_read_dense
 (
     /* ---- input ---- */
@@ -3145,14 +3170,14 @@ cholmod_dense *cholmod_read_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_read_dense (FILE *, cholmod_common *) ; 
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_read_matrix: read a sparse or dense matrix from a file */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_read_matrix
 (
     /* ---- input ---- */
@@ -3177,14 +3202,14 @@ void *cholmod_read_matrix
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_l_read_matrix (FILE *, int, int *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_write_sparse: write a sparse matrix to a file */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_write_sparse
 (
     /* ---- input ---- */
@@ -3196,7 +3221,7 @@ int cholmod_write_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_write_sparse (FILE *, cholmod_sparse *, cholmod_sparse *,
     const char *c, cholmod_common *) ;
 
@@ -3204,7 +3229,7 @@ int cholmod_l_write_sparse (FILE *, cholmod_sparse *, cholmod_sparse *,
 /* cholmod_write_dense: write a dense matrix to a file */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_write_dense
 (
     /* ---- input ---- */
@@ -3215,7 +3240,7 @@ int cholmod_write_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_write_dense (FILE *, cholmod_dense *, const char *,
     cholmod_common *) ;
 #endif
@@ -3281,7 +3306,7 @@ int cholmod_l_write_dense (FILE *, cholmod_dense *, const char *,
 /* Orders and analyzes A, AA', PAP', or PAA'P' and returns a symbolic factor
  * that can later be passed to cholmod_factorize. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_analyze 
 (
     /* ---- input ---- */
@@ -3290,7 +3315,7 @@ cholmod_factor *cholmod_analyze
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_l_analyze (cholmod_sparse *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
@@ -3302,7 +3327,7 @@ cholmod_factor *cholmod_l_analyze (cholmod_sparse *, cholmod_common *) ;
  * F = A(:,fset) if fset is not NULL and A->stype is zero.
  * UserPerm is tried if non-NULL.  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_analyze_p
 (
     /* ---- input ---- */
@@ -3314,7 +3339,7 @@ cholmod_factor *cholmod_analyze_p
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_l_analyze_p (cholmod_sparse *, int64_t *,
     int64_t *, size_t, cholmod_common *) ;
 
@@ -3322,7 +3347,7 @@ cholmod_factor *cholmod_l_analyze_p (cholmod_sparse *, int64_t *,
 /* cholmod_analyze_p2:  analyze for sparse Cholesky or sparse QR */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_analyze_p2
 (
     /* ---- input ---- */
@@ -3337,7 +3362,7 @@ cholmod_factor *cholmod_analyze_p2
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_l_analyze_p2 (int, cholmod_sparse *, int64_t *,
     int64_t *, size_t, cholmod_common *) ;
 
@@ -3350,7 +3375,7 @@ cholmod_factor *cholmod_l_analyze_p2 (int, cholmod_sparse *, int64_t *,
  * routine a second time with another matrix.  A must have the same nonzero
  * pattern as that passed to cholmod_analyze. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_factorize 
 (
     /* ---- input ---- */
@@ -3361,7 +3386,7 @@ int cholmod_factorize
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_factorize (cholmod_sparse *, cholmod_factor *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
@@ -3370,7 +3395,7 @@ int cholmod_l_factorize (cholmod_sparse *, cholmod_factor *, cholmod_common *) ;
 
 /* Same as cholmod_factorize, but with more options. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_factorize_p
 (
     /* ---- input ---- */
@@ -3384,7 +3409,7 @@ int cholmod_factorize_p
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_factorize_p (cholmod_sparse *, double *, int64_t *,
     size_t, cholmod_factor *, cholmod_common *) ;
 
@@ -3406,7 +3431,7 @@ int cholmod_l_factorize_p (cholmod_sparse *, double *, int64_t *,
 #define CHOLMOD_P    7		/* permute x=Px */
 #define CHOLMOD_Pt   8		/* permute x=P'x */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_solve	/* returns the solution X */
 (
     /* ---- input ---- */
@@ -3417,7 +3442,7 @@ cholmod_dense *cholmod_solve	/* returns the solution X */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_solve (int, cholmod_factor *, cholmod_dense *,
     cholmod_common *) ;
 
@@ -3425,7 +3450,7 @@ cholmod_dense *cholmod_l_solve (int, cholmod_factor *, cholmod_dense *,
 /* cholmod_solve2:  like cholmod_solve, but with reusable workspace */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_solve2     /* returns TRUE on success, FALSE on failure */
 (
     /* ---- input ---- */
@@ -3443,7 +3468,7 @@ int cholmod_solve2     /* returns TRUE on success, FALSE on failure */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_solve2 (int, cholmod_factor *, cholmod_dense *, cholmod_sparse *,
     cholmod_dense **, cholmod_sparse **, cholmod_dense **, cholmod_dense **,
     cholmod_common *) ;
@@ -3452,7 +3477,7 @@ int cholmod_l_solve2 (int, cholmod_factor *, cholmod_dense *, cholmod_sparse *,
 /* cholmod_spsolve:  solve a linear system with a sparse right-hand-side */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_spsolve
 (
     /* ---- input ---- */
@@ -3463,7 +3488,7 @@ cholmod_sparse *cholmod_spsolve
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_spsolve (int, cholmod_factor *, cholmod_sparse *,
     cholmod_common *) ;
 
@@ -3471,7 +3496,7 @@ cholmod_sparse *cholmod_l_spsolve (int, cholmod_factor *, cholmod_sparse *,
 /* cholmod_etree: find the elimination tree of A or A'*A */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_etree
 (
     /* ---- input ---- */
@@ -3482,14 +3507,14 @@ int cholmod_etree
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_etree (cholmod_sparse *, int64_t *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_rowcolcounts: compute the row/column counts of L */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowcolcounts
 (
     /* ---- input ---- */
@@ -3512,7 +3537,7 @@ int cholmod_rowcolcounts
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowcolcounts (cholmod_sparse *, int64_t *, size_t,
     int64_t *, int64_t *, int64_t *,
     int64_t *, int64_t *, int64_t *,
@@ -3522,7 +3547,7 @@ int cholmod_l_rowcolcounts (cholmod_sparse *, int64_t *, size_t,
 /* cholmod_analyze_ordering:  analyze a fill-reducing ordering */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_analyze_ordering
 (
     /* ---- input ---- */
@@ -3542,7 +3567,7 @@ int cholmod_analyze_ordering
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_analyze_ordering (cholmod_sparse *, int, int64_t *,
     int64_t *, size_t, int64_t *, int64_t *, int64_t *, int64_t *, int64_t *,
     cholmod_common *) ;
@@ -3554,7 +3579,7 @@ int cholmod_l_analyze_ordering (cholmod_sparse *, int, int64_t *,
 /* Finds a permutation P to reduce fill-in in the factorization of P*A*P'
  * or P*A*A'P' */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_amd
 (
     /* ---- input ---- */
@@ -3567,7 +3592,7 @@ int cholmod_amd
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_amd (cholmod_sparse *, int64_t *, size_t,
     int64_t *, cholmod_common *) ;
 
@@ -3578,7 +3603,7 @@ int cholmod_l_amd (cholmod_sparse *, int64_t *, size_t,
 /* Finds a permutation P to reduce fill-in in the factorization of P*A*A'*P'.
  * Orders F*F' where F = A (:,fset) if fset is not NULL */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_colamd
 (
     /* ---- input ---- */
@@ -3592,7 +3617,7 @@ int cholmod_colamd
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_colamd (cholmod_sparse *, int64_t *, size_t, int,
     int64_t *, cholmod_common *) ;
 
@@ -3605,7 +3630,7 @@ int cholmod_l_colamd (cholmod_sparse *, int64_t *, size_t, int,
  * identity matrix.   Row k can only be factorized if all descendants of node
  * k in the elimination tree have been factorized. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowfac
 (
     /* ---- input ---- */
@@ -3620,7 +3645,7 @@ int cholmod_rowfac
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowfac (cholmod_sparse *, cholmod_sparse *, double *, size_t,
     size_t, cholmod_factor *, cholmod_common *) ;
 
@@ -3631,7 +3656,7 @@ int cholmod_l_rowfac (cholmod_sparse *, cholmod_sparse *, double *, size_t,
 /* cholmod_rowfac_mask is a version of cholmod_rowfac that is specific to
  * LPDASA.  It is unlikely to be needed by any other application. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowfac_mask
 (
     /* ---- input ---- */
@@ -3648,12 +3673,12 @@ int cholmod_rowfac_mask
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowfac_mask (cholmod_sparse *, cholmod_sparse *, double *, size_t,
     size_t, int64_t *, int64_t *, cholmod_factor *,
     cholmod_common *) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowfac_mask2
 (
     /* ---- input ---- */
@@ -3671,7 +3696,7 @@ int cholmod_rowfac_mask2
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowfac_mask2 (cholmod_sparse *, cholmod_sparse *, double *,
     size_t, size_t, int64_t *, int64_t, int64_t *,
     cholmod_factor *, cholmod_common *) ;
@@ -3683,7 +3708,7 @@ int cholmod_l_rowfac_mask2 (cholmod_sparse *, cholmod_sparse *, double *,
 /* Find the nonzero pattern of x for the system Lx=b where L = (0:k-1,0:k-1)
  * and b = kth column of A or A*A' (rows 0 to k-1 only) */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_row_subtree
 (
     /* ---- input ---- */
@@ -3697,7 +3722,7 @@ int cholmod_row_subtree
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_row_subtree (cholmod_sparse *, cholmod_sparse *, size_t,
     int64_t *, cholmod_sparse *, cholmod_common *) ;
 
@@ -3705,7 +3730,7 @@ int cholmod_l_row_subtree (cholmod_sparse *, cholmod_sparse *, size_t,
 /* cholmod_lsolve_pattern: find the nonzero pattern of x=L\b */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_lsolve_pattern
 (
     /* ---- input ---- */
@@ -3717,7 +3742,7 @@ int cholmod_lsolve_pattern
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_lsolve_pattern (cholmod_sparse *, cholmod_factor *,
     cholmod_sparse *, cholmod_common *) ;
 
@@ -3728,7 +3753,7 @@ int cholmod_l_lsolve_pattern (cholmod_sparse *, cholmod_factor *,
 /* Identical to cholmod_row_subtree, except that it finds the elimination tree
  * from L itself. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_row_lsubtree
 (
     /* ---- input ---- */
@@ -3743,7 +3768,7 @@ int cholmod_row_lsubtree
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_row_lsubtree (cholmod_sparse *, int64_t *, size_t,
     size_t, cholmod_factor *, cholmod_sparse *, cholmod_common *) ;
 
@@ -3758,7 +3783,7 @@ int cholmod_l_row_lsubtree (cholmod_sparse *, int64_t *, size_t,
  * first permutes A according to L->Perm.  A can be upper/lower/unsymmetric,
  * in contrast to cholmod_resymbol_noperm (which can be lower or unsym). */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_resymbol 
 (
     /* ---- input ---- */
@@ -3772,7 +3797,7 @@ int cholmod_resymbol
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_resymbol (cholmod_sparse *, int64_t *, size_t, int,
     cholmod_factor *, cholmod_common *) ;
 
@@ -3783,7 +3808,7 @@ int cholmod_l_resymbol (cholmod_sparse *, int64_t *, size_t, int,
 /* Remove entries from L that are not in the factorization of A, A*A',
  * or F*F' (depending on A->stype and whether fset is NULL or not). */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_resymbol_noperm
 (
     /* ---- input ---- */
@@ -3797,7 +3822,7 @@ int cholmod_resymbol_noperm
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_resymbol_noperm (cholmod_sparse *, int64_t *, size_t, int,
     cholmod_factor *, cholmod_common *) ;
 
@@ -3805,7 +3830,7 @@ int cholmod_l_resymbol_noperm (cholmod_sparse *, int64_t *, size_t, int,
 /* cholmod_rcond:  compute rough estimate of reciprocal of condition number */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_rcond	    /* return min(diag(L)) / max(diag(L)) */
 (
     /* ---- input ---- */
@@ -3814,14 +3839,14 @@ double cholmod_rcond	    /* return min(diag(L)) / max(diag(L)) */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_l_rcond (cholmod_factor *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_postorder: Compute the postorder of a tree */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int32_t cholmod_postorder	/* return # of nodes postordered */
 (
     /* ---- input ---- */
@@ -3834,7 +3859,7 @@ int32_t cholmod_postorder	/* return # of nodes postordered */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_l_postorder (int64_t *, size_t,
     int64_t *, int64_t *, cholmod_common *) ;
 
@@ -3872,7 +3897,7 @@ int64_t cholmod_l_postorder (int64_t *, size_t,
 /* cholmod_drop:  drop entries with small absolute value */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_drop
 (
     /* ---- input ---- */
@@ -3883,14 +3908,14 @@ int cholmod_drop
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_drop (double, cholmod_sparse *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_norm_dense:  s = norm (X), 1-norm, inf-norm, or 2-norm */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_norm_dense
 (
     /* ---- input ---- */
@@ -3900,14 +3925,14 @@ double cholmod_norm_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_l_norm_dense (cholmod_dense *, int, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_norm_sparse:  s = norm (A), 1-norm or inf-norm */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_norm_sparse
 (
     /* ---- input ---- */
@@ -3917,14 +3942,14 @@ double cholmod_norm_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_l_norm_sparse (cholmod_sparse *, int, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_horzcat:  C = [A,B] */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_horzcat
 (
     /* ---- input ---- */
@@ -3935,7 +3960,7 @@ cholmod_sparse *cholmod_horzcat
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_horzcat (cholmod_sparse *, cholmod_sparse *, int,
     cholmod_common *) ;
 
@@ -3949,7 +3974,7 @@ cholmod_sparse *cholmod_l_horzcat (cholmod_sparse *, cholmod_sparse *, int,
 #define CHOLMOD_COL 2		/* A = A*diag(s) */
 #define CHOLMOD_SYM 3		/* A = diag(s)*A*diag(s) */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_scale
 (
     /* ---- input ---- */
@@ -3961,7 +3986,7 @@ int cholmod_scale
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_scale (cholmod_dense *, int, cholmod_sparse *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
@@ -3970,7 +3995,7 @@ int cholmod_l_scale (cholmod_dense *, int, cholmod_sparse *, cholmod_common *) ;
 
 /* Sparse matrix times dense matrix */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_sdmult
 (
     /* ---- input ---- */
@@ -3985,7 +4010,7 @@ int cholmod_sdmult
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_sdmult (cholmod_sparse *, int, double *, double *,
     cholmod_dense *, cholmod_dense *Y, cholmod_common *) ;
 
@@ -3995,7 +4020,7 @@ int cholmod_l_sdmult (cholmod_sparse *, int, double *, double *,
 
 /* Sparse matrix times sparse matrix */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_ssmult
 (
     /* ---- input ---- */
@@ -4008,7 +4033,7 @@ cholmod_sparse *cholmod_ssmult
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_ssmult (cholmod_sparse *, cholmod_sparse *, int, int,
     int, cholmod_common *) ;
 
@@ -4022,7 +4047,7 @@ cholmod_sparse *cholmod_l_ssmult (cholmod_sparse *, cholmod_sparse *, int, int,
  * Similar rules hold for csize.
  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_submatrix
 (
     /* ---- input ---- */
@@ -4037,7 +4062,7 @@ cholmod_sparse *cholmod_submatrix
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_submatrix (cholmod_sparse *, int64_t *,
     int64_t, int64_t *, int64_t, int, int,
     cholmod_common *) ;
@@ -4046,7 +4071,7 @@ cholmod_sparse *cholmod_l_submatrix (cholmod_sparse *, int64_t *,
 /* cholmod_vertcat:  C = [A ; B] */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_vertcat
 (
     /* ---- input ---- */
@@ -4057,7 +4082,7 @@ cholmod_sparse *cholmod_vertcat
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_vertcat (cholmod_sparse *, cholmod_sparse *, int,
     cholmod_common *) ;
 
@@ -4065,7 +4090,7 @@ cholmod_sparse *cholmod_l_vertcat (cholmod_sparse *, cholmod_sparse *, int,
 /* cholmod_symmetry: determine if a sparse matrix is symmetric */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_symmetry
 (
     /* ---- input ---- */
@@ -4080,7 +4105,7 @@ int cholmod_symmetry
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_symmetry (cholmod_sparse *, int, int64_t *,
     int64_t *, int64_t *, int64_t *,
     cholmod_common *) ;
@@ -4142,7 +4167,7 @@ int cholmod_l_symmetry (cholmod_sparse *, int, int64_t *,
  * (a downdate).  The factor object L need not be an LDL' factorization; it
  * is converted to one if it isn't. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_updown 
 (
     /* ---- input ---- */
@@ -4154,7 +4179,7 @@ int cholmod_updown
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_updown (int, cholmod_sparse *, cholmod_factor *,
     cholmod_common *) ;
 
@@ -4168,7 +4193,7 @@ int cholmod_l_updown (int, cholmod_sparse *, cholmod_factor *,
  * entries in DeltaB corresponding to columns modified in L are accessed; the
  * rest must be zero. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_updown_solve
 (
     /* ---- input ---- */
@@ -4182,7 +4207,7 @@ int cholmod_updown_solve
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_updown_solve (int, cholmod_sparse *, cholmod_factor *,
     cholmod_dense *, cholmod_dense *, cholmod_common *) ;
 
@@ -4195,7 +4220,7 @@ int cholmod_l_updown_solve (int, cholmod_sparse *, cholmod_factor *,
  * routine.  It is meant for use in LPDASA only.  See cholmod_updown.c for
  * a description of colmark. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_updown_mark
 (
     /* ---- input ---- */
@@ -4210,7 +4235,7 @@ int cholmod_updown_mark
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_updown_mark (int, cholmod_sparse *, int64_t *,
     cholmod_factor *, cholmod_dense *, cholmod_dense *, cholmod_common *) ;
 
@@ -4222,7 +4247,7 @@ int cholmod_l_updown_mark (int, cholmod_sparse *, int64_t *,
  * argument.  This routine is an "expert" routine.  It is meant for use in
  * LPDASA only.  See cholmod_updown.c for a description of mask. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_updown_mask
 (
     /* ---- input ---- */
@@ -4238,12 +4263,12 @@ int cholmod_updown_mask
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_updown_mask (int, cholmod_sparse *, int64_t *,
     int64_t *, cholmod_factor *, cholmod_dense *, cholmod_dense *,
     cholmod_common *) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_updown_mask2
 (
     /* ---- input ---- */
@@ -4260,7 +4285,7 @@ int cholmod_updown_mask2
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_updown_mask2 (int, cholmod_sparse *, int64_t *,
     int64_t *, int64_t, cholmod_factor *, cholmod_dense *,
     cholmod_dense *, cholmod_common *) ;
@@ -4276,7 +4301,7 @@ int cholmod_l_updown_mask2 (int, cholmod_sparse *, int64_t *,
  * computed as the factorization of the kth row/column of the matrix to
  * factorize, which is provided as a single n-by-1 sparse matrix R. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowadd 
 (
     /* ---- input ---- */
@@ -4288,7 +4313,7 @@ int cholmod_rowadd
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowadd (size_t, cholmod_sparse *, cholmod_factor *,
     cholmod_common *) ;
 
@@ -4300,7 +4325,7 @@ int cholmod_l_rowadd (size_t, cholmod_sparse *, cholmod_factor *,
  * See cholmod_updown for a description of how Lx=b is updated.  There is on
  * additional parameter:  bk specifies the new kth entry of b. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowadd_solve
 (
     /* ---- input ---- */
@@ -4315,7 +4340,7 @@ int cholmod_rowadd_solve
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowadd_solve (size_t, cholmod_sparse *, double *,
     cholmod_factor *, cholmod_dense *, cholmod_dense *, cholmod_common *) ;
 
@@ -4327,7 +4352,7 @@ int cholmod_l_rowadd_solve (size_t, cholmod_sparse *, double *,
  * the update/downdate of the solution to Lx=b.  This routine is an "expert"
  * routine.  It is meant for use in LPDASA only.  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowadd_mark
 (
     /* ---- input ---- */
@@ -4343,7 +4368,7 @@ int cholmod_rowadd_mark
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowadd_mark (size_t, cholmod_sparse *, double *,
     int64_t *, cholmod_factor *, cholmod_dense *, cholmod_dense *,
     cholmod_common *) ;
@@ -4360,7 +4385,7 @@ int cholmod_l_rowadd_mark (size_t, cholmod_sparse *, double *,
  * a little more time.
  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowdel 
 (
     /* ---- input ---- */
@@ -4372,7 +4397,7 @@ int cholmod_rowdel
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowdel (size_t, cholmod_sparse *, cholmod_factor *,
     cholmod_common *) ;
 
@@ -4385,7 +4410,7 @@ int cholmod_l_rowdel (size_t, cholmod_sparse *, cholmod_factor *,
  * a change to x, in addition to changes arising when L and b are modified.
  * If this is the case, the kth entry of y is required as input (yk) */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowdel_solve
 (
     /* ---- input ---- */
@@ -4400,7 +4425,7 @@ int cholmod_rowdel_solve
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowdel_solve (size_t, cholmod_sparse *, double *,
     cholmod_factor *, cholmod_dense *, cholmod_dense *, cholmod_common *) ;
 
@@ -4412,7 +4437,7 @@ int cholmod_l_rowdel_solve (size_t, cholmod_sparse *, double *,
  * the update/downdate of the solution to Lx=b.  This routine is an "expert"
  * routine.  It is meant for use in LPDASA only.  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowdel_mark
 (
     /* ---- input ---- */
@@ -4428,7 +4453,7 @@ int cholmod_rowdel_mark
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowdel_mark (size_t, cholmod_sparse *, double *,
     int64_t *, cholmod_factor *, cholmod_dense *, cholmod_dense *,
     cholmod_common *) ;
@@ -4465,7 +4490,7 @@ int cholmod_l_rowdel_mark (size_t, cholmod_sparse *, double *,
 
 /* Order AA' or A(:,f)*A(:,f)' using CCOLAMD. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_ccolamd
 (
     /* ---- input ---- */
@@ -4483,7 +4508,7 @@ int cholmod_ccolamd
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_ccolamd (cholmod_sparse *, int64_t *, size_t,
     int64_t *, int64_t *, cholmod_common *) ;
 
@@ -4493,7 +4518,7 @@ int cholmod_l_ccolamd (cholmod_sparse *, int64_t *, size_t,
 
 /* Order A using CSYMAMD. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_csymamd
 (
     /* ---- input ---- */
@@ -4505,7 +4530,7 @@ int cholmod_csymamd
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_csymamd (cholmod_sparse *, int64_t *,
     int64_t *, cholmod_common *) ;
 
@@ -4515,7 +4540,7 @@ int cholmod_l_csymamd (cholmod_sparse *, int64_t *,
 
 /* Order A using CAMD. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_camd
 (
     /* ---- input ---- */
@@ -4529,7 +4554,7 @@ int cholmod_camd
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_camd (cholmod_sparse *, int64_t *, size_t,
     int64_t *, int64_t *, cholmod_common *) ;
 
@@ -4581,7 +4606,7 @@ int cholmod_l_camd (cholmod_sparse *, int64_t *, size_t,
  * finds better orderings than METIS_NodeND, but takes longer.
  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_nested_dissection	/* returns # of components */
 (
     /* ---- input ---- */
@@ -4599,7 +4624,7 @@ int64_t cholmod_nested_dissection	/* returns # of components */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_l_nested_dissection (cholmod_sparse *,
     int64_t *, size_t, int64_t *, int64_t *,
     int64_t *, cholmod_common *) ;
@@ -4610,7 +4635,7 @@ int64_t cholmod_l_nested_dissection (cholmod_sparse *,
 
 /* Order A, AA', or A(:,f)*A(:,f)' using METIS_NodeND. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_metis
 (
     /* ---- input ---- */
@@ -4624,7 +4649,7 @@ int cholmod_metis
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_metis (cholmod_sparse *, int64_t *, size_t, int,
     int64_t *, cholmod_common *) ;
 
@@ -4634,7 +4659,7 @@ int cholmod_l_metis (cholmod_sparse *, int64_t *, size_t, int,
 
 /* Finds a node bisector of A, A*A', A(:,f)*A(:,f)'. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_bisect	/* returns # of nodes in separator */
 (
     /* ---- input ---- */
@@ -4650,7 +4675,7 @@ int64_t cholmod_bisect	/* returns # of nodes in separator */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_l_bisect (cholmod_sparse *, int64_t *,
     size_t, int, int64_t *, cholmod_common *) ;
 
@@ -4661,7 +4686,7 @@ int64_t cholmod_l_bisect (cholmod_sparse *, int64_t *,
 /* Find a set of nodes that bisects the graph of A or AA' (direct interface
  * to METIS_ComputeVertexSeperator). */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_metis_bisector	/* returns separator size */
 (
     /* ---- input ---- */
@@ -4679,7 +4704,7 @@ int64_t cholmod_metis_bisector	/* returns separator size */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_l_metis_bisector (cholmod_sparse *,
     int64_t *, int64_t *, int64_t *,
     cholmod_common *) ;
@@ -4690,7 +4715,7 @@ int64_t cholmod_l_metis_bisector (cholmod_sparse *,
 
 /* Collapse nodes in a separator tree. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_collapse_septree
 (
     /* ---- input ---- */
@@ -4705,7 +4730,7 @@ int64_t cholmod_collapse_septree
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_l_collapse_septree (size_t, size_t, double, size_t,
     int64_t *, int64_t *, cholmod_common *) ;
 
@@ -4757,7 +4782,7 @@ int64_t cholmod_l_collapse_septree (size_t, size_t, double, size_t,
  * a "simple" wrapper for this routine.
  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_super_symbolic
 (
     /* ---- input ---- */
@@ -4771,7 +4796,7 @@ int cholmod_super_symbolic
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_super_symbolic (cholmod_sparse *, cholmod_sparse *,
     int64_t *, cholmod_factor *, cholmod_common *) ;
 
@@ -4781,7 +4806,7 @@ int cholmod_l_super_symbolic (cholmod_sparse *, cholmod_sparse *,
 
 /* Analyze for supernodal Cholesky or multifrontal QR */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_super_symbolic2
 (
     /* ---- input ---- */
@@ -4798,7 +4823,7 @@ int cholmod_super_symbolic2
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_super_symbolic2 (int, cholmod_sparse *, cholmod_sparse *,
     int64_t *, cholmod_factor *, cholmod_common *) ;
 
@@ -4811,7 +4836,7 @@ int cholmod_l_super_symbolic2 (int, cholmod_sparse *, cholmod_sparse *,
  * cholmod_factorize is a "simple" wrapper for this routine.
  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_super_numeric
 (
     /* ---- input ---- */
@@ -4824,7 +4849,7 @@ int cholmod_super_numeric
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_super_numeric (cholmod_sparse *, cholmod_sparse *, double *,
     cholmod_factor *, cholmod_common *) ;
 
@@ -4836,7 +4861,7 @@ int cholmod_l_super_numeric (cholmod_sparse *, cholmod_sparse *, double *,
  * need not call this routine directly.  cholmod_solve is a "simple" wrapper
  * for this routine. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_super_lsolve
 (
     /* ---- input ---- */
@@ -4849,7 +4874,7 @@ int cholmod_super_lsolve
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_super_lsolve (cholmod_factor *, cholmod_dense *, cholmod_dense *,
     cholmod_common *) ;
 
@@ -4861,7 +4886,7 @@ int cholmod_l_super_lsolve (cholmod_factor *, cholmod_dense *, cholmod_dense *,
  * need not call this routine directly.  cholmod_solve is a "simple" wrapper
  * for this routine. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_super_ltsolve
 (
     /* ---- input ---- */
@@ -4874,7 +4899,7 @@ int cholmod_super_ltsolve
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_super_ltsolve (cholmod_factor *, cholmod_dense *, cholmod_dense *,
     cholmod_common *) ;
 
@@ -4930,7 +4955,7 @@ typedef struct cholmod_gpu_pointers
 
 } cholmod_gpu_pointers ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_gpu_memorysize   /* GPU memory size available, 1 if no GPU */
 (
     size_t         *total_mem,
@@ -4938,7 +4963,7 @@ int cholmod_gpu_memorysize   /* GPU memory size available, 1 if no GPU */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_gpu_memorysize /* GPU memory size available, 1 if no GPU */
 (
     size_t         *total_mem,
@@ -4946,17 +4971,17 @@ int cholmod_l_gpu_memorysize /* GPU memory size available, 1 if no GPU */
     cholmod_common *Common
 ) ;
  
-SUITESPARSE_PUBLIC int cholmod_gpu_probe   ( cholmod_common *Common ) ;
-SUITESPARSE_PUBLIC int cholmod_l_gpu_probe ( cholmod_common *Common ) ;
+CHOLMOD_PUBLIC int cholmod_gpu_probe   ( cholmod_common *Common ) ;
+CHOLMOD_PUBLIC int cholmod_l_gpu_probe ( cholmod_common *Common ) ;
 
-SUITESPARSE_PUBLIC int cholmod_gpu_deallocate   ( cholmod_common *Common ) ;
-SUITESPARSE_PUBLIC int cholmod_l_gpu_deallocate ( cholmod_common *Common ) ;
+CHOLMOD_PUBLIC int cholmod_gpu_deallocate   ( cholmod_common *Common ) ;
+CHOLMOD_PUBLIC int cholmod_l_gpu_deallocate ( cholmod_common *Common ) ;
 
-SUITESPARSE_PUBLIC void cholmod_gpu_end   ( cholmod_common *Common ) ;
-SUITESPARSE_PUBLIC void cholmod_l_gpu_end ( cholmod_common *Common ) ;
+CHOLMOD_PUBLIC void cholmod_gpu_end   ( cholmod_common *Common ) ;
+CHOLMOD_PUBLIC void cholmod_l_gpu_end ( cholmod_common *Common ) ;
 
-SUITESPARSE_PUBLIC int cholmod_gpu_allocate   ( cholmod_common *Common ) ;
-SUITESPARSE_PUBLIC int cholmod_l_gpu_allocate ( cholmod_common *Common ) ;
+CHOLMOD_PUBLIC int cholmod_gpu_allocate   ( cholmod_common *Common ) ;
+CHOLMOD_PUBLIC int cholmod_l_gpu_allocate ( cholmod_common *Common ) ;
 
 #endif
 

--- a/CHOLMOD/Include/cholmod.h
+++ b/CHOLMOD/Include/cholmod.h
@@ -148,10 +148,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( CHOLMOD_LIBRARY )
@@ -167,7 +167,7 @@ extern "C" {
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define CHOLMOD_PUBLIC extern
 
 #endif

--- a/CHOLMOD/Include/cholmod.h
+++ b/CHOLMOD/Include/cholmod.h
@@ -147,6 +147,31 @@ extern "C" {
 
 #include "SuiteSparse_config.h"
 
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( CHOLMOD_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define CHOLMOD_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( CHOLMOD_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define CHOLMOD_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define CHOLMOD_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define CHOLMOD_PUBLIC extern
+
+#endif
+
 /* ========================================================================== */
 /* === Include/cholmod_config.h ============================================= */
 /* ========================================================================== */
@@ -1234,39 +1259,39 @@ typedef struct cholmod_common_struct
 /* cholmod_start:  first call to CHOLMOD */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_start
 (
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_start (cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_finish:  last call to CHOLMOD */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_finish
 (
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_finish (cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_defaults:  restore default parameters */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_defaults
 (
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_defaults (cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
@@ -1287,7 +1312,7 @@ size_t cholmod_l_maxrank (size_t, cholmod_common *) ;
 /* cholmod_allocate_work:  allocate workspace in Common */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_allocate_work
 (
     /* ---- input ---- */
@@ -1298,20 +1323,20 @@ int cholmod_allocate_work
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_allocate_work (size_t, size_t, size_t, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_free_work:  free workspace in Common */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_free_work
 (
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_free_work (cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
@@ -1329,20 +1354,20 @@ int cholmod_l_free_work (cholmod_common *) ;
     } \
 }
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_clear_flag
 (
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_l_clear_flag (cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_error:  called when CHOLMOD encounters an error */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_error
 (
     /* ---- input ---- */
@@ -1354,14 +1379,14 @@ int cholmod_error
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_error (int, const char *, int, const char *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_dbound:  for internal use in CHOLMOD only */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_dbound	/* returns modified diagonal entry of D or L */
 (
     /* ---- input ---- */
@@ -1370,28 +1395,28 @@ double cholmod_dbound	/* returns modified diagonal entry of D or L */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_l_dbound (double, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_hypot:  compute sqrt (x*x + y*y) accurately */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_hypot
 (
     /* ---- input ---- */
     double x, double y
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_l_hypot (double, double) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_divcomplex:  complex division, c = a/b */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_divcomplex		/* return 1 if divide-by-zero, 0 otherise */
 (
     /* ---- input ---- */
@@ -1401,7 +1426,7 @@ int cholmod_divcomplex		/* return 1 if divide-by-zero, 0 otherise */
     double *cr, double *ci	/* real and imaginary parts of c */
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_divcomplex (double, double, double, double, double *, double *) ;
 
 
@@ -1470,11 +1495,11 @@ typedef struct cholmod_descendant_score_t
 descendantScore ;
 
 /* For sorting descendant supernodes with qsort */
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_score_comp (struct cholmod_descendant_score_t *i,
 			struct cholmod_descendant_score_t *j) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_score_comp (struct cholmod_descendant_score_t *i,
 			  struct cholmod_descendant_score_t *j) ;
 
@@ -1482,7 +1507,7 @@ int cholmod_l_score_comp (struct cholmod_descendant_score_t *i,
 /* cholmod_allocate_sparse:  allocate a sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_allocate_sparse
 (
     /* ---- input ---- */
@@ -1497,7 +1522,7 @@ cholmod_sparse *cholmod_allocate_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_allocate_sparse (size_t, size_t, size_t, int, int,
     int, int, cholmod_common *) ;
 
@@ -1505,7 +1530,7 @@ cholmod_sparse *cholmod_l_allocate_sparse (size_t, size_t, size_t, int, int,
 /* cholmod_free_sparse:  free a sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_free_sparse
 (
     /* ---- in/out --- */
@@ -1514,14 +1539,14 @@ int cholmod_free_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_free_sparse (cholmod_sparse **, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_reallocate_sparse:  change the size (# entries) of sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_reallocate_sparse
 (
     /* ---- input ---- */
@@ -1532,14 +1557,14 @@ int cholmod_reallocate_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_reallocate_sparse ( size_t, cholmod_sparse *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_nnz:  return number of nonzeros in a sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_nnz
 (
     /* ---- input ---- */
@@ -1548,14 +1573,14 @@ int64_t cholmod_nnz
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_l_nnz (cholmod_sparse *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_speye:  sparse identity matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_speye
 (
     /* ---- input ---- */
@@ -1566,14 +1591,14 @@ cholmod_sparse *cholmod_speye
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_speye (size_t, size_t, int, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_spzeros:  sparse zero matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_spzeros
 (
     /* ---- input ---- */
@@ -1585,7 +1610,7 @@ cholmod_sparse *cholmod_spzeros
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_spzeros (size_t, size_t, size_t, int,
     cholmod_common *) ;
 
@@ -1598,7 +1623,7 @@ cholmod_sparse *cholmod_l_spzeros (size_t, size_t, size_t, int,
  * (A').
  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_transpose
 (
     /* ---- input ---- */
@@ -1608,7 +1633,7 @@ cholmod_sparse *cholmod_transpose
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_transpose (cholmod_sparse *, int, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
@@ -1618,7 +1643,7 @@ cholmod_sparse *cholmod_l_transpose (cholmod_sparse *, int, cholmod_common *) ;
 /* Compute F = A', A (:,f)', or A (p,f)', where A is unsymmetric and F is
  * already allocated.  See cholmod_transpose for a simpler routine. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_transpose_unsym
 (
     /* ---- input ---- */
@@ -1633,7 +1658,7 @@ int cholmod_transpose_unsym
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_transpose_unsym (cholmod_sparse *, int, int64_t *,
     int64_t *, size_t, cholmod_sparse *, cholmod_common *) ;
 
@@ -1644,7 +1669,7 @@ int cholmod_l_transpose_unsym (cholmod_sparse *, int, int64_t *,
 /* Compute F = A' or A (p,p)', where A is symmetric and F is already allocated.
  * See cholmod_transpose for a simpler routine. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_transpose_sym
 (
     /* ---- input ---- */
@@ -1657,7 +1682,7 @@ int cholmod_transpose_sym
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_transpose_sym (cholmod_sparse *, int, int64_t *,
     cholmod_sparse *, cholmod_common *) ;
 
@@ -1668,7 +1693,7 @@ int cholmod_l_transpose_sym (cholmod_sparse *, int, int64_t *,
 /* Return A' or A(p,p)' if A is symmetric.  Return A', A(:,f)', or A(p,f)' if
  * A is unsymmetric. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_ptranspose
 (
     /* ---- input ---- */
@@ -1681,7 +1706,7 @@ cholmod_sparse *cholmod_ptranspose
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_ptranspose (cholmod_sparse *, int, int64_t *,
     int64_t *, size_t, cholmod_common *) ;
 
@@ -1689,7 +1714,7 @@ cholmod_sparse *cholmod_l_ptranspose (cholmod_sparse *, int, int64_t *,
 /* cholmod_sort:  sort row indices in each column of sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_sort
 (
     /* ---- in/out --- */
@@ -1698,14 +1723,14 @@ int cholmod_sort
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_sort (cholmod_sparse *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_band:  C = tril (triu (A,k1), k2) */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_band
 (
     /* ---- input ---- */
@@ -1717,7 +1742,7 @@ cholmod_sparse *cholmod_band
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_band (cholmod_sparse *, int64_t,
     int64_t, int, cholmod_common *) ;
 
@@ -1725,7 +1750,7 @@ cholmod_sparse *cholmod_l_band (cholmod_sparse *, int64_t,
 /* cholmod_band_inplace:  A = tril (triu (A,k1), k2) */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_band_inplace
 (
     /* ---- input ---- */
@@ -1738,7 +1763,7 @@ int cholmod_band_inplace
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_band_inplace (int64_t, int64_t, int,
     cholmod_sparse *, cholmod_common *) ;
 
@@ -1746,7 +1771,7 @@ int cholmod_l_band_inplace (int64_t, int64_t, int,
 /* cholmod_aat:  C = A*A' or A(:,f)*A(:,f)' */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_aat
 (
     /* ---- input ---- */
@@ -1760,7 +1785,7 @@ cholmod_sparse *cholmod_aat
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_aat (cholmod_sparse *, int64_t *, size_t,
     int, cholmod_common *) ;
 
@@ -1768,7 +1793,7 @@ cholmod_sparse *cholmod_l_aat (cholmod_sparse *, int64_t *, size_t,
 /* cholmod_copy_sparse:  C = A, create an exact copy of a sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_copy_sparse
 (
     /* ---- input ---- */
@@ -1777,14 +1802,14 @@ cholmod_sparse *cholmod_copy_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_copy_sparse (cholmod_sparse *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_copy:  C = A, with possible change of stype */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_copy
 (
     /* ---- input ---- */
@@ -1795,14 +1820,14 @@ cholmod_sparse *cholmod_copy
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_copy (cholmod_sparse *, int, int, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_add: C = alpha*A + beta*B */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_add
 (
     /* ---- input ---- */
@@ -1816,7 +1841,7 @@ cholmod_sparse *cholmod_add
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_add (cholmod_sparse *, cholmod_sparse *, double *,
     double *, int, int, cholmod_common *) ;
 
@@ -1824,7 +1849,7 @@ cholmod_sparse *cholmod_l_add (cholmod_sparse *, cholmod_sparse *, double *,
 /* cholmod_sparse_xtype: change the xtype of a sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_sparse_xtype
 (
     /* ---- input ---- */
@@ -1835,7 +1860,7 @@ int cholmod_sparse_xtype
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_sparse_xtype (int, cholmod_sparse *, cholmod_common *) ;
 
 
@@ -1978,7 +2003,7 @@ typedef struct cholmod_factor_struct
 /* cholmod_allocate_factor: allocate a factor (symbolic LL' or LDL') */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_allocate_factor
 (
     /* ---- input ---- */
@@ -1987,14 +2012,14 @@ cholmod_factor *cholmod_allocate_factor
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_l_allocate_factor (size_t, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_free_factor:  free a factor */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_free_factor
 (
     /* ---- in/out --- */
@@ -2003,14 +2028,14 @@ int cholmod_free_factor
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_free_factor (cholmod_factor **, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_reallocate_factor:  change the # entries in a factor */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_reallocate_factor
 (
     /* ---- input ---- */
@@ -2021,14 +2046,14 @@ int cholmod_reallocate_factor
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_reallocate_factor (size_t, cholmod_factor *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_change_factor:  change the type of factor (e.g., LDL' to LL') */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_change_factor
 (
     /* ---- input ---- */
@@ -2043,7 +2068,7 @@ int cholmod_change_factor
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_change_factor ( int, int, int, int, int, cholmod_factor *,
     cholmod_common *) ;
 
@@ -2055,7 +2080,7 @@ int cholmod_l_change_factor ( int, int, int, int, int, cholmod_factor *,
  * it can pack the columns of a factor even if they are not stored in their
  * natural order (non-monotonic). */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_pack_factor
 (
     /* ---- in/out --- */
@@ -2064,14 +2089,14 @@ int cholmod_pack_factor
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_pack_factor (cholmod_factor *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_reallocate_column:  resize a single column of a factor */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_reallocate_column
 (
     /* ---- input ---- */
@@ -2083,7 +2108,7 @@ int cholmod_reallocate_column
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_reallocate_column (size_t, size_t, cholmod_factor *,
     cholmod_common *) ;
 
@@ -2093,7 +2118,7 @@ int cholmod_l_reallocate_column (size_t, size_t, cholmod_factor *,
 
 /* Only operates on numeric factors, not symbolic ones */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_factor_to_sparse
 (
     /* ---- in/out --- */
@@ -2102,7 +2127,7 @@ cholmod_sparse *cholmod_factor_to_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_factor_to_sparse (cholmod_factor *,
 	cholmod_common *) ;
 
@@ -2110,7 +2135,7 @@ cholmod_sparse *cholmod_l_factor_to_sparse (cholmod_factor *,
 /* cholmod_copy_factor:  create a copy of a factor */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_copy_factor
 (
     /* ---- input ---- */
@@ -2119,14 +2144,14 @@ cholmod_factor *cholmod_copy_factor
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_l_copy_factor (cholmod_factor *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_factor_xtype: change the xtype of a factor */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_factor_xtype
 (
     /* ---- input ---- */
@@ -2137,7 +2162,7 @@ int cholmod_factor_xtype
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_factor_xtype (int, cholmod_factor *, cholmod_common *) ;
 
 
@@ -2166,7 +2191,7 @@ typedef struct cholmod_dense_struct
 /* cholmod_allocate_dense:  allocate a dense matrix (contents uninitialized) */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_allocate_dense
 (
     /* ---- input ---- */
@@ -2178,7 +2203,7 @@ cholmod_dense *cholmod_allocate_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_allocate_dense (size_t, size_t, size_t, int,
     cholmod_common *) ;
 
@@ -2186,7 +2211,7 @@ cholmod_dense *cholmod_l_allocate_dense (size_t, size_t, size_t, int,
 /* cholmod_zeros: allocate a dense matrix and set it to zero */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_zeros
 (
     /* ---- input ---- */
@@ -2197,14 +2222,14 @@ cholmod_dense *cholmod_zeros
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_zeros (size_t, size_t, int, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_ones: allocate a dense matrix and set it to all ones */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_ones
 (
     /* ---- input ---- */
@@ -2215,14 +2240,14 @@ cholmod_dense *cholmod_ones
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_ones (size_t, size_t, int, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_eye: allocate a dense matrix and set it to the identity matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_eye
 (
     /* ---- input ---- */
@@ -2233,14 +2258,14 @@ cholmod_dense *cholmod_eye
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_eye (size_t, size_t, int, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_free_dense:  free a dense matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_free_dense
 (
     /* ---- in/out --- */
@@ -2249,14 +2274,14 @@ int cholmod_free_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_free_dense (cholmod_dense **, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_ensure_dense:  ensure a dense matrix has a given size and type */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_ensure_dense
 (
     /* ---- input/output ---- */
@@ -2270,7 +2295,7 @@ cholmod_dense *cholmod_ensure_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_ensure_dense (cholmod_dense **, size_t, size_t, size_t,
     int, cholmod_common *) ;
 
@@ -2278,7 +2303,7 @@ cholmod_dense *cholmod_l_ensure_dense (cholmod_dense **, size_t, size_t, size_t,
 /* cholmod_sparse_to_dense:  create a dense matrix copy of a sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_sparse_to_dense
 (
     /* ---- input ---- */
@@ -2287,7 +2312,7 @@ cholmod_dense *cholmod_sparse_to_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_sparse_to_dense (cholmod_sparse *,
     cholmod_common *) ;
 
@@ -2295,7 +2320,7 @@ cholmod_dense *cholmod_l_sparse_to_dense (cholmod_sparse *,
 /* cholmod_dense_to_sparse:  create a sparse matrix copy of a dense matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_dense_to_sparse
 (
     /* ---- input ---- */
@@ -2305,7 +2330,7 @@ cholmod_sparse *cholmod_dense_to_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_dense_to_sparse (cholmod_dense *, int,
     cholmod_common *) ;
 
@@ -2313,7 +2338,7 @@ cholmod_sparse *cholmod_l_dense_to_sparse (cholmod_dense *, int,
 /* cholmod_copy_dense:  create a copy of a dense matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_copy_dense
 (
     /* ---- input ---- */
@@ -2322,14 +2347,14 @@ cholmod_dense *cholmod_copy_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_copy_dense (cholmod_dense *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_copy_dense2:  copy a dense matrix (pre-allocated) */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_copy_dense2
 (
     /* ---- input ---- */
@@ -2340,14 +2365,14 @@ int cholmod_copy_dense2
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_copy_dense2 (cholmod_dense *, cholmod_dense *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_dense_xtype: change the xtype of a dense matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_dense_xtype
 (
     /* ---- input ---- */
@@ -2358,7 +2383,7 @@ int cholmod_dense_xtype
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_dense_xtype (int, cholmod_dense *, cholmod_common *) ;
 
 
@@ -2435,7 +2460,7 @@ typedef struct cholmod_triplet_struct
 /* cholmod_allocate_triplet:  allocate a triplet matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_triplet *cholmod_allocate_triplet
 (
     /* ---- input ---- */
@@ -2448,7 +2473,7 @@ cholmod_triplet *cholmod_allocate_triplet
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_triplet *cholmod_l_allocate_triplet (size_t, size_t, size_t, int, int,
     cholmod_common *) ;
 
@@ -2456,7 +2481,7 @@ cholmod_triplet *cholmod_l_allocate_triplet (size_t, size_t, size_t, int, int,
 /* cholmod_free_triplet:  free a triplet matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_free_triplet
 (
     /* ---- in/out --- */
@@ -2465,14 +2490,14 @@ int cholmod_free_triplet
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_free_triplet (cholmod_triplet **, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_reallocate_triplet:  change the # of entries in a triplet matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_reallocate_triplet
 (
     /* ---- input ---- */
@@ -2483,14 +2508,14 @@ int cholmod_reallocate_triplet
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_reallocate_triplet (size_t, cholmod_triplet *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_sparse_to_triplet:  create a triplet matrix copy of a sparse matrix*/
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_triplet *cholmod_sparse_to_triplet
 (
     /* ---- input ---- */
@@ -2499,7 +2524,7 @@ cholmod_triplet *cholmod_sparse_to_triplet
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_triplet *cholmod_l_sparse_to_triplet (cholmod_sparse *,
     cholmod_common *) ;
 
@@ -2507,7 +2532,7 @@ cholmod_triplet *cholmod_l_sparse_to_triplet (cholmod_sparse *,
 /* cholmod_triplet_to_sparse:  create a sparse matrix copy of a triplet matrix*/
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_triplet_to_sparse
 (
     /* ---- input ---- */
@@ -2517,7 +2542,7 @@ cholmod_sparse *cholmod_triplet_to_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_triplet_to_sparse (cholmod_triplet *, size_t,
     cholmod_common *) ;
 
@@ -2525,7 +2550,7 @@ cholmod_sparse *cholmod_l_triplet_to_sparse (cholmod_triplet *, size_t,
 /* cholmod_copy_triplet:  create a copy of a triplet matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_triplet *cholmod_copy_triplet
 (
     /* ---- input ---- */
@@ -2534,14 +2559,14 @@ cholmod_triplet *cholmod_copy_triplet
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_triplet *cholmod_l_copy_triplet (cholmod_triplet *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_triplet_xtype: change the xtype of a triplet matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_triplet_xtype
 (
     /* ---- input ---- */
@@ -2552,7 +2577,7 @@ int cholmod_triplet_xtype
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_triplet_xtype (int, cholmod_triplet *, cholmod_common *) ;
 
 
@@ -2576,7 +2601,7 @@ int cholmod_l_triplet_xtype (int, cholmod_triplet *, cholmod_common *) ;
  * corrupted.
  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_malloc	/* returns pointer to the newly malloc'd block */
 (
     /* ---- input ---- */
@@ -2586,10 +2611,10 @@ void *cholmod_malloc	/* returns pointer to the newly malloc'd block */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_l_malloc (size_t, size_t, cholmod_common *) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_calloc	/* returns pointer to the newly calloc'd block */
 (
     /* ---- input ---- */
@@ -2599,10 +2624,10 @@ void *cholmod_calloc	/* returns pointer to the newly calloc'd block */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_l_calloc (size_t, size_t, cholmod_common *) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_free	/* always returns NULL */
 (
     /* ---- input ---- */
@@ -2614,10 +2639,10 @@ void *cholmod_free	/* always returns NULL */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_l_free (size_t, size_t, void *, cholmod_common *) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_realloc	/* returns pointer to reallocated block */
 (
     /* ---- input ---- */
@@ -2630,10 +2655,10 @@ void *cholmod_realloc	/* returns pointer to reallocated block */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_l_realloc (size_t, size_t, void *, size_t *, cholmod_common *) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_realloc_multiple
 (
     /* ---- input ---- */
@@ -2651,7 +2676,7 @@ int cholmod_realloc_multiple
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_realloc_multiple (size_t, int, int, void **, void **, void **,
     void **, size_t *, cholmod_common *) ;
 
@@ -2659,7 +2684,7 @@ int cholmod_l_realloc_multiple (size_t, int, int, void **, void **, void **,
 /* === version control ====================================================== */
 /* ========================================================================== */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_version     /* returns CHOLMOD_VERSION */
 (
     /* output, contents not defined on input.  Not used if NULL.
@@ -2670,7 +2695,7 @@ int cholmod_version     /* returns CHOLMOD_VERSION */
     int version [3]
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_version (int version [3]) ;
 
 /* Versions prior to 2.1.1 do not have the above function.  The following
@@ -2821,20 +2846,20 @@ int cholmod_l_version (int version [3]) ;
 /* cholmod_check_common:  check the Common object */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_check_common
 (
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_check_common (cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_print_common:  print the Common object */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_print_common
 (
     /* ---- input ---- */
@@ -2843,23 +2868,23 @@ int cholmod_print_common
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_print_common (const char *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_gpu_stats:  print the GPU / CPU statistics */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_gpu_stats   (cholmod_common *) ;
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_gpu_stats (cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_check_sparse:  check a sparse matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_check_sparse
 (
     /* ---- input ---- */
@@ -2868,14 +2893,14 @@ int cholmod_check_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_check_sparse (cholmod_sparse *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_print_sparse */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_print_sparse
 (
     /* ---- input ---- */
@@ -2885,14 +2910,14 @@ int cholmod_print_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_print_sparse (cholmod_sparse *, const char *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_check_dense:  check a dense matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_check_dense
 (
     /* ---- input ---- */
@@ -2901,14 +2926,14 @@ int cholmod_check_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_check_dense (cholmod_dense *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_print_dense:  print a dense matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_print_dense
 (
     /* ---- input ---- */
@@ -2918,14 +2943,14 @@ int cholmod_print_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_print_dense (cholmod_dense *, const char *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_check_factor:  check a factor */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_check_factor
 (
     /* ---- input ---- */
@@ -2934,14 +2959,14 @@ int cholmod_check_factor
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_check_factor (cholmod_factor *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_print_factor:  print a factor */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_print_factor
 (
     /* ---- input ---- */
@@ -2951,14 +2976,14 @@ int cholmod_print_factor
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_print_factor (cholmod_factor *, const char *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_check_triplet:  check a sparse matrix in triplet form */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_check_triplet
 (
     /* ---- input ---- */
@@ -2967,14 +2992,14 @@ int cholmod_check_triplet
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_check_triplet (cholmod_triplet *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_print_triplet:  print a triplet matrix */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_print_triplet
 (
     /* ---- input ---- */
@@ -2984,14 +3009,14 @@ int cholmod_print_triplet
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_print_triplet (cholmod_triplet *, const char *, cholmod_common *);
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_check_subset:  check a subset */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_check_subset
 (
     /* ---- input ---- */
@@ -3002,7 +3027,7 @@ int cholmod_check_subset
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_check_subset (int64_t *, int64_t, size_t,
     cholmod_common *) ;
 
@@ -3010,7 +3035,7 @@ int cholmod_l_check_subset (int64_t *, int64_t, size_t,
 /* cholmod_print_subset:  print a subset */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_print_subset
 (
     /* ---- input ---- */
@@ -3022,7 +3047,7 @@ int cholmod_print_subset
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_print_subset (int64_t *, int64_t, size_t,
     const char *, cholmod_common *) ;
 
@@ -3030,7 +3055,7 @@ int cholmod_l_print_subset (int64_t *, int64_t, size_t,
 /* cholmod_check_perm:  check a permutation */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_check_perm
 (
     /* ---- input ---- */
@@ -3041,14 +3066,14 @@ int cholmod_check_perm
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_check_perm (int64_t *, size_t, size_t, cholmod_common *);
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_print_perm:  print a permutation vector */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_print_perm
 (
     /* ---- input ---- */
@@ -3060,7 +3085,7 @@ int cholmod_print_perm
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_print_perm (int64_t *, size_t, size_t, const char *,
     cholmod_common *) ;
 
@@ -3068,7 +3093,7 @@ int cholmod_l_print_perm (int64_t *, size_t, size_t, const char *,
 /* cholmod_check_parent:  check an elimination tree */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_check_parent
 (
     /* ---- input ---- */
@@ -3078,14 +3103,14 @@ int cholmod_check_parent
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_check_parent (int64_t *, size_t, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_print_parent */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_print_parent
 (
     /* ---- input ---- */
@@ -3096,7 +3121,7 @@ int cholmod_print_parent
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_print_parent (int64_t *, size_t, const char *,
     cholmod_common *) ;
 
@@ -3104,7 +3129,7 @@ int cholmod_l_print_parent (int64_t *, size_t, const char *,
 /* cholmod_read_sparse: read a sparse matrix from a file */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_read_sparse
 (
     /* ---- input ---- */
@@ -3113,14 +3138,14 @@ cholmod_sparse *cholmod_read_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_read_sparse (FILE *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_read_triplet: read a triplet matrix from a file */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_triplet *cholmod_read_triplet
 (
     /* ---- input ---- */
@@ -3129,14 +3154,14 @@ cholmod_triplet *cholmod_read_triplet
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_triplet *cholmod_l_read_triplet (FILE *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_read_dense: read a dense matrix from a file */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_read_dense
 (
     /* ---- input ---- */
@@ -3145,14 +3170,14 @@ cholmod_dense *cholmod_read_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_read_dense (FILE *, cholmod_common *) ; 
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_read_matrix: read a sparse or dense matrix from a file */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_read_matrix
 (
     /* ---- input ---- */
@@ -3177,14 +3202,14 @@ void *cholmod_read_matrix
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 void *cholmod_l_read_matrix (FILE *, int, int *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_write_sparse: write a sparse matrix to a file */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_write_sparse
 (
     /* ---- input ---- */
@@ -3196,7 +3221,7 @@ int cholmod_write_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_write_sparse (FILE *, cholmod_sparse *, cholmod_sparse *,
     const char *c, cholmod_common *) ;
 
@@ -3204,7 +3229,7 @@ int cholmod_l_write_sparse (FILE *, cholmod_sparse *, cholmod_sparse *,
 /* cholmod_write_dense: write a dense matrix to a file */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_write_dense
 (
     /* ---- input ---- */
@@ -3215,7 +3240,7 @@ int cholmod_write_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_write_dense (FILE *, cholmod_dense *, const char *,
     cholmod_common *) ;
 #endif
@@ -3281,7 +3306,7 @@ int cholmod_l_write_dense (FILE *, cholmod_dense *, const char *,
 /* Orders and analyzes A, AA', PAP', or PAA'P' and returns a symbolic factor
  * that can later be passed to cholmod_factorize. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_analyze 
 (
     /* ---- input ---- */
@@ -3290,7 +3315,7 @@ cholmod_factor *cholmod_analyze
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_l_analyze (cholmod_sparse *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
@@ -3302,7 +3327,7 @@ cholmod_factor *cholmod_l_analyze (cholmod_sparse *, cholmod_common *) ;
  * F = A(:,fset) if fset is not NULL and A->stype is zero.
  * UserPerm is tried if non-NULL.  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_analyze_p
 (
     /* ---- input ---- */
@@ -3314,7 +3339,7 @@ cholmod_factor *cholmod_analyze_p
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_l_analyze_p (cholmod_sparse *, int64_t *,
     int64_t *, size_t, cholmod_common *) ;
 
@@ -3322,7 +3347,7 @@ cholmod_factor *cholmod_l_analyze_p (cholmod_sparse *, int64_t *,
 /* cholmod_analyze_p2:  analyze for sparse Cholesky or sparse QR */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_analyze_p2
 (
     /* ---- input ---- */
@@ -3337,7 +3362,7 @@ cholmod_factor *cholmod_analyze_p2
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_factor *cholmod_l_analyze_p2 (int, cholmod_sparse *, int64_t *,
     int64_t *, size_t, cholmod_common *) ;
 
@@ -3350,7 +3375,7 @@ cholmod_factor *cholmod_l_analyze_p2 (int, cholmod_sparse *, int64_t *,
  * routine a second time with another matrix.  A must have the same nonzero
  * pattern as that passed to cholmod_analyze. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_factorize 
 (
     /* ---- input ---- */
@@ -3361,7 +3386,7 @@ int cholmod_factorize
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_factorize (cholmod_sparse *, cholmod_factor *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
@@ -3370,7 +3395,7 @@ int cholmod_l_factorize (cholmod_sparse *, cholmod_factor *, cholmod_common *) ;
 
 /* Same as cholmod_factorize, but with more options. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_factorize_p
 (
     /* ---- input ---- */
@@ -3384,7 +3409,7 @@ int cholmod_factorize_p
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_factorize_p (cholmod_sparse *, double *, int64_t *,
     size_t, cholmod_factor *, cholmod_common *) ;
 
@@ -3406,7 +3431,7 @@ int cholmod_l_factorize_p (cholmod_sparse *, double *, int64_t *,
 #define CHOLMOD_P    7		/* permute x=Px */
 #define CHOLMOD_Pt   8		/* permute x=P'x */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_solve	/* returns the solution X */
 (
     /* ---- input ---- */
@@ -3417,7 +3442,7 @@ cholmod_dense *cholmod_solve	/* returns the solution X */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_dense *cholmod_l_solve (int, cholmod_factor *, cholmod_dense *,
     cholmod_common *) ;
 
@@ -3425,7 +3450,7 @@ cholmod_dense *cholmod_l_solve (int, cholmod_factor *, cholmod_dense *,
 /* cholmod_solve2:  like cholmod_solve, but with reusable workspace */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_solve2     /* returns TRUE on success, FALSE on failure */
 (
     /* ---- input ---- */
@@ -3443,7 +3468,7 @@ int cholmod_solve2     /* returns TRUE on success, FALSE on failure */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_solve2 (int, cholmod_factor *, cholmod_dense *, cholmod_sparse *,
     cholmod_dense **, cholmod_sparse **, cholmod_dense **, cholmod_dense **,
     cholmod_common *) ;
@@ -3452,7 +3477,7 @@ int cholmod_l_solve2 (int, cholmod_factor *, cholmod_dense *, cholmod_sparse *,
 /* cholmod_spsolve:  solve a linear system with a sparse right-hand-side */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_spsolve
 (
     /* ---- input ---- */
@@ -3463,7 +3488,7 @@ cholmod_sparse *cholmod_spsolve
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_spsolve (int, cholmod_factor *, cholmod_sparse *,
     cholmod_common *) ;
 
@@ -3471,7 +3496,7 @@ cholmod_sparse *cholmod_l_spsolve (int, cholmod_factor *, cholmod_sparse *,
 /* cholmod_etree: find the elimination tree of A or A'*A */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_etree
 (
     /* ---- input ---- */
@@ -3482,14 +3507,14 @@ int cholmod_etree
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_etree (cholmod_sparse *, int64_t *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_rowcolcounts: compute the row/column counts of L */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowcolcounts
 (
     /* ---- input ---- */
@@ -3512,7 +3537,7 @@ int cholmod_rowcolcounts
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowcolcounts (cholmod_sparse *, int64_t *, size_t,
     int64_t *, int64_t *, int64_t *,
     int64_t *, int64_t *, int64_t *,
@@ -3522,7 +3547,7 @@ int cholmod_l_rowcolcounts (cholmod_sparse *, int64_t *, size_t,
 /* cholmod_analyze_ordering:  analyze a fill-reducing ordering */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_analyze_ordering
 (
     /* ---- input ---- */
@@ -3542,7 +3567,7 @@ int cholmod_analyze_ordering
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_analyze_ordering (cholmod_sparse *, int, int64_t *,
     int64_t *, size_t, int64_t *, int64_t *, int64_t *, int64_t *, int64_t *,
     cholmod_common *) ;
@@ -3554,7 +3579,7 @@ int cholmod_l_analyze_ordering (cholmod_sparse *, int, int64_t *,
 /* Finds a permutation P to reduce fill-in in the factorization of P*A*P'
  * or P*A*A'P' */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_amd
 (
     /* ---- input ---- */
@@ -3567,7 +3592,7 @@ int cholmod_amd
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_amd (cholmod_sparse *, int64_t *, size_t,
     int64_t *, cholmod_common *) ;
 
@@ -3578,7 +3603,7 @@ int cholmod_l_amd (cholmod_sparse *, int64_t *, size_t,
 /* Finds a permutation P to reduce fill-in in the factorization of P*A*A'*P'.
  * Orders F*F' where F = A (:,fset) if fset is not NULL */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_colamd
 (
     /* ---- input ---- */
@@ -3592,7 +3617,7 @@ int cholmod_colamd
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_colamd (cholmod_sparse *, int64_t *, size_t, int,
     int64_t *, cholmod_common *) ;
 
@@ -3605,7 +3630,7 @@ int cholmod_l_colamd (cholmod_sparse *, int64_t *, size_t, int,
  * identity matrix.   Row k can only be factorized if all descendants of node
  * k in the elimination tree have been factorized. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowfac
 (
     /* ---- input ---- */
@@ -3620,7 +3645,7 @@ int cholmod_rowfac
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowfac (cholmod_sparse *, cholmod_sparse *, double *, size_t,
     size_t, cholmod_factor *, cholmod_common *) ;
 
@@ -3631,7 +3656,7 @@ int cholmod_l_rowfac (cholmod_sparse *, cholmod_sparse *, double *, size_t,
 /* cholmod_rowfac_mask is a version of cholmod_rowfac that is specific to
  * LPDASA.  It is unlikely to be needed by any other application. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowfac_mask
 (
     /* ---- input ---- */
@@ -3648,12 +3673,12 @@ int cholmod_rowfac_mask
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowfac_mask (cholmod_sparse *, cholmod_sparse *, double *, size_t,
     size_t, int64_t *, int64_t *, cholmod_factor *,
     cholmod_common *) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowfac_mask2
 (
     /* ---- input ---- */
@@ -3671,7 +3696,7 @@ int cholmod_rowfac_mask2
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowfac_mask2 (cholmod_sparse *, cholmod_sparse *, double *,
     size_t, size_t, int64_t *, int64_t, int64_t *,
     cholmod_factor *, cholmod_common *) ;
@@ -3683,7 +3708,7 @@ int cholmod_l_rowfac_mask2 (cholmod_sparse *, cholmod_sparse *, double *,
 /* Find the nonzero pattern of x for the system Lx=b where L = (0:k-1,0:k-1)
  * and b = kth column of A or A*A' (rows 0 to k-1 only) */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_row_subtree
 (
     /* ---- input ---- */
@@ -3697,7 +3722,7 @@ int cholmod_row_subtree
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_row_subtree (cholmod_sparse *, cholmod_sparse *, size_t,
     int64_t *, cholmod_sparse *, cholmod_common *) ;
 
@@ -3705,7 +3730,7 @@ int cholmod_l_row_subtree (cholmod_sparse *, cholmod_sparse *, size_t,
 /* cholmod_lsolve_pattern: find the nonzero pattern of x=L\b */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_lsolve_pattern
 (
     /* ---- input ---- */
@@ -3717,7 +3742,7 @@ int cholmod_lsolve_pattern
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_lsolve_pattern (cholmod_sparse *, cholmod_factor *,
     cholmod_sparse *, cholmod_common *) ;
 
@@ -3728,7 +3753,7 @@ int cholmod_l_lsolve_pattern (cholmod_sparse *, cholmod_factor *,
 /* Identical to cholmod_row_subtree, except that it finds the elimination tree
  * from L itself. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_row_lsubtree
 (
     /* ---- input ---- */
@@ -3743,7 +3768,7 @@ int cholmod_row_lsubtree
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_row_lsubtree (cholmod_sparse *, int64_t *, size_t,
     size_t, cholmod_factor *, cholmod_sparse *, cholmod_common *) ;
 
@@ -3758,7 +3783,7 @@ int cholmod_l_row_lsubtree (cholmod_sparse *, int64_t *, size_t,
  * first permutes A according to L->Perm.  A can be upper/lower/unsymmetric,
  * in contrast to cholmod_resymbol_noperm (which can be lower or unsym). */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_resymbol 
 (
     /* ---- input ---- */
@@ -3772,7 +3797,7 @@ int cholmod_resymbol
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_resymbol (cholmod_sparse *, int64_t *, size_t, int,
     cholmod_factor *, cholmod_common *) ;
 
@@ -3783,7 +3808,7 @@ int cholmod_l_resymbol (cholmod_sparse *, int64_t *, size_t, int,
 /* Remove entries from L that are not in the factorization of A, A*A',
  * or F*F' (depending on A->stype and whether fset is NULL or not). */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_resymbol_noperm
 (
     /* ---- input ---- */
@@ -3797,7 +3822,7 @@ int cholmod_resymbol_noperm
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_resymbol_noperm (cholmod_sparse *, int64_t *, size_t, int,
     cholmod_factor *, cholmod_common *) ;
 
@@ -3805,7 +3830,7 @@ int cholmod_l_resymbol_noperm (cholmod_sparse *, int64_t *, size_t, int,
 /* cholmod_rcond:  compute rough estimate of reciprocal of condition number */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_rcond	    /* return min(diag(L)) / max(diag(L)) */
 (
     /* ---- input ---- */
@@ -3814,14 +3839,14 @@ double cholmod_rcond	    /* return min(diag(L)) / max(diag(L)) */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_l_rcond (cholmod_factor *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_postorder: Compute the postorder of a tree */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int32_t cholmod_postorder	/* return # of nodes postordered */
 (
     /* ---- input ---- */
@@ -3834,7 +3859,7 @@ int32_t cholmod_postorder	/* return # of nodes postordered */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_l_postorder (int64_t *, size_t,
     int64_t *, int64_t *, cholmod_common *) ;
 
@@ -3872,7 +3897,7 @@ int64_t cholmod_l_postorder (int64_t *, size_t,
 /* cholmod_drop:  drop entries with small absolute value */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_drop
 (
     /* ---- input ---- */
@@ -3883,14 +3908,14 @@ int cholmod_drop
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_drop (double, cholmod_sparse *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_norm_dense:  s = norm (X), 1-norm, inf-norm, or 2-norm */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_norm_dense
 (
     /* ---- input ---- */
@@ -3900,14 +3925,14 @@ double cholmod_norm_dense
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_l_norm_dense (cholmod_dense *, int, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_norm_sparse:  s = norm (A), 1-norm or inf-norm */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_norm_sparse
 (
     /* ---- input ---- */
@@ -3917,14 +3942,14 @@ double cholmod_norm_sparse
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 double cholmod_l_norm_sparse (cholmod_sparse *, int, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
 /* cholmod_horzcat:  C = [A,B] */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_horzcat
 (
     /* ---- input ---- */
@@ -3935,7 +3960,7 @@ cholmod_sparse *cholmod_horzcat
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_horzcat (cholmod_sparse *, cholmod_sparse *, int,
     cholmod_common *) ;
 
@@ -3949,7 +3974,7 @@ cholmod_sparse *cholmod_l_horzcat (cholmod_sparse *, cholmod_sparse *, int,
 #define CHOLMOD_COL 2		/* A = A*diag(s) */
 #define CHOLMOD_SYM 3		/* A = diag(s)*A*diag(s) */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_scale
 (
     /* ---- input ---- */
@@ -3961,7 +3986,7 @@ int cholmod_scale
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_scale (cholmod_dense *, int, cholmod_sparse *, cholmod_common *) ;
 
 /* -------------------------------------------------------------------------- */
@@ -3970,7 +3995,7 @@ int cholmod_l_scale (cholmod_dense *, int, cholmod_sparse *, cholmod_common *) ;
 
 /* Sparse matrix times dense matrix */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_sdmult
 (
     /* ---- input ---- */
@@ -3985,7 +4010,7 @@ int cholmod_sdmult
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_sdmult (cholmod_sparse *, int, double *, double *,
     cholmod_dense *, cholmod_dense *Y, cholmod_common *) ;
 
@@ -3995,7 +4020,7 @@ int cholmod_l_sdmult (cholmod_sparse *, int, double *, double *,
 
 /* Sparse matrix times sparse matrix */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_ssmult
 (
     /* ---- input ---- */
@@ -4008,7 +4033,7 @@ cholmod_sparse *cholmod_ssmult
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_ssmult (cholmod_sparse *, cholmod_sparse *, int, int,
     int, cholmod_common *) ;
 
@@ -4022,7 +4047,7 @@ cholmod_sparse *cholmod_l_ssmult (cholmod_sparse *, cholmod_sparse *, int, int,
  * Similar rules hold for csize.
  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_submatrix
 (
     /* ---- input ---- */
@@ -4037,7 +4062,7 @@ cholmod_sparse *cholmod_submatrix
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_submatrix (cholmod_sparse *, int64_t *,
     int64_t, int64_t *, int64_t, int, int,
     cholmod_common *) ;
@@ -4046,7 +4071,7 @@ cholmod_sparse *cholmod_l_submatrix (cholmod_sparse *, int64_t *,
 /* cholmod_vertcat:  C = [A ; B] */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_vertcat
 (
     /* ---- input ---- */
@@ -4057,7 +4082,7 @@ cholmod_sparse *cholmod_vertcat
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 cholmod_sparse *cholmod_l_vertcat (cholmod_sparse *, cholmod_sparse *, int,
     cholmod_common *) ;
 
@@ -4065,7 +4090,7 @@ cholmod_sparse *cholmod_l_vertcat (cholmod_sparse *, cholmod_sparse *, int,
 /* cholmod_symmetry: determine if a sparse matrix is symmetric */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_symmetry
 (
     /* ---- input ---- */
@@ -4080,7 +4105,7 @@ int cholmod_symmetry
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_symmetry (cholmod_sparse *, int, int64_t *,
     int64_t *, int64_t *, int64_t *,
     cholmod_common *) ;
@@ -4142,7 +4167,7 @@ int cholmod_l_symmetry (cholmod_sparse *, int, int64_t *,
  * (a downdate).  The factor object L need not be an LDL' factorization; it
  * is converted to one if it isn't. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_updown 
 (
     /* ---- input ---- */
@@ -4154,7 +4179,7 @@ int cholmod_updown
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_updown (int, cholmod_sparse *, cholmod_factor *,
     cholmod_common *) ;
 
@@ -4168,7 +4193,7 @@ int cholmod_l_updown (int, cholmod_sparse *, cholmod_factor *,
  * entries in DeltaB corresponding to columns modified in L are accessed; the
  * rest must be zero. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_updown_solve
 (
     /* ---- input ---- */
@@ -4182,7 +4207,7 @@ int cholmod_updown_solve
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_updown_solve (int, cholmod_sparse *, cholmod_factor *,
     cholmod_dense *, cholmod_dense *, cholmod_common *) ;
 
@@ -4195,7 +4220,7 @@ int cholmod_l_updown_solve (int, cholmod_sparse *, cholmod_factor *,
  * routine.  It is meant for use in LPDASA only.  See cholmod_updown.c for
  * a description of colmark. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_updown_mark
 (
     /* ---- input ---- */
@@ -4210,7 +4235,7 @@ int cholmod_updown_mark
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_updown_mark (int, cholmod_sparse *, int64_t *,
     cholmod_factor *, cholmod_dense *, cholmod_dense *, cholmod_common *) ;
 
@@ -4222,7 +4247,7 @@ int cholmod_l_updown_mark (int, cholmod_sparse *, int64_t *,
  * argument.  This routine is an "expert" routine.  It is meant for use in
  * LPDASA only.  See cholmod_updown.c for a description of mask. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_updown_mask
 (
     /* ---- input ---- */
@@ -4238,12 +4263,12 @@ int cholmod_updown_mask
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_updown_mask (int, cholmod_sparse *, int64_t *,
     int64_t *, cholmod_factor *, cholmod_dense *, cholmod_dense *,
     cholmod_common *) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_updown_mask2
 (
     /* ---- input ---- */
@@ -4260,7 +4285,7 @@ int cholmod_updown_mask2
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_updown_mask2 (int, cholmod_sparse *, int64_t *,
     int64_t *, int64_t, cholmod_factor *, cholmod_dense *,
     cholmod_dense *, cholmod_common *) ;
@@ -4276,7 +4301,7 @@ int cholmod_l_updown_mask2 (int, cholmod_sparse *, int64_t *,
  * computed as the factorization of the kth row/column of the matrix to
  * factorize, which is provided as a single n-by-1 sparse matrix R. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowadd 
 (
     /* ---- input ---- */
@@ -4288,7 +4313,7 @@ int cholmod_rowadd
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowadd (size_t, cholmod_sparse *, cholmod_factor *,
     cholmod_common *) ;
 
@@ -4300,7 +4325,7 @@ int cholmod_l_rowadd (size_t, cholmod_sparse *, cholmod_factor *,
  * See cholmod_updown for a description of how Lx=b is updated.  There is on
  * additional parameter:  bk specifies the new kth entry of b. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowadd_solve
 (
     /* ---- input ---- */
@@ -4315,7 +4340,7 @@ int cholmod_rowadd_solve
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowadd_solve (size_t, cholmod_sparse *, double *,
     cholmod_factor *, cholmod_dense *, cholmod_dense *, cholmod_common *) ;
 
@@ -4327,7 +4352,7 @@ int cholmod_l_rowadd_solve (size_t, cholmod_sparse *, double *,
  * the update/downdate of the solution to Lx=b.  This routine is an "expert"
  * routine.  It is meant for use in LPDASA only.  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowadd_mark
 (
     /* ---- input ---- */
@@ -4343,7 +4368,7 @@ int cholmod_rowadd_mark
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowadd_mark (size_t, cholmod_sparse *, double *,
     int64_t *, cholmod_factor *, cholmod_dense *, cholmod_dense *,
     cholmod_common *) ;
@@ -4360,7 +4385,7 @@ int cholmod_l_rowadd_mark (size_t, cholmod_sparse *, double *,
  * a little more time.
  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowdel 
 (
     /* ---- input ---- */
@@ -4372,7 +4397,7 @@ int cholmod_rowdel
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowdel (size_t, cholmod_sparse *, cholmod_factor *,
     cholmod_common *) ;
 
@@ -4385,7 +4410,7 @@ int cholmod_l_rowdel (size_t, cholmod_sparse *, cholmod_factor *,
  * a change to x, in addition to changes arising when L and b are modified.
  * If this is the case, the kth entry of y is required as input (yk) */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowdel_solve
 (
     /* ---- input ---- */
@@ -4400,7 +4425,7 @@ int cholmod_rowdel_solve
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowdel_solve (size_t, cholmod_sparse *, double *,
     cholmod_factor *, cholmod_dense *, cholmod_dense *, cholmod_common *) ;
 
@@ -4412,7 +4437,7 @@ int cholmod_l_rowdel_solve (size_t, cholmod_sparse *, double *,
  * the update/downdate of the solution to Lx=b.  This routine is an "expert"
  * routine.  It is meant for use in LPDASA only.  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_rowdel_mark
 (
     /* ---- input ---- */
@@ -4428,7 +4453,7 @@ int cholmod_rowdel_mark
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_rowdel_mark (size_t, cholmod_sparse *, double *,
     int64_t *, cholmod_factor *, cholmod_dense *, cholmod_dense *,
     cholmod_common *) ;
@@ -4465,7 +4490,7 @@ int cholmod_l_rowdel_mark (size_t, cholmod_sparse *, double *,
 
 /* Order AA' or A(:,f)*A(:,f)' using CCOLAMD. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_ccolamd
 (
     /* ---- input ---- */
@@ -4483,7 +4508,7 @@ int cholmod_ccolamd
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_ccolamd (cholmod_sparse *, int64_t *, size_t,
     int64_t *, int64_t *, cholmod_common *) ;
 
@@ -4493,7 +4518,7 @@ int cholmod_l_ccolamd (cholmod_sparse *, int64_t *, size_t,
 
 /* Order A using CSYMAMD. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_csymamd
 (
     /* ---- input ---- */
@@ -4505,7 +4530,7 @@ int cholmod_csymamd
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_csymamd (cholmod_sparse *, int64_t *,
     int64_t *, cholmod_common *) ;
 
@@ -4515,7 +4540,7 @@ int cholmod_l_csymamd (cholmod_sparse *, int64_t *,
 
 /* Order A using CAMD. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_camd
 (
     /* ---- input ---- */
@@ -4529,7 +4554,7 @@ int cholmod_camd
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_camd (cholmod_sparse *, int64_t *, size_t,
     int64_t *, int64_t *, cholmod_common *) ;
 
@@ -4581,7 +4606,7 @@ int cholmod_l_camd (cholmod_sparse *, int64_t *, size_t,
  * finds better orderings than METIS_NodeND, but takes longer.
  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_nested_dissection	/* returns # of components */
 (
     /* ---- input ---- */
@@ -4599,7 +4624,7 @@ int64_t cholmod_nested_dissection	/* returns # of components */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_l_nested_dissection (cholmod_sparse *,
     int64_t *, size_t, int64_t *, int64_t *,
     int64_t *, cholmod_common *) ;
@@ -4610,7 +4635,7 @@ int64_t cholmod_l_nested_dissection (cholmod_sparse *,
 
 /* Order A, AA', or A(:,f)*A(:,f)' using METIS_NodeND. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_metis
 (
     /* ---- input ---- */
@@ -4624,7 +4649,7 @@ int cholmod_metis
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_metis (cholmod_sparse *, int64_t *, size_t, int,
     int64_t *, cholmod_common *) ;
 
@@ -4634,7 +4659,7 @@ int cholmod_l_metis (cholmod_sparse *, int64_t *, size_t, int,
 
 /* Finds a node bisector of A, A*A', A(:,f)*A(:,f)'. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_bisect	/* returns # of nodes in separator */
 (
     /* ---- input ---- */
@@ -4650,7 +4675,7 @@ int64_t cholmod_bisect	/* returns # of nodes in separator */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_l_bisect (cholmod_sparse *, int64_t *,
     size_t, int, int64_t *, cholmod_common *) ;
 
@@ -4661,7 +4686,7 @@ int64_t cholmod_l_bisect (cholmod_sparse *, int64_t *,
 /* Find a set of nodes that bisects the graph of A or AA' (direct interface
  * to METIS_ComputeVertexSeperator). */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_metis_bisector	/* returns separator size */
 (
     /* ---- input ---- */
@@ -4679,7 +4704,7 @@ int64_t cholmod_metis_bisector	/* returns separator size */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_l_metis_bisector (cholmod_sparse *,
     int64_t *, int64_t *, int64_t *,
     cholmod_common *) ;
@@ -4690,7 +4715,7 @@ int64_t cholmod_l_metis_bisector (cholmod_sparse *,
 
 /* Collapse nodes in a separator tree. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_collapse_septree
 (
     /* ---- input ---- */
@@ -4705,7 +4730,7 @@ int64_t cholmod_collapse_septree
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int64_t cholmod_l_collapse_septree (size_t, size_t, double, size_t,
     int64_t *, int64_t *, cholmod_common *) ;
 
@@ -4757,7 +4782,7 @@ int64_t cholmod_l_collapse_septree (size_t, size_t, double, size_t,
  * a "simple" wrapper for this routine.
  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_super_symbolic
 (
     /* ---- input ---- */
@@ -4771,7 +4796,7 @@ int cholmod_super_symbolic
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_super_symbolic (cholmod_sparse *, cholmod_sparse *,
     int64_t *, cholmod_factor *, cholmod_common *) ;
 
@@ -4781,7 +4806,7 @@ int cholmod_l_super_symbolic (cholmod_sparse *, cholmod_sparse *,
 
 /* Analyze for supernodal Cholesky or multifrontal QR */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_super_symbolic2
 (
     /* ---- input ---- */
@@ -4798,7 +4823,7 @@ int cholmod_super_symbolic2
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_super_symbolic2 (int, cholmod_sparse *, cholmod_sparse *,
     int64_t *, cholmod_factor *, cholmod_common *) ;
 
@@ -4811,7 +4836,7 @@ int cholmod_l_super_symbolic2 (int, cholmod_sparse *, cholmod_sparse *,
  * cholmod_factorize is a "simple" wrapper for this routine.
  */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_super_numeric
 (
     /* ---- input ---- */
@@ -4824,7 +4849,7 @@ int cholmod_super_numeric
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_super_numeric (cholmod_sparse *, cholmod_sparse *, double *,
     cholmod_factor *, cholmod_common *) ;
 
@@ -4836,7 +4861,7 @@ int cholmod_l_super_numeric (cholmod_sparse *, cholmod_sparse *, double *,
  * need not call this routine directly.  cholmod_solve is a "simple" wrapper
  * for this routine. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_super_lsolve
 (
     /* ---- input ---- */
@@ -4849,7 +4874,7 @@ int cholmod_super_lsolve
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_super_lsolve (cholmod_factor *, cholmod_dense *, cholmod_dense *,
     cholmod_common *) ;
 
@@ -4861,7 +4886,7 @@ int cholmod_l_super_lsolve (cholmod_factor *, cholmod_dense *, cholmod_dense *,
  * need not call this routine directly.  cholmod_solve is a "simple" wrapper
  * for this routine. */
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_super_ltsolve
 (
     /* ---- input ---- */
@@ -4874,7 +4899,7 @@ int cholmod_super_ltsolve
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_super_ltsolve (cholmod_factor *, cholmod_dense *, cholmod_dense *,
     cholmod_common *) ;
 
@@ -4930,7 +4955,7 @@ typedef struct cholmod_gpu_pointers
 
 } cholmod_gpu_pointers ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_gpu_memorysize   /* GPU memory size available, 1 if no GPU */
 (
     size_t         *total_mem,
@@ -4938,7 +4963,7 @@ int cholmod_gpu_memorysize   /* GPU memory size available, 1 if no GPU */
     cholmod_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+CHOLMOD_PUBLIC
 int cholmod_l_gpu_memorysize /* GPU memory size available, 1 if no GPU */
 (
     size_t         *total_mem,
@@ -4946,17 +4971,17 @@ int cholmod_l_gpu_memorysize /* GPU memory size available, 1 if no GPU */
     cholmod_common *Common
 ) ;
  
-SUITESPARSE_PUBLIC int cholmod_gpu_probe   ( cholmod_common *Common ) ;
-SUITESPARSE_PUBLIC int cholmod_l_gpu_probe ( cholmod_common *Common ) ;
+CHOLMOD_PUBLIC int cholmod_gpu_probe   ( cholmod_common *Common ) ;
+CHOLMOD_PUBLIC int cholmod_l_gpu_probe ( cholmod_common *Common ) ;
 
-SUITESPARSE_PUBLIC int cholmod_gpu_deallocate   ( cholmod_common *Common ) ;
-SUITESPARSE_PUBLIC int cholmod_l_gpu_deallocate ( cholmod_common *Common ) ;
+CHOLMOD_PUBLIC int cholmod_gpu_deallocate   ( cholmod_common *Common ) ;
+CHOLMOD_PUBLIC int cholmod_l_gpu_deallocate ( cholmod_common *Common ) ;
 
-SUITESPARSE_PUBLIC void cholmod_gpu_end   ( cholmod_common *Common ) ;
-SUITESPARSE_PUBLIC void cholmod_l_gpu_end ( cholmod_common *Common ) ;
+CHOLMOD_PUBLIC void cholmod_gpu_end   ( cholmod_common *Common ) ;
+CHOLMOD_PUBLIC void cholmod_l_gpu_end ( cholmod_common *Common ) ;
 
-SUITESPARSE_PUBLIC int cholmod_gpu_allocate   ( cholmod_common *Common ) ;
-SUITESPARSE_PUBLIC int cholmod_l_gpu_allocate ( cholmod_common *Common ) ;
+CHOLMOD_PUBLIC int cholmod_gpu_allocate   ( cholmod_common *Common ) ;
+CHOLMOD_PUBLIC int cholmod_l_gpu_allocate ( cholmod_common *Common ) ;
 
 #endif
 

--- a/COLAMD/CMakeLists.txt
+++ b/COLAMD/CMakeLists.txt
@@ -71,6 +71,8 @@ set_target_properties ( colamd PROPERTIES
     SOVERSION ${COLAMD_VERSION_MAJOR}
     PUBLIC_HEADER "Include/colamd.h" )
 
+target_compile_definitions ( colamd PRIVATE COLAMD_LIBRARY )
+
 #-------------------------------------------------------------------------------
 # static colamd library properties
 #-------------------------------------------------------------------------------
@@ -83,6 +85,8 @@ set_target_properties ( colamd_static PROPERTIES
     OUTPUT_NAME colamd
     C_STANDARD_REQUIRED 11
     SOVERSION ${COLAMD_VERSION_MAJOR} )
+
+target_compile_definitions ( colamd_static PUBLIC COLAMD_STATIC )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -95,7 +99,7 @@ if ( NOT NSTATIC )
 endif ( )
 
 # libm:
-if ( NOT MSVC )
+if ( NOT WIN32 )
     target_link_libraries ( colamd PUBLIC m )
     if ( NOT NSTATIC )
         target_link_libraries ( colamd_static PUBLIC m )

--- a/COLAMD/Config/colamd.h.in
+++ b/COLAMD/Config/colamd.h.in
@@ -49,10 +49,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( COLAMD_LIBRARY )
@@ -68,7 +68,7 @@ extern "C" {
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define COLAMD_PUBLIC extern
 
 #endif

--- a/COLAMD/Config/colamd.h.in
+++ b/COLAMD/Config/colamd.h.in
@@ -48,6 +48,31 @@ extern "C" {
 
 #include "SuiteSparse_config.h"
 
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( COLAMD_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define COLAMD_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( CCOLAMD_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define COLAMD_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define COLAMD_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define COLAMD_PUBLIC extern
+
+#endif
+
 /* ========================================================================== */
 /* === COLAMD version ======================================================= */
 /* ========================================================================== */
@@ -129,7 +154,7 @@ extern "C" {
 /* === Prototypes of user-callable routines ================================= */
 /* ========================================================================== */
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 size_t colamd_recommended       /* returns recommended value of Alen, */
                                 /* or 0 if input arguments are erroneous */
 (
@@ -138,7 +163,7 @@ size_t colamd_recommended       /* returns recommended value of Alen, */
     int32_t n_col               /* number of columns in A */
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 size_t colamd_l_recommended     /* returns recommended value of Alen, */
                                 /* or 0 if input arguments are erroneous */
 (
@@ -147,19 +172,19 @@ size_t colamd_l_recommended     /* returns recommended value of Alen, */
     int64_t n_col               /* number of columns in A */
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 void colamd_set_defaults        /* sets default parameters */
 (                               /* knobs argument is modified on output */
     double knobs [COLAMD_KNOBS] /* parameter settings for colamd */
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 void colamd_l_set_defaults      /* sets default parameters */
 (                               /* knobs argument is modified on output */
     double knobs [COLAMD_KNOBS] /* parameter settings for colamd */
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 int colamd                      /* returns (1) if successful, (0) otherwise*/
 (                               /* A and p arguments are modified on output */
     int32_t n_row,              /* number of rows in A */
@@ -171,7 +196,7 @@ int colamd                      /* returns (1) if successful, (0) otherwise*/
     int32_t stats [COLAMD_STATS]    /* colamd output stats and error codes */
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 int colamd_l                    /* returns (1) if successful, (0) otherwise*/
 (                               /* A and p arguments are modified on output */
     int64_t n_row,              /* number of rows in A */
@@ -183,7 +208,7 @@ int colamd_l                    /* returns (1) if successful, (0) otherwise*/
     int64_t stats [COLAMD_STATS]    /* colamd output stats and error codes */
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 int symamd                              /* return (1) if OK, (0) otherwise */
 (
     int32_t n,                          /* number of rows and columns of A */
@@ -200,7 +225,7 @@ int symamd                              /* return (1) if OK, (0) otherwise */
                                         /* mxFree (for MATLAB mexFunction) */
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 int symamd_l                            /* return (1) if OK, (0) otherwise */
 (
     int64_t n,                          /* number of rows and columns of A */
@@ -217,25 +242,25 @@ int symamd_l                            /* return (1) if OK, (0) otherwise */
                                         /* mxFree (for MATLAB mexFunction) */
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 void colamd_report
 (
     int32_t stats [COLAMD_STATS]
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 void colamd_l_report
 (
     int64_t stats [COLAMD_STATS]
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 void symamd_report
 (
     int32_t stats [COLAMD_STATS]
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 void symamd_l_report
 (
     int64_t stats [COLAMD_STATS]

--- a/COLAMD/Include/colamd.h
+++ b/COLAMD/Include/colamd.h
@@ -49,10 +49,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( COLAMD_LIBRARY )
@@ -68,7 +68,7 @@ extern "C" {
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define COLAMD_PUBLIC extern
 
 #endif

--- a/COLAMD/Include/colamd.h
+++ b/COLAMD/Include/colamd.h
@@ -48,6 +48,31 @@ extern "C" {
 
 #include "SuiteSparse_config.h"
 
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( COLAMD_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define COLAMD_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( CCOLAMD_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define COLAMD_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define COLAMD_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define COLAMD_PUBLIC extern
+
+#endif
+
 /* ========================================================================== */
 /* === COLAMD version ======================================================= */
 /* ========================================================================== */
@@ -129,7 +154,7 @@ extern "C" {
 /* === Prototypes of user-callable routines ================================= */
 /* ========================================================================== */
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 size_t colamd_recommended       /* returns recommended value of Alen, */
                                 /* or 0 if input arguments are erroneous */
 (
@@ -138,7 +163,7 @@ size_t colamd_recommended       /* returns recommended value of Alen, */
     int32_t n_col               /* number of columns in A */
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 size_t colamd_l_recommended     /* returns recommended value of Alen, */
                                 /* or 0 if input arguments are erroneous */
 (
@@ -147,19 +172,19 @@ size_t colamd_l_recommended     /* returns recommended value of Alen, */
     int64_t n_col               /* number of columns in A */
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 void colamd_set_defaults        /* sets default parameters */
 (                               /* knobs argument is modified on output */
     double knobs [COLAMD_KNOBS] /* parameter settings for colamd */
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 void colamd_l_set_defaults      /* sets default parameters */
 (                               /* knobs argument is modified on output */
     double knobs [COLAMD_KNOBS] /* parameter settings for colamd */
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 int colamd                      /* returns (1) if successful, (0) otherwise*/
 (                               /* A and p arguments are modified on output */
     int32_t n_row,              /* number of rows in A */
@@ -171,7 +196,7 @@ int colamd                      /* returns (1) if successful, (0) otherwise*/
     int32_t stats [COLAMD_STATS]    /* colamd output stats and error codes */
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 int colamd_l                    /* returns (1) if successful, (0) otherwise*/
 (                               /* A and p arguments are modified on output */
     int64_t n_row,              /* number of rows in A */
@@ -183,7 +208,7 @@ int colamd_l                    /* returns (1) if successful, (0) otherwise*/
     int64_t stats [COLAMD_STATS]    /* colamd output stats and error codes */
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 int symamd                              /* return (1) if OK, (0) otherwise */
 (
     int32_t n,                          /* number of rows and columns of A */
@@ -200,7 +225,7 @@ int symamd                              /* return (1) if OK, (0) otherwise */
                                         /* mxFree (for MATLAB mexFunction) */
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 int symamd_l                            /* return (1) if OK, (0) otherwise */
 (
     int64_t n,                          /* number of rows and columns of A */
@@ -217,25 +242,25 @@ int symamd_l                            /* return (1) if OK, (0) otherwise */
                                         /* mxFree (for MATLAB mexFunction) */
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 void colamd_report
 (
     int32_t stats [COLAMD_STATS]
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 void colamd_l_report
 (
     int64_t stats [COLAMD_STATS]
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 void symamd_report
 (
     int32_t stats [COLAMD_STATS]
 ) ;
 
-SUITESPARSE_PUBLIC 
+COLAMD_PUBLIC 
 void symamd_l_report
 (
     int64_t stats [COLAMD_STATS]

--- a/COLAMD/Source/colamd.c
+++ b/COLAMD/Source/colamd.c
@@ -740,8 +740,8 @@ typedef struct Colamd_Row_struct
 /* ========================================================================== */
 
 /* Routines are either PUBLIC (user-callable) or PRIVATE (not user-callable) */
-#define GLOBAL SUITESPARSE_PUBLIC
-#define PUBLIC SUITESPARSE_PUBLIC
+#define GLOBAL COLAMD_PUBLIC
+#define PUBLIC COLAMD_PUBLIC
 #define PRIVATE static 
 
 #define DENSE_DEGREE(alpha,n) \

--- a/COLAMD/Source/colamd.c
+++ b/COLAMD/Source/colamd.c
@@ -740,8 +740,8 @@ typedef struct Colamd_Row_struct
 /* ========================================================================== */
 
 /* Routines are either PUBLIC (user-callable) or PRIVATE (not user-callable) */
-#define GLOBAL COLAMD_PUBLIC
-#define PUBLIC COLAMD_PUBLIC
+#define GLOBAL
+#define PUBLIC
 #define PRIVATE static 
 
 #define DENSE_DEGREE(alpha,n) \

--- a/CXSparse/CMakeLists.txt
+++ b/CXSparse/CMakeLists.txt
@@ -71,6 +71,8 @@ set_target_properties ( cxsparse PROPERTIES
     SOVERSION ${CXSPARSE_VERSION_MAJOR}
     PUBLIC_HEADER "Include/cs.h" )
 
+target_compile_definitions ( cxsparse PRIVATE CS_LIBRARY )
+
 #-------------------------------------------------------------------------------
 # static cxsparse library properties
 #-------------------------------------------------------------------------------
@@ -83,6 +85,8 @@ set_target_properties ( cxsparse_static PROPERTIES
     OUTPUT_NAME cxsparse
     C_STANDARD_REQUIRED 11
     SOVERSION ${CXSPARSE_VERSION_MAJOR} )
+
+target_compile_definitions ( cxsparse_static PUBLIC CS_STATIC )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -95,7 +99,7 @@ if ( NOT NSTATIC )
 endif ( )
 
 # libm:
-if ( NOT MSVC )
+if ( NOT WIN32 )
     target_link_libraries ( cxsparse PUBLIC m )
     if ( NOT NSTATIC )
         target_link_libraries ( cxsparse_static PUBLIC m )

--- a/CXSparse/Config/cs.h.in
+++ b/CXSparse/Config/cs.h.in
@@ -49,10 +49,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( CS_LIBRARY )
@@ -68,7 +68,7 @@ extern "C" {
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define CS_PUBLIC extern
 
 #endif

--- a/CXSparse/Config/cs.h.in
+++ b/CXSparse/Config/cs.h.in
@@ -47,6 +47,32 @@ extern "C" {
 #define CXSPARSE
 
 #include "SuiteSparse_config.h"
+
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( CS_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define CS_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( CS_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define CS_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define CS_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define CS_PUBLIC extern
+
+#endif
+
 #define cs_long_t       int64_t
 #define cs_long_t_id    "%" PRId64
 #define cs_long_t_max   INT64_MAX
@@ -68,29 +94,29 @@ typedef struct cs_di_sparse  /* matrix in compressed-column or triplet form */
     int32_t nz ;    /* # of entries in triplet matrix, -1 for compressed-col */
 } cs_di ;
 
-SUITESPARSE_PUBLIC cs_di *cs_di_add (const cs_di *A, const cs_di *B, double alpha, double beta) ;
-SUITESPARSE_PUBLIC int32_t cs_di_cholsol (int32_t order, const cs_di *A, double *b) ;
-SUITESPARSE_PUBLIC int32_t cs_di_dupl (cs_di *A) ;
-SUITESPARSE_PUBLIC int32_t cs_di_entry (cs_di *T, int32_t i, int32_t j, double x) ;
-SUITESPARSE_PUBLIC int32_t cs_di_lusol (int32_t order, const cs_di *A, double *b, double tol) ;
-SUITESPARSE_PUBLIC int32_t cs_di_gaxpy (const cs_di *A, const double *x, double *y) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_multiply (const cs_di *A, const cs_di *B) ;
-SUITESPARSE_PUBLIC int32_t cs_di_qrsol (int32_t order, const cs_di *A, double *b) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_transpose (const cs_di *A, int32_t values) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_compress (const cs_di *T) ;
-SUITESPARSE_PUBLIC double cs_di_norm (const cs_di *A) ;
-SUITESPARSE_PUBLIC int32_t cs_di_print (const cs_di *A, int32_t brief) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_load (FILE *f) ;
+CS_PUBLIC cs_di *cs_di_add (const cs_di *A, const cs_di *B, double alpha, double beta) ;
+CS_PUBLIC int32_t cs_di_cholsol (int32_t order, const cs_di *A, double *b) ;
+CS_PUBLIC int32_t cs_di_dupl (cs_di *A) ;
+CS_PUBLIC int32_t cs_di_entry (cs_di *T, int32_t i, int32_t j, double x) ;
+CS_PUBLIC int32_t cs_di_lusol (int32_t order, const cs_di *A, double *b, double tol) ;
+CS_PUBLIC int32_t cs_di_gaxpy (const cs_di *A, const double *x, double *y) ;
+CS_PUBLIC cs_di *cs_di_multiply (const cs_di *A, const cs_di *B) ;
+CS_PUBLIC int32_t cs_di_qrsol (int32_t order, const cs_di *A, double *b) ;
+CS_PUBLIC cs_di *cs_di_transpose (const cs_di *A, int32_t values) ;
+CS_PUBLIC cs_di *cs_di_compress (const cs_di *T) ;
+CS_PUBLIC double cs_di_norm (const cs_di *A) ;
+CS_PUBLIC int32_t cs_di_print (const cs_di *A, int32_t brief) ;
+CS_PUBLIC cs_di *cs_di_load (FILE *f) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC void *cs_di_calloc (int32_t n, size_t size) ;
-SUITESPARSE_PUBLIC void *cs_di_free (void *p) ;
-SUITESPARSE_PUBLIC void *cs_di_realloc (void *p, int32_t n, size_t size, int32_t *ok) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_spalloc (int32_t m, int32_t n, int32_t nzmax, int32_t values,
+CS_PUBLIC void *cs_di_calloc (int32_t n, size_t size) ;
+CS_PUBLIC void *cs_di_free (void *p) ;
+CS_PUBLIC void *cs_di_realloc (void *p, int32_t n, size_t size, int32_t *ok) ;
+CS_PUBLIC cs_di *cs_di_spalloc (int32_t m, int32_t n, int32_t nzmax, int32_t values,
     int32_t t) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_spfree (cs_di *A) ;
-SUITESPARSE_PUBLIC int32_t cs_di_sprealloc (cs_di *A, int32_t nzmax) ;
-SUITESPARSE_PUBLIC void *cs_di_malloc (int32_t n, size_t size) ;
+CS_PUBLIC cs_di *cs_di_spfree (cs_di *A) ;
+CS_PUBLIC int32_t cs_di_sprealloc (cs_di *A, int32_t nzmax) ;
+CS_PUBLIC void *cs_di_malloc (int32_t n, size_t size) ;
 
 /* --- secondary CSparse routines and data structures ----------------------- */
 
@@ -125,68 +151,68 @@ typedef struct cs_di_dmperm_results    /* cs_di_dmperm or cs_di_scc output */
     int32_t cc [5] ; /* coarse column decomposition */
 } cs_did ;
 
-SUITESPARSE_PUBLIC int32_t *cs_di_amd (int32_t order, const cs_di *A) ;
-SUITESPARSE_PUBLIC cs_din *cs_di_chol (const cs_di *A, const cs_dis *S) ;
-SUITESPARSE_PUBLIC cs_did *cs_di_dmperm (const cs_di *A, int32_t seed) ;
-SUITESPARSE_PUBLIC int32_t cs_di_droptol (cs_di *A, double tol) ;
-SUITESPARSE_PUBLIC int32_t cs_di_dropzeros (cs_di *A) ;
-SUITESPARSE_PUBLIC int32_t cs_di_happly (const cs_di *V, int32_t i, double beta, double *x) ;
-SUITESPARSE_PUBLIC int32_t cs_di_ipvec (const int32_t *p, const double *b, double *x, int32_t n) ;
-SUITESPARSE_PUBLIC int32_t cs_di_lsolve (const cs_di *L, double *x) ;
-SUITESPARSE_PUBLIC int32_t cs_di_ltsolve (const cs_di *L, double *x) ;
-SUITESPARSE_PUBLIC cs_din *cs_di_lu (const cs_di *A, const cs_dis *S, double tol) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_permute (const cs_di *A, const int32_t *pinv, const int32_t *q,
+CS_PUBLIC int32_t *cs_di_amd (int32_t order, const cs_di *A) ;
+CS_PUBLIC cs_din *cs_di_chol (const cs_di *A, const cs_dis *S) ;
+CS_PUBLIC cs_did *cs_di_dmperm (const cs_di *A, int32_t seed) ;
+CS_PUBLIC int32_t cs_di_droptol (cs_di *A, double tol) ;
+CS_PUBLIC int32_t cs_di_dropzeros (cs_di *A) ;
+CS_PUBLIC int32_t cs_di_happly (const cs_di *V, int32_t i, double beta, double *x) ;
+CS_PUBLIC int32_t cs_di_ipvec (const int32_t *p, const double *b, double *x, int32_t n) ;
+CS_PUBLIC int32_t cs_di_lsolve (const cs_di *L, double *x) ;
+CS_PUBLIC int32_t cs_di_ltsolve (const cs_di *L, double *x) ;
+CS_PUBLIC cs_din *cs_di_lu (const cs_di *A, const cs_dis *S, double tol) ;
+CS_PUBLIC cs_di *cs_di_permute (const cs_di *A, const int32_t *pinv, const int32_t *q,
     int32_t values) ;
-SUITESPARSE_PUBLIC int32_t *cs_di_pinv (const int32_t *p, int32_t n) ;
-SUITESPARSE_PUBLIC int32_t cs_di_pvec (const int32_t *p, const double *b, double *x, int32_t n) ;
-SUITESPARSE_PUBLIC cs_din *cs_di_qr (const cs_di *A, const cs_dis *S) ;
-SUITESPARSE_PUBLIC cs_dis *cs_di_schol (int32_t order, const cs_di *A) ;
-SUITESPARSE_PUBLIC cs_dis *cs_di_sqr (int32_t order, const cs_di *A, int32_t qr) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_symperm (const cs_di *A, const int32_t *pinv, int32_t values) ;
-SUITESPARSE_PUBLIC int32_t cs_di_usolve (const cs_di *U, double *x) ;
-SUITESPARSE_PUBLIC int32_t cs_di_utsolve (const cs_di *U, double *x) ;
-SUITESPARSE_PUBLIC int32_t cs_di_updown (cs_di *L, int32_t sigma, const cs_di *C,
+CS_PUBLIC int32_t *cs_di_pinv (const int32_t *p, int32_t n) ;
+CS_PUBLIC int32_t cs_di_pvec (const int32_t *p, const double *b, double *x, int32_t n) ;
+CS_PUBLIC cs_din *cs_di_qr (const cs_di *A, const cs_dis *S) ;
+CS_PUBLIC cs_dis *cs_di_schol (int32_t order, const cs_di *A) ;
+CS_PUBLIC cs_dis *cs_di_sqr (int32_t order, const cs_di *A, int32_t qr) ;
+CS_PUBLIC cs_di *cs_di_symperm (const cs_di *A, const int32_t *pinv, int32_t values) ;
+CS_PUBLIC int32_t cs_di_usolve (const cs_di *U, double *x) ;
+CS_PUBLIC int32_t cs_di_utsolve (const cs_di *U, double *x) ;
+CS_PUBLIC int32_t cs_di_updown (cs_di *L, int32_t sigma, const cs_di *C,
     const int32_t *parent) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC cs_dis *cs_di_sfree (cs_dis *S) ;
-SUITESPARSE_PUBLIC cs_din *cs_di_nfree (cs_din *N) ;
-SUITESPARSE_PUBLIC cs_did *cs_di_dfree (cs_did *D) ;
+CS_PUBLIC cs_dis *cs_di_sfree (cs_dis *S) ;
+CS_PUBLIC cs_din *cs_di_nfree (cs_din *N) ;
+CS_PUBLIC cs_did *cs_di_dfree (cs_did *D) ;
 
 /* --- tertiary CSparse routines -------------------------------------------- */
 
-SUITESPARSE_PUBLIC int32_t *cs_di_counts (const cs_di *A, const int32_t *parent,
+CS_PUBLIC int32_t *cs_di_counts (const cs_di *A, const int32_t *parent,
     const int32_t *post, int32_t ata) ;
-SUITESPARSE_PUBLIC double cs_di_cumsum (int32_t *p, int32_t *c, int32_t n) ;
-SUITESPARSE_PUBLIC int32_t cs_di_dfs (int32_t j, cs_di *G, int32_t top, int32_t *xi,
+CS_PUBLIC double cs_di_cumsum (int32_t *p, int32_t *c, int32_t n) ;
+CS_PUBLIC int32_t cs_di_dfs (int32_t j, cs_di *G, int32_t top, int32_t *xi,
     int32_t *pstack, const int32_t *pinv) ;
-SUITESPARSE_PUBLIC int32_t *cs_di_etree (const cs_di *A, int32_t ata) ;
-SUITESPARSE_PUBLIC int32_t cs_di_fkeep (cs_di *A,
+CS_PUBLIC int32_t *cs_di_etree (const cs_di *A, int32_t ata) ;
+CS_PUBLIC int32_t cs_di_fkeep (cs_di *A,
     int32_t (*fkeep) (int32_t, int32_t, double, void *), void *other) ;
-SUITESPARSE_PUBLIC double cs_di_house (double *x, double *beta, int32_t n) ;
-SUITESPARSE_PUBLIC int32_t *cs_di_maxtrans (const cs_di *A, int32_t seed) ;
-SUITESPARSE_PUBLIC int32_t *cs_di_post (const int32_t *parent, int32_t n) ;
-SUITESPARSE_PUBLIC cs_did *cs_di_scc (cs_di *A) ;
-SUITESPARSE_PUBLIC int32_t cs_di_scatter (const cs_di *A, int32_t j, double beta, int32_t *w,
+CS_PUBLIC double cs_di_house (double *x, double *beta, int32_t n) ;
+CS_PUBLIC int32_t *cs_di_maxtrans (const cs_di *A, int32_t seed) ;
+CS_PUBLIC int32_t *cs_di_post (const int32_t *parent, int32_t n) ;
+CS_PUBLIC cs_did *cs_di_scc (cs_di *A) ;
+CS_PUBLIC int32_t cs_di_scatter (const cs_di *A, int32_t j, double beta, int32_t *w,
     double *x, int32_t mark, cs_di *C, int32_t nz) ;
-SUITESPARSE_PUBLIC int32_t cs_di_tdfs (int32_t j, int32_t k, int32_t *head, const int32_t *next,
+CS_PUBLIC int32_t cs_di_tdfs (int32_t j, int32_t k, int32_t *head, const int32_t *next,
     int32_t *post, int32_t *stack) ;
-SUITESPARSE_PUBLIC int32_t cs_di_leaf (int32_t i, int32_t j, const int32_t *first,
+CS_PUBLIC int32_t cs_di_leaf (int32_t i, int32_t j, const int32_t *first,
     int32_t *maxfirst, int32_t *prevleaf, int32_t *ancestor, int32_t *jleaf) ;
-SUITESPARSE_PUBLIC int32_t cs_di_reach (cs_di *G, const cs_di *B, int32_t k, int32_t *xi,
+CS_PUBLIC int32_t cs_di_reach (cs_di *G, const cs_di *B, int32_t k, int32_t *xi,
     const int32_t *pinv) ;
-SUITESPARSE_PUBLIC int32_t cs_di_spsolve (cs_di *L, const cs_di *B, int32_t k, int32_t *xi,
+CS_PUBLIC int32_t cs_di_spsolve (cs_di *L, const cs_di *B, int32_t k, int32_t *xi,
     double *x, const int32_t *pinv, int32_t lo) ;
-SUITESPARSE_PUBLIC int32_t cs_di_ereach (const cs_di *A, int32_t k, const int32_t *parent,
+CS_PUBLIC int32_t cs_di_ereach (const cs_di *A, int32_t k, const int32_t *parent,
     int32_t *s, int32_t *w) ;
-SUITESPARSE_PUBLIC int32_t *cs_di_randperm (int32_t n, int32_t seed) ;
+CS_PUBLIC int32_t *cs_di_randperm (int32_t n, int32_t seed) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC cs_did *cs_di_dalloc (int32_t m, int32_t n) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_done (cs_di *C, void *w, void *x, int32_t ok) ;
-SUITESPARSE_PUBLIC int32_t *cs_di_idone (int32_t *p, cs_di *C, void *w, int32_t ok) ;
-SUITESPARSE_PUBLIC cs_din *cs_di_ndone (cs_din *N, cs_di *C, void *w, void *x, int32_t ok) ;
-SUITESPARSE_PUBLIC cs_did *cs_di_ddone (cs_did *D, cs_di *C, void *w, int32_t ok) ;
+CS_PUBLIC cs_did *cs_di_dalloc (int32_t m, int32_t n) ;
+CS_PUBLIC cs_di *cs_di_done (cs_di *C, void *w, void *x, int32_t ok) ;
+CS_PUBLIC int32_t *cs_di_idone (int32_t *p, cs_di *C, void *w, int32_t ok) ;
+CS_PUBLIC cs_din *cs_di_ndone (cs_din *N, cs_di *C, void *w, void *x, int32_t ok) ;
+CS_PUBLIC cs_did *cs_di_ddone (cs_did *D, cs_di *C, void *w, int32_t ok) ;
 
 
 /* -------------------------------------------------------------------------- */
@@ -206,29 +232,29 @@ typedef struct cs_dl_sparse  /* matrix in compressed-column or triplet form */
     int64_t nz ;  /* # of entries in triplet matrix, -1 for compressed-col */
 } cs_dl ;
 
-SUITESPARSE_PUBLIC cs_dl *cs_dl_add (const cs_dl *A, const cs_dl *B, double alpha, double beta) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_cholsol (int64_t order, const cs_dl *A, double *b) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_dupl (cs_dl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_entry (cs_dl *T, int64_t i, int64_t j, double x) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_lusol (int64_t order, const cs_dl *A, double *b, double tol) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_gaxpy (const cs_dl *A, const double *x, double *y) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_multiply (const cs_dl *A, const cs_dl *B) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_qrsol (int64_t order, const cs_dl *A, double *b) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_transpose (const cs_dl *A, int64_t values) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_compress (const cs_dl *T) ;
-SUITESPARSE_PUBLIC double cs_dl_norm (const cs_dl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_print (const cs_dl *A, int64_t brief) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_load (FILE *f) ;
+CS_PUBLIC cs_dl *cs_dl_add (const cs_dl *A, const cs_dl *B, double alpha, double beta) ;
+CS_PUBLIC int64_t cs_dl_cholsol (int64_t order, const cs_dl *A, double *b) ;
+CS_PUBLIC int64_t cs_dl_dupl (cs_dl *A) ;
+CS_PUBLIC int64_t cs_dl_entry (cs_dl *T, int64_t i, int64_t j, double x) ;
+CS_PUBLIC int64_t cs_dl_lusol (int64_t order, const cs_dl *A, double *b, double tol) ;
+CS_PUBLIC int64_t cs_dl_gaxpy (const cs_dl *A, const double *x, double *y) ;
+CS_PUBLIC cs_dl *cs_dl_multiply (const cs_dl *A, const cs_dl *B) ;
+CS_PUBLIC int64_t cs_dl_qrsol (int64_t order, const cs_dl *A, double *b) ;
+CS_PUBLIC cs_dl *cs_dl_transpose (const cs_dl *A, int64_t values) ;
+CS_PUBLIC cs_dl *cs_dl_compress (const cs_dl *T) ;
+CS_PUBLIC double cs_dl_norm (const cs_dl *A) ;
+CS_PUBLIC int64_t cs_dl_print (const cs_dl *A, int64_t brief) ;
+CS_PUBLIC cs_dl *cs_dl_load (FILE *f) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC void *cs_dl_calloc (int64_t n, size_t size) ;
-SUITESPARSE_PUBLIC void *cs_dl_free (void *p) ;
-SUITESPARSE_PUBLIC void *cs_dl_realloc (void *p, int64_t n, size_t size, int64_t *ok) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_spalloc (int64_t m, int64_t n, int64_t nzmax,
+CS_PUBLIC void *cs_dl_calloc (int64_t n, size_t size) ;
+CS_PUBLIC void *cs_dl_free (void *p) ;
+CS_PUBLIC void *cs_dl_realloc (void *p, int64_t n, size_t size, int64_t *ok) ;
+CS_PUBLIC cs_dl *cs_dl_spalloc (int64_t m, int64_t n, int64_t nzmax,
     int64_t values, int64_t t) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_spfree (cs_dl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_sprealloc (cs_dl *A, int64_t nzmax) ;
-SUITESPARSE_PUBLIC void *cs_dl_malloc (int64_t n, size_t size) ;
+CS_PUBLIC cs_dl *cs_dl_spfree (cs_dl *A) ;
+CS_PUBLIC int64_t cs_dl_sprealloc (cs_dl *A, int64_t nzmax) ;
+CS_PUBLIC void *cs_dl_malloc (int64_t n, size_t size) ;
 
 /* --- secondary CSparse routines and data structures ----------------------- */
 
@@ -263,71 +289,71 @@ typedef struct cs_dl_dmperm_results    /* cs_dl_dmperm or cs_dl_scc output */
     int64_t cc [5] ;    /* coarse column decomposition */
 } cs_dld ;
 
-SUITESPARSE_PUBLIC int64_t *cs_dl_amd (int64_t order, const cs_dl *A) ;
-SUITESPARSE_PUBLIC cs_dln *cs_dl_chol (const cs_dl *A, const cs_dls *S) ;
-SUITESPARSE_PUBLIC cs_dld *cs_dl_dmperm (const cs_dl *A, int64_t seed) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_droptol (cs_dl *A, double tol) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_dropzeros (cs_dl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_happly (const cs_dl *V, int64_t i, double beta, double *x) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_ipvec (const int64_t *p, const double *b, double *x,
+CS_PUBLIC int64_t *cs_dl_amd (int64_t order, const cs_dl *A) ;
+CS_PUBLIC cs_dln *cs_dl_chol (const cs_dl *A, const cs_dls *S) ;
+CS_PUBLIC cs_dld *cs_dl_dmperm (const cs_dl *A, int64_t seed) ;
+CS_PUBLIC int64_t cs_dl_droptol (cs_dl *A, double tol) ;
+CS_PUBLIC int64_t cs_dl_dropzeros (cs_dl *A) ;
+CS_PUBLIC int64_t cs_dl_happly (const cs_dl *V, int64_t i, double beta, double *x) ;
+CS_PUBLIC int64_t cs_dl_ipvec (const int64_t *p, const double *b, double *x,
     int64_t n) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_lsolve (const cs_dl *L, double *x) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_ltsolve (const cs_dl *L, double *x) ;
-SUITESPARSE_PUBLIC cs_dln *cs_dl_lu (const cs_dl *A, const cs_dls *S, double tol) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_permute (const cs_dl *A, const int64_t *pinv, const int64_t *q,
+CS_PUBLIC int64_t cs_dl_lsolve (const cs_dl *L, double *x) ;
+CS_PUBLIC int64_t cs_dl_ltsolve (const cs_dl *L, double *x) ;
+CS_PUBLIC cs_dln *cs_dl_lu (const cs_dl *A, const cs_dls *S, double tol) ;
+CS_PUBLIC cs_dl *cs_dl_permute (const cs_dl *A, const int64_t *pinv, const int64_t *q,
     int64_t values) ;
-SUITESPARSE_PUBLIC int64_t *cs_dl_pinv (const int64_t *p, int64_t n) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_pvec (const int64_t *p, const double *b, double *x,
+CS_PUBLIC int64_t *cs_dl_pinv (const int64_t *p, int64_t n) ;
+CS_PUBLIC int64_t cs_dl_pvec (const int64_t *p, const double *b, double *x,
     int64_t n) ;
-SUITESPARSE_PUBLIC cs_dln *cs_dl_qr (const cs_dl *A, const cs_dls *S) ;
-SUITESPARSE_PUBLIC cs_dls *cs_dl_schol (int64_t order, const cs_dl *A) ;
-SUITESPARSE_PUBLIC cs_dls *cs_dl_sqr (int64_t order, const cs_dl *A, int64_t qr) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_symperm (const cs_dl *A, const int64_t *pinv, int64_t values) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_usolve (const cs_dl *U, double *x) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_utsolve (const cs_dl *U, double *x) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_updown (cs_dl *L, int64_t sigma, const cs_dl *C,
+CS_PUBLIC cs_dln *cs_dl_qr (const cs_dl *A, const cs_dls *S) ;
+CS_PUBLIC cs_dls *cs_dl_schol (int64_t order, const cs_dl *A) ;
+CS_PUBLIC cs_dls *cs_dl_sqr (int64_t order, const cs_dl *A, int64_t qr) ;
+CS_PUBLIC cs_dl *cs_dl_symperm (const cs_dl *A, const int64_t *pinv, int64_t values) ;
+CS_PUBLIC int64_t cs_dl_usolve (const cs_dl *U, double *x) ;
+CS_PUBLIC int64_t cs_dl_utsolve (const cs_dl *U, double *x) ;
+CS_PUBLIC int64_t cs_dl_updown (cs_dl *L, int64_t sigma, const cs_dl *C,
     const int64_t *parent) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC cs_dls *cs_dl_sfree (cs_dls *S) ;
-SUITESPARSE_PUBLIC cs_dln *cs_dl_nfree (cs_dln *N) ;
-SUITESPARSE_PUBLIC cs_dld *cs_dl_dfree (cs_dld *D) ;
+CS_PUBLIC cs_dls *cs_dl_sfree (cs_dls *S) ;
+CS_PUBLIC cs_dln *cs_dl_nfree (cs_dln *N) ;
+CS_PUBLIC cs_dld *cs_dl_dfree (cs_dld *D) ;
 
 /* --- tertiary CSparse routines -------------------------------------------- */
 
-SUITESPARSE_PUBLIC int64_t *cs_dl_counts (const cs_dl *A, const int64_t *parent,
+CS_PUBLIC int64_t *cs_dl_counts (const cs_dl *A, const int64_t *parent,
     const int64_t *post, int64_t ata) ;
-SUITESPARSE_PUBLIC double cs_dl_cumsum (int64_t *p, int64_t *c, int64_t n) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_dfs (int64_t j, cs_dl *G, int64_t top, int64_t *xi,
+CS_PUBLIC double cs_dl_cumsum (int64_t *p, int64_t *c, int64_t n) ;
+CS_PUBLIC int64_t cs_dl_dfs (int64_t j, cs_dl *G, int64_t top, int64_t *xi,
     int64_t *pstack, const int64_t *pinv) ;
-SUITESPARSE_PUBLIC int64_t *cs_dl_etree (const cs_dl *A, int64_t ata) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_fkeep (cs_dl *A,
+CS_PUBLIC int64_t *cs_dl_etree (const cs_dl *A, int64_t ata) ;
+CS_PUBLIC int64_t cs_dl_fkeep (cs_dl *A,
     int64_t (*fkeep) (int64_t, int64_t, double, void *), void *other) ;
-SUITESPARSE_PUBLIC double cs_dl_house (double *x, double *beta, int64_t n) ;
-SUITESPARSE_PUBLIC int64_t *cs_dl_maxtrans (const cs_dl *A, int64_t seed) ;
-SUITESPARSE_PUBLIC int64_t *cs_dl_post (const int64_t *parent, int64_t n) ;
-SUITESPARSE_PUBLIC cs_dld *cs_dl_scc (cs_dl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_scatter (const cs_dl *A, int64_t j, double beta, int64_t *w,
+CS_PUBLIC double cs_dl_house (double *x, double *beta, int64_t n) ;
+CS_PUBLIC int64_t *cs_dl_maxtrans (const cs_dl *A, int64_t seed) ;
+CS_PUBLIC int64_t *cs_dl_post (const int64_t *parent, int64_t n) ;
+CS_PUBLIC cs_dld *cs_dl_scc (cs_dl *A) ;
+CS_PUBLIC int64_t cs_dl_scatter (const cs_dl *A, int64_t j, double beta, int64_t *w,
     double *x, int64_t mark,cs_dl *C, int64_t nz) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_tdfs (int64_t j, int64_t k, int64_t *head,
+CS_PUBLIC int64_t cs_dl_tdfs (int64_t j, int64_t k, int64_t *head,
     const int64_t *next, int64_t *post, int64_t *stack) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_leaf (int64_t i, int64_t j, const int64_t *first,
+CS_PUBLIC int64_t cs_dl_leaf (int64_t i, int64_t j, const int64_t *first,
     int64_t *maxfirst, int64_t *prevleaf, int64_t *ancestor,
     int64_t *jleaf) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_reach (cs_dl *G, const cs_dl *B, int64_t k, int64_t *xi,
+CS_PUBLIC int64_t cs_dl_reach (cs_dl *G, const cs_dl *B, int64_t k, int64_t *xi,
     const int64_t *pinv) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_spsolve (cs_dl *L, const cs_dl *B, int64_t k, int64_t *xi,
+CS_PUBLIC int64_t cs_dl_spsolve (cs_dl *L, const cs_dl *B, int64_t k, int64_t *xi,
     double *x, const int64_t *pinv, int64_t lo) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_ereach (const cs_dl *A, int64_t k, const int64_t *parent,
+CS_PUBLIC int64_t cs_dl_ereach (const cs_dl *A, int64_t k, const int64_t *parent,
     int64_t *s, int64_t *w) ;
-SUITESPARSE_PUBLIC int64_t *cs_dl_randperm (int64_t n, int64_t seed) ;
+CS_PUBLIC int64_t *cs_dl_randperm (int64_t n, int64_t seed) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC cs_dld *cs_dl_dalloc (int64_t m, int64_t n) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_done (cs_dl *C, void *w, void *x, int64_t ok) ;
-SUITESPARSE_PUBLIC int64_t *cs_dl_idone (int64_t *p, cs_dl *C, void *w, int64_t ok) ;
-SUITESPARSE_PUBLIC cs_dln *cs_dl_ndone (cs_dln *N, cs_dl *C, void *w, void *x, int64_t ok) ;
-SUITESPARSE_PUBLIC cs_dld *cs_dl_ddone (cs_dld *D, cs_dl *C, void *w, int64_t ok) ;
+CS_PUBLIC cs_dld *cs_dl_dalloc (int64_t m, int64_t n) ;
+CS_PUBLIC cs_dl *cs_dl_done (cs_dl *C, void *w, void *x, int64_t ok) ;
+CS_PUBLIC int64_t *cs_dl_idone (int64_t *p, cs_dl *C, void *w, int64_t ok) ;
+CS_PUBLIC cs_dln *cs_dl_ndone (cs_dln *N, cs_dl *C, void *w, void *x, int64_t ok) ;
+CS_PUBLIC cs_dld *cs_dl_ddone (cs_dld *D, cs_dl *C, void *w, int64_t ok) ;
 
 
 /* -------------------------------------------------------------------------- */
@@ -349,31 +375,31 @@ typedef struct cs_ci_sparse  /* matrix in compressed-column or triplet form */
     int32_t nz ;  /* # of entries in triplet matrix, -1 for compressed-col */
 } cs_ci ;
 
-SUITESPARSE_PUBLIC cs_ci *cs_ci_add (const cs_ci *A, const cs_ci *B, cs_complex_t alpha,
+CS_PUBLIC cs_ci *cs_ci_add (const cs_ci *A, const cs_ci *B, cs_complex_t alpha,
     cs_complex_t beta) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_cholsol (int32_t order, const cs_ci *A, cs_complex_t *b) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_dupl (cs_ci *A) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_entry (cs_ci *T, int32_t i, int32_t j, cs_complex_t x) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_lusol (int32_t order, const cs_ci *A, cs_complex_t *b,
+CS_PUBLIC int32_t cs_ci_cholsol (int32_t order, const cs_ci *A, cs_complex_t *b) ;
+CS_PUBLIC int32_t cs_ci_dupl (cs_ci *A) ;
+CS_PUBLIC int32_t cs_ci_entry (cs_ci *T, int32_t i, int32_t j, cs_complex_t x) ;
+CS_PUBLIC int32_t cs_ci_lusol (int32_t order, const cs_ci *A, cs_complex_t *b,
     double tol) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_gaxpy (const cs_ci *A, const cs_complex_t *x, cs_complex_t *y) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_multiply (const cs_ci *A, const cs_ci *B) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_qrsol (int32_t order, const cs_ci *A, cs_complex_t *b) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_transpose (const cs_ci *A, int32_t values) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_compress (const cs_ci *T) ;
-SUITESPARSE_PUBLIC double cs_ci_norm (const cs_ci *A) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_print (const cs_ci *A, int32_t brief) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_load (FILE *f) ;
+CS_PUBLIC int32_t cs_ci_gaxpy (const cs_ci *A, const cs_complex_t *x, cs_complex_t *y) ;
+CS_PUBLIC cs_ci *cs_ci_multiply (const cs_ci *A, const cs_ci *B) ;
+CS_PUBLIC int32_t cs_ci_qrsol (int32_t order, const cs_ci *A, cs_complex_t *b) ;
+CS_PUBLIC cs_ci *cs_ci_transpose (const cs_ci *A, int32_t values) ;
+CS_PUBLIC cs_ci *cs_ci_compress (const cs_ci *T) ;
+CS_PUBLIC double cs_ci_norm (const cs_ci *A) ;
+CS_PUBLIC int32_t cs_ci_print (const cs_ci *A, int32_t brief) ;
+CS_PUBLIC cs_ci *cs_ci_load (FILE *f) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC void *cs_ci_calloc (int32_t n, size_t size) ;
-SUITESPARSE_PUBLIC void *cs_ci_free (void *p) ;
-SUITESPARSE_PUBLIC void *cs_ci_realloc (void *p, int32_t n, size_t size, int32_t *ok) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_spalloc (int32_t m, int32_t n, int32_t nzmax, int32_t values,
+CS_PUBLIC void *cs_ci_calloc (int32_t n, size_t size) ;
+CS_PUBLIC void *cs_ci_free (void *p) ;
+CS_PUBLIC void *cs_ci_realloc (void *p, int32_t n, size_t size, int32_t *ok) ;
+CS_PUBLIC cs_ci *cs_ci_spalloc (int32_t m, int32_t n, int32_t nzmax, int32_t values,
     int32_t t) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_spfree (cs_ci *A) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_sprealloc (cs_ci *A, int32_t nzmax) ;
-SUITESPARSE_PUBLIC void *cs_ci_malloc (int32_t n, size_t size) ;
+CS_PUBLIC cs_ci *cs_ci_spfree (cs_ci *A) ;
+CS_PUBLIC int32_t cs_ci_sprealloc (cs_ci *A, int32_t nzmax) ;
+CS_PUBLIC void *cs_ci_malloc (int32_t n, size_t size) ;
 
 /* --- secondary CSparse routines and data structures ----------------------- */
 
@@ -408,70 +434,70 @@ typedef struct cs_ci_dmperm_results    /* cs_ci_dmperm or cs_ci_scc output */
     int32_t cc [5] ;  /* coarse column decomposition */
 } cs_cid ;
 
-SUITESPARSE_PUBLIC int32_t *cs_ci_amd (int32_t order, const cs_ci *A) ;
-SUITESPARSE_PUBLIC cs_cin *cs_ci_chol (const cs_ci *A, const cs_cis *S) ;
-SUITESPARSE_PUBLIC cs_cid *cs_ci_dmperm (const cs_ci *A, int32_t seed) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_droptol (cs_ci *A, double tol) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_dropzeros (cs_ci *A) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_happly (const cs_ci *V, int32_t i, double beta, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_ipvec (const int32_t *p, const cs_complex_t *b, cs_complex_t *x,
+CS_PUBLIC int32_t *cs_ci_amd (int32_t order, const cs_ci *A) ;
+CS_PUBLIC cs_cin *cs_ci_chol (const cs_ci *A, const cs_cis *S) ;
+CS_PUBLIC cs_cid *cs_ci_dmperm (const cs_ci *A, int32_t seed) ;
+CS_PUBLIC int32_t cs_ci_droptol (cs_ci *A, double tol) ;
+CS_PUBLIC int32_t cs_ci_dropzeros (cs_ci *A) ;
+CS_PUBLIC int32_t cs_ci_happly (const cs_ci *V, int32_t i, double beta, cs_complex_t *x) ;
+CS_PUBLIC int32_t cs_ci_ipvec (const int32_t *p, const cs_complex_t *b, cs_complex_t *x,
     int32_t n) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_lsolve (const cs_ci *L, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_ltsolve (const cs_ci *L, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC cs_cin *cs_ci_lu (const cs_ci *A, const cs_cis *S, double tol) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_permute (const cs_ci *A, const int32_t *pinv, const int32_t *q,
+CS_PUBLIC int32_t cs_ci_lsolve (const cs_ci *L, cs_complex_t *x) ;
+CS_PUBLIC int32_t cs_ci_ltsolve (const cs_ci *L, cs_complex_t *x) ;
+CS_PUBLIC cs_cin *cs_ci_lu (const cs_ci *A, const cs_cis *S, double tol) ;
+CS_PUBLIC cs_ci *cs_ci_permute (const cs_ci *A, const int32_t *pinv, const int32_t *q,
     int32_t values) ;
-SUITESPARSE_PUBLIC int32_t *cs_ci_pinv (const int32_t *p, int32_t n) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_pvec (const int32_t *p, const cs_complex_t *b, cs_complex_t *x,
+CS_PUBLIC int32_t *cs_ci_pinv (const int32_t *p, int32_t n) ;
+CS_PUBLIC int32_t cs_ci_pvec (const int32_t *p, const cs_complex_t *b, cs_complex_t *x,
     int32_t n) ;
-SUITESPARSE_PUBLIC cs_cin *cs_ci_qr (const cs_ci *A, const cs_cis *S) ;
-SUITESPARSE_PUBLIC cs_cis *cs_ci_schol (int32_t order, const cs_ci *A) ;
-SUITESPARSE_PUBLIC cs_cis *cs_ci_sqr (int32_t order, const cs_ci *A, int32_t qr) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_symperm (const cs_ci *A, const int32_t *pinv, int32_t values) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_usolve (const cs_ci *U, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_utsolve (const cs_ci *U, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_updown (cs_ci *L, int32_t sigma, const cs_ci *C,
+CS_PUBLIC cs_cin *cs_ci_qr (const cs_ci *A, const cs_cis *S) ;
+CS_PUBLIC cs_cis *cs_ci_schol (int32_t order, const cs_ci *A) ;
+CS_PUBLIC cs_cis *cs_ci_sqr (int32_t order, const cs_ci *A, int32_t qr) ;
+CS_PUBLIC cs_ci *cs_ci_symperm (const cs_ci *A, const int32_t *pinv, int32_t values) ;
+CS_PUBLIC int32_t cs_ci_usolve (const cs_ci *U, cs_complex_t *x) ;
+CS_PUBLIC int32_t cs_ci_utsolve (const cs_ci *U, cs_complex_t *x) ;
+CS_PUBLIC int32_t cs_ci_updown (cs_ci *L, int32_t sigma, const cs_ci *C,
     const int32_t *parent) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC cs_cis *cs_ci_sfree (cs_cis *S) ;
-SUITESPARSE_PUBLIC cs_cin *cs_ci_nfree (cs_cin *N) ;
-SUITESPARSE_PUBLIC cs_cid *cs_ci_dfree (cs_cid *D) ;
+CS_PUBLIC cs_cis *cs_ci_sfree (cs_cis *S) ;
+CS_PUBLIC cs_cin *cs_ci_nfree (cs_cin *N) ;
+CS_PUBLIC cs_cid *cs_ci_dfree (cs_cid *D) ;
 
 /* --- tertiary CSparse routines -------------------------------------------- */
 
-SUITESPARSE_PUBLIC int32_t *cs_ci_counts (const cs_ci *A, const int32_t *parent,
+CS_PUBLIC int32_t *cs_ci_counts (const cs_ci *A, const int32_t *parent,
     const int32_t *post, int32_t ata) ;
-SUITESPARSE_PUBLIC double cs_ci_cumsum (int32_t *p, int32_t *c, int32_t n) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_dfs (int32_t j, cs_ci *G, int32_t top, int32_t *xi,
+CS_PUBLIC double cs_ci_cumsum (int32_t *p, int32_t *c, int32_t n) ;
+CS_PUBLIC int32_t cs_ci_dfs (int32_t j, cs_ci *G, int32_t top, int32_t *xi,
     int32_t *pstack, const int32_t *pinv) ;
-SUITESPARSE_PUBLIC int32_t *cs_ci_etree (const cs_ci *A, int32_t ata) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_fkeep (cs_ci *A,
+CS_PUBLIC int32_t *cs_ci_etree (const cs_ci *A, int32_t ata) ;
+CS_PUBLIC int32_t cs_ci_fkeep (cs_ci *A,
     int32_t (*fkeep) (int32_t, int32_t, cs_complex_t, void *), void *other) ;
-SUITESPARSE_PUBLIC cs_complex_t cs_ci_house (cs_complex_t *x, double *beta, int32_t n) ;
-SUITESPARSE_PUBLIC int32_t *cs_ci_maxtrans (const cs_ci *A, int32_t seed) ;
-SUITESPARSE_PUBLIC int32_t *cs_ci_post (const int32_t *parent, int32_t n) ;
-SUITESPARSE_PUBLIC cs_cid *cs_ci_scc (cs_ci *A) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_scatter (const cs_ci *A, int32_t j, cs_complex_t beta, int32_t *w, 
+CS_PUBLIC cs_complex_t cs_ci_house (cs_complex_t *x, double *beta, int32_t n) ;
+CS_PUBLIC int32_t *cs_ci_maxtrans (const cs_ci *A, int32_t seed) ;
+CS_PUBLIC int32_t *cs_ci_post (const int32_t *parent, int32_t n) ;
+CS_PUBLIC cs_cid *cs_ci_scc (cs_ci *A) ;
+CS_PUBLIC int32_t cs_ci_scatter (const cs_ci *A, int32_t j, cs_complex_t beta, int32_t *w,
     cs_complex_t *x, int32_t mark,cs_ci *C, int32_t nz) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_tdfs (int32_t j, int32_t k, int32_t *head, const int32_t *next,
+CS_PUBLIC int32_t cs_ci_tdfs (int32_t j, int32_t k, int32_t *head, const int32_t *next,
     int32_t *post, int32_t *stack) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_leaf (int32_t i, int32_t j, const int32_t *first,
+CS_PUBLIC int32_t cs_ci_leaf (int32_t i, int32_t j, const int32_t *first,
     int32_t *maxfirst, int32_t *prevleaf, int32_t *ancestor, int32_t *jleaf) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_reach (cs_ci *G, const cs_ci *B, int32_t k, int32_t *xi,
+CS_PUBLIC int32_t cs_ci_reach (cs_ci *G, const cs_ci *B, int32_t k, int32_t *xi,
     const int32_t *pinv) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_spsolve (cs_ci *L, const cs_ci *B, int32_t k, int32_t *xi, 
+CS_PUBLIC int32_t cs_ci_spsolve (cs_ci *L, const cs_ci *B, int32_t k, int32_t *xi,
     cs_complex_t *x, const int32_t *pinv, int32_t lo) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_ereach (const cs_ci *A, int32_t k, const int32_t *parent,
+CS_PUBLIC int32_t cs_ci_ereach (const cs_ci *A, int32_t k, const int32_t *parent,
     int32_t *s, int32_t *w) ;
-SUITESPARSE_PUBLIC int32_t *cs_ci_randperm (int32_t n, int32_t seed) ;
+CS_PUBLIC int32_t *cs_ci_randperm (int32_t n, int32_t seed) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC cs_cid *cs_ci_dalloc (int32_t m, int32_t n) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_done (cs_ci *C, void *w, void *x, int32_t ok) ;
-SUITESPARSE_PUBLIC int32_t *cs_ci_idone (int32_t *p, cs_ci *C, void *w, int32_t ok) ;
-SUITESPARSE_PUBLIC cs_cin *cs_ci_ndone (cs_cin *N, cs_ci *C, void *w, void *x, int32_t ok) ;
-SUITESPARSE_PUBLIC cs_cid *cs_ci_ddone (cs_cid *D, cs_ci *C, void *w, int32_t ok) ;
+CS_PUBLIC cs_cid *cs_ci_dalloc (int32_t m, int32_t n) ;
+CS_PUBLIC cs_ci *cs_ci_done (cs_ci *C, void *w, void *x, int32_t ok) ;
+CS_PUBLIC int32_t *cs_ci_idone (int32_t *p, cs_ci *C, void *w, int32_t ok) ;
+CS_PUBLIC cs_cin *cs_ci_ndone (cs_cin *N, cs_ci *C, void *w, void *x, int32_t ok) ;
+CS_PUBLIC cs_cid *cs_ci_ddone (cs_cid *D, cs_ci *C, void *w, int32_t ok) ;
 
 
 /* -------------------------------------------------------------------------- */
@@ -491,31 +517,31 @@ typedef struct cs_cl_sparse  /* matrix in compressed-column or triplet form */
     int64_t nz ;   /* # of entries in triplet matrix, -1 for compressed-col */
 } cs_cl ;
 
-SUITESPARSE_PUBLIC cs_cl *cs_cl_add (const cs_cl *A, const cs_cl *B, cs_complex_t alpha,
+CS_PUBLIC cs_cl *cs_cl_add (const cs_cl *A, const cs_cl *B, cs_complex_t alpha,
     cs_complex_t beta) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_cholsol (int64_t order, const cs_cl *A, cs_complex_t *b) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_dupl (cs_cl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_entry (cs_cl *T, int64_t i, int64_t j, cs_complex_t x) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_lusol (int64_t order, const cs_cl *A, cs_complex_t *b,
+CS_PUBLIC int64_t cs_cl_cholsol (int64_t order, const cs_cl *A, cs_complex_t *b) ;
+CS_PUBLIC int64_t cs_cl_dupl (cs_cl *A) ;
+CS_PUBLIC int64_t cs_cl_entry (cs_cl *T, int64_t i, int64_t j, cs_complex_t x) ;
+CS_PUBLIC int64_t cs_cl_lusol (int64_t order, const cs_cl *A, cs_complex_t *b,
     double tol) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_gaxpy (const cs_cl *A, const cs_complex_t *x, cs_complex_t *y) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_multiply (const cs_cl *A, const cs_cl *B) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_qrsol (int64_t order, const cs_cl *A, cs_complex_t *b) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_transpose (const cs_cl *A, int64_t values) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_compress (const cs_cl *T) ;
-SUITESPARSE_PUBLIC double cs_cl_norm (const cs_cl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_print (const cs_cl *A, int64_t brief) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_load (FILE *f) ;
+CS_PUBLIC int64_t cs_cl_gaxpy (const cs_cl *A, const cs_complex_t *x, cs_complex_t *y) ;
+CS_PUBLIC cs_cl *cs_cl_multiply (const cs_cl *A, const cs_cl *B) ;
+CS_PUBLIC int64_t cs_cl_qrsol (int64_t order, const cs_cl *A, cs_complex_t *b) ;
+CS_PUBLIC cs_cl *cs_cl_transpose (const cs_cl *A, int64_t values) ;
+CS_PUBLIC cs_cl *cs_cl_compress (const cs_cl *T) ;
+CS_PUBLIC double cs_cl_norm (const cs_cl *A) ;
+CS_PUBLIC int64_t cs_cl_print (const cs_cl *A, int64_t brief) ;
+CS_PUBLIC cs_cl *cs_cl_load (FILE *f) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC void *cs_cl_calloc (int64_t n, size_t size) ;
-SUITESPARSE_PUBLIC void *cs_cl_free (void *p) ;
-SUITESPARSE_PUBLIC void *cs_cl_realloc (void *p, int64_t n, size_t size, int64_t *ok) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_spalloc (int64_t m, int64_t n, int64_t nzmax,
+CS_PUBLIC void *cs_cl_calloc (int64_t n, size_t size) ;
+CS_PUBLIC void *cs_cl_free (void *p) ;
+CS_PUBLIC void *cs_cl_realloc (void *p, int64_t n, size_t size, int64_t *ok) ;
+CS_PUBLIC cs_cl *cs_cl_spalloc (int64_t m, int64_t n, int64_t nzmax,
     int64_t values, int64_t t) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_spfree (cs_cl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_sprealloc (cs_cl *A, int64_t nzmax) ;
-SUITESPARSE_PUBLIC void *cs_cl_malloc (int64_t n, size_t size) ;
+CS_PUBLIC cs_cl *cs_cl_spfree (cs_cl *A) ;
+CS_PUBLIC int64_t cs_cl_sprealloc (cs_cl *A, int64_t nzmax) ;
+CS_PUBLIC void *cs_cl_malloc (int64_t n, size_t size) ;
 
 /* --- secondary CSparse routines and data structures ----------------------- */
 
@@ -550,73 +576,73 @@ typedef struct cs_cl_dmperm_results    /* cs_cl_dmperm or cs_cl_scc output */
     int64_t cc [5] ;   /* coarse column decomposition */
 } cs_cld ;
 
-SUITESPARSE_PUBLIC int64_t *cs_cl_amd (int64_t order, const cs_cl *A) ;
-SUITESPARSE_PUBLIC cs_cln *cs_cl_chol (const cs_cl *A, const cs_cls *S) ;
-SUITESPARSE_PUBLIC cs_cld *cs_cl_dmperm (const cs_cl *A, int64_t seed) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_droptol (cs_cl *A, double tol) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_dropzeros (cs_cl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_happly (const cs_cl *V, int64_t i, double beta,
+CS_PUBLIC int64_t *cs_cl_amd (int64_t order, const cs_cl *A) ;
+CS_PUBLIC cs_cln *cs_cl_chol (const cs_cl *A, const cs_cls *S) ;
+CS_PUBLIC cs_cld *cs_cl_dmperm (const cs_cl *A, int64_t seed) ;
+CS_PUBLIC int64_t cs_cl_droptol (cs_cl *A, double tol) ;
+CS_PUBLIC int64_t cs_cl_dropzeros (cs_cl *A) ;
+CS_PUBLIC int64_t cs_cl_happly (const cs_cl *V, int64_t i, double beta,
     cs_complex_t *x) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_ipvec (const int64_t *p, const cs_complex_t *b,
+CS_PUBLIC int64_t cs_cl_ipvec (const int64_t *p, const cs_complex_t *b,
     cs_complex_t *x, int64_t n) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_lsolve (const cs_cl *L, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_ltsolve (const cs_cl *L, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC cs_cln *cs_cl_lu (const cs_cl *A, const cs_cls *S, double tol) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_permute (const cs_cl *A, const int64_t *pinv, const int64_t *q,
+CS_PUBLIC int64_t cs_cl_lsolve (const cs_cl *L, cs_complex_t *x) ;
+CS_PUBLIC int64_t cs_cl_ltsolve (const cs_cl *L, cs_complex_t *x) ;
+CS_PUBLIC cs_cln *cs_cl_lu (const cs_cl *A, const cs_cls *S, double tol) ;
+CS_PUBLIC cs_cl *cs_cl_permute (const cs_cl *A, const int64_t *pinv, const int64_t *q,
     int64_t values) ;
-SUITESPARSE_PUBLIC int64_t *cs_cl_pinv (const int64_t *p, int64_t n) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_pvec (const int64_t *p, const cs_complex_t *b,
+CS_PUBLIC int64_t *cs_cl_pinv (const int64_t *p, int64_t n) ;
+CS_PUBLIC int64_t cs_cl_pvec (const int64_t *p, const cs_complex_t *b,
     cs_complex_t *x, int64_t n) ;
-SUITESPARSE_PUBLIC cs_cln *cs_cl_qr (const cs_cl *A, const cs_cls *S) ;
-SUITESPARSE_PUBLIC cs_cls *cs_cl_schol (int64_t order, const cs_cl *A) ;
-SUITESPARSE_PUBLIC cs_cls *cs_cl_sqr (int64_t order, const cs_cl *A, int64_t qr) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_symperm (const cs_cl *A, const int64_t *pinv, int64_t values) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_usolve (const cs_cl *U, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_utsolve (const cs_cl *U, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_updown (cs_cl *L, int64_t sigma, const cs_cl *C,
+CS_PUBLIC cs_cln *cs_cl_qr (const cs_cl *A, const cs_cls *S) ;
+CS_PUBLIC cs_cls *cs_cl_schol (int64_t order, const cs_cl *A) ;
+CS_PUBLIC cs_cls *cs_cl_sqr (int64_t order, const cs_cl *A, int64_t qr) ;
+CS_PUBLIC cs_cl *cs_cl_symperm (const cs_cl *A, const int64_t *pinv, int64_t values) ;
+CS_PUBLIC int64_t cs_cl_usolve (const cs_cl *U, cs_complex_t *x) ;
+CS_PUBLIC int64_t cs_cl_utsolve (const cs_cl *U, cs_complex_t *x) ;
+CS_PUBLIC int64_t cs_cl_updown (cs_cl *L, int64_t sigma, const cs_cl *C,
     const int64_t *parent) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC cs_cls *cs_cl_sfree (cs_cls *S) ;
-SUITESPARSE_PUBLIC cs_cln *cs_cl_nfree (cs_cln *N) ;
-SUITESPARSE_PUBLIC cs_cld *cs_cl_dfree (cs_cld *D) ;
+CS_PUBLIC cs_cls *cs_cl_sfree (cs_cls *S) ;
+CS_PUBLIC cs_cln *cs_cl_nfree (cs_cln *N) ;
+CS_PUBLIC cs_cld *cs_cl_dfree (cs_cld *D) ;
 
 /* --- tertiary CSparse routines -------------------------------------------- */
 
-SUITESPARSE_PUBLIC int64_t *cs_cl_counts (const cs_cl *A, const int64_t *parent,
+CS_PUBLIC int64_t *cs_cl_counts (const cs_cl *A, const int64_t *parent,
     const int64_t *post, int64_t ata) ;
-SUITESPARSE_PUBLIC double cs_cl_cumsum (int64_t *p, int64_t *c, int64_t n) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_dfs (int64_t j, cs_cl *G, int64_t top, int64_t *xi,
+CS_PUBLIC double cs_cl_cumsum (int64_t *p, int64_t *c, int64_t n) ;
+CS_PUBLIC int64_t cs_cl_dfs (int64_t j, cs_cl *G, int64_t top, int64_t *xi,
     int64_t *pstack, const int64_t *pinv) ;
-SUITESPARSE_PUBLIC int64_t *cs_cl_etree (const cs_cl *A, int64_t ata) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_fkeep (cs_cl *A,
+CS_PUBLIC int64_t *cs_cl_etree (const cs_cl *A, int64_t ata) ;
+CS_PUBLIC int64_t cs_cl_fkeep (cs_cl *A,
     int64_t (*fkeep) (int64_t, int64_t, cs_complex_t, void *),
     void *other) ;
-SUITESPARSE_PUBLIC cs_complex_t cs_cl_house (cs_complex_t *x, double *beta, int64_t n) ;
-SUITESPARSE_PUBLIC int64_t *cs_cl_maxtrans (const cs_cl *A, int64_t seed) ;
-SUITESPARSE_PUBLIC int64_t *cs_cl_post (const int64_t *parent, int64_t n) ;
-SUITESPARSE_PUBLIC cs_cld *cs_cl_scc (cs_cl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_scatter (const cs_cl *A, int64_t j, cs_complex_t beta,
+CS_PUBLIC cs_complex_t cs_cl_house (cs_complex_t *x, double *beta, int64_t n) ;
+CS_PUBLIC int64_t *cs_cl_maxtrans (const cs_cl *A, int64_t seed) ;
+CS_PUBLIC int64_t *cs_cl_post (const int64_t *parent, int64_t n) ;
+CS_PUBLIC cs_cld *cs_cl_scc (cs_cl *A) ;
+CS_PUBLIC int64_t cs_cl_scatter (const cs_cl *A, int64_t j, cs_complex_t beta,
     int64_t *w, cs_complex_t *x, int64_t mark,cs_cl *C, int64_t nz) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_tdfs (int64_t j, int64_t k, int64_t *head,
+CS_PUBLIC int64_t cs_cl_tdfs (int64_t j, int64_t k, int64_t *head,
     const int64_t *next, int64_t *post, int64_t *stack) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_leaf (int64_t i, int64_t j, const int64_t *first,
+CS_PUBLIC int64_t cs_cl_leaf (int64_t i, int64_t j, const int64_t *first,
     int64_t *maxfirst, int64_t *prevleaf, int64_t *ancestor,
     int64_t *jleaf) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_reach (cs_cl *G, const cs_cl *B, int64_t k, int64_t *xi,
+CS_PUBLIC int64_t cs_cl_reach (cs_cl *G, const cs_cl *B, int64_t k, int64_t *xi,
     const int64_t *pinv) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_spsolve (cs_cl *L, const cs_cl *B, int64_t k, int64_t *xi, 
+CS_PUBLIC int64_t cs_cl_spsolve (cs_cl *L, const cs_cl *B, int64_t k, int64_t *xi,
     cs_complex_t *x, const int64_t *pinv, int64_t lo) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_ereach (const cs_cl *A, int64_t k, const int64_t *parent,
+CS_PUBLIC int64_t cs_cl_ereach (const cs_cl *A, int64_t k, const int64_t *parent,
     int64_t *s, int64_t *w) ;
-SUITESPARSE_PUBLIC int64_t *cs_cl_randperm (int64_t n, int64_t seed) ;
+CS_PUBLIC int64_t *cs_cl_randperm (int64_t n, int64_t seed) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC cs_cld *cs_cl_dalloc (int64_t m, int64_t n) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_done (cs_cl *C, void *w, void *x, int64_t ok) ;
-SUITESPARSE_PUBLIC int64_t *cs_cl_idone (int64_t *p, cs_cl *C, void *w, int64_t ok) ;
-SUITESPARSE_PUBLIC cs_cln *cs_cl_ndone (cs_cln *N, cs_cl *C, void *w, void *x, int64_t ok) ;
-SUITESPARSE_PUBLIC cs_cld *cs_cl_ddone (cs_cld *D, cs_cl *C, void *w, int64_t ok) ;
+CS_PUBLIC cs_cld *cs_cl_dalloc (int64_t m, int64_t n) ;
+CS_PUBLIC cs_cl *cs_cl_done (cs_cl *C, void *w, void *x, int64_t ok) ;
+CS_PUBLIC int64_t *cs_cl_idone (int64_t *p, cs_cl *C, void *w, int64_t ok) ;
+CS_PUBLIC cs_cln *cs_cl_ndone (cs_cln *N, cs_cl *C, void *w, void *x, int64_t ok) ;
+CS_PUBLIC cs_cld *cs_cl_ddone (cs_cld *D, cs_cl *C, void *w, int64_t ok) ;
 
 #endif
 
@@ -760,10 +786,10 @@ SUITESPARSE_PUBLIC cs_cld *cs_cl_ddone (cs_cld *D, cs_cl *C, void *w, int64_t ok
 /* -------------------------------------------------------------------------- */
 
 #ifndef NCOMPLEX
-SUITESPARSE_PUBLIC cs_di *cs_i_real (cs_ci *A, int32_t real) ;
-SUITESPARSE_PUBLIC cs_ci *cs_i_complex (cs_di *A, int32_t real) ;
-SUITESPARSE_PUBLIC cs_dl *cs_l_real (cs_cl *A, int64_t real) ;
-SUITESPARSE_PUBLIC cs_cl *cs_l_complex (cs_dl *A, int64_t real) ;
+CS_PUBLIC cs_di *cs_i_real (cs_ci *A, int32_t real) ;
+CS_PUBLIC cs_ci *cs_i_complex (cs_di *A, int32_t real) ;
+CS_PUBLIC cs_dl *cs_l_real (cs_cl *A, int64_t real) ;
+CS_PUBLIC cs_cl *cs_l_complex (cs_dl *A, int64_t real) ;
 #endif
 
 #ifdef __cplusplus

--- a/CXSparse/Include/cs.h
+++ b/CXSparse/Include/cs.h
@@ -49,10 +49,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( CS_LIBRARY )
@@ -68,7 +68,7 @@ extern "C" {
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define CS_PUBLIC extern
 
 #endif

--- a/CXSparse/Include/cs.h
+++ b/CXSparse/Include/cs.h
@@ -47,6 +47,32 @@ extern "C" {
 #define CXSPARSE
 
 #include "SuiteSparse_config.h"
+
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( CS_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define CS_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( CS_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define CS_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define CS_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define CS_PUBLIC extern
+
+#endif
+
 #define cs_long_t       int64_t
 #define cs_long_t_id    "%" PRId64
 #define cs_long_t_max   INT64_MAX
@@ -68,29 +94,29 @@ typedef struct cs_di_sparse  /* matrix in compressed-column or triplet form */
     int32_t nz ;    /* # of entries in triplet matrix, -1 for compressed-col */
 } cs_di ;
 
-SUITESPARSE_PUBLIC cs_di *cs_di_add (const cs_di *A, const cs_di *B, double alpha, double beta) ;
-SUITESPARSE_PUBLIC int32_t cs_di_cholsol (int32_t order, const cs_di *A, double *b) ;
-SUITESPARSE_PUBLIC int32_t cs_di_dupl (cs_di *A) ;
-SUITESPARSE_PUBLIC int32_t cs_di_entry (cs_di *T, int32_t i, int32_t j, double x) ;
-SUITESPARSE_PUBLIC int32_t cs_di_lusol (int32_t order, const cs_di *A, double *b, double tol) ;
-SUITESPARSE_PUBLIC int32_t cs_di_gaxpy (const cs_di *A, const double *x, double *y) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_multiply (const cs_di *A, const cs_di *B) ;
-SUITESPARSE_PUBLIC int32_t cs_di_qrsol (int32_t order, const cs_di *A, double *b) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_transpose (const cs_di *A, int32_t values) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_compress (const cs_di *T) ;
-SUITESPARSE_PUBLIC double cs_di_norm (const cs_di *A) ;
-SUITESPARSE_PUBLIC int32_t cs_di_print (const cs_di *A, int32_t brief) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_load (FILE *f) ;
+CS_PUBLIC cs_di *cs_di_add (const cs_di *A, const cs_di *B, double alpha, double beta) ;
+CS_PUBLIC int32_t cs_di_cholsol (int32_t order, const cs_di *A, double *b) ;
+CS_PUBLIC int32_t cs_di_dupl (cs_di *A) ;
+CS_PUBLIC int32_t cs_di_entry (cs_di *T, int32_t i, int32_t j, double x) ;
+CS_PUBLIC int32_t cs_di_lusol (int32_t order, const cs_di *A, double *b, double tol) ;
+CS_PUBLIC int32_t cs_di_gaxpy (const cs_di *A, const double *x, double *y) ;
+CS_PUBLIC cs_di *cs_di_multiply (const cs_di *A, const cs_di *B) ;
+CS_PUBLIC int32_t cs_di_qrsol (int32_t order, const cs_di *A, double *b) ;
+CS_PUBLIC cs_di *cs_di_transpose (const cs_di *A, int32_t values) ;
+CS_PUBLIC cs_di *cs_di_compress (const cs_di *T) ;
+CS_PUBLIC double cs_di_norm (const cs_di *A) ;
+CS_PUBLIC int32_t cs_di_print (const cs_di *A, int32_t brief) ;
+CS_PUBLIC cs_di *cs_di_load (FILE *f) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC void *cs_di_calloc (int32_t n, size_t size) ;
-SUITESPARSE_PUBLIC void *cs_di_free (void *p) ;
-SUITESPARSE_PUBLIC void *cs_di_realloc (void *p, int32_t n, size_t size, int32_t *ok) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_spalloc (int32_t m, int32_t n, int32_t nzmax, int32_t values,
+CS_PUBLIC void *cs_di_calloc (int32_t n, size_t size) ;
+CS_PUBLIC void *cs_di_free (void *p) ;
+CS_PUBLIC void *cs_di_realloc (void *p, int32_t n, size_t size, int32_t *ok) ;
+CS_PUBLIC cs_di *cs_di_spalloc (int32_t m, int32_t n, int32_t nzmax, int32_t values,
     int32_t t) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_spfree (cs_di *A) ;
-SUITESPARSE_PUBLIC int32_t cs_di_sprealloc (cs_di *A, int32_t nzmax) ;
-SUITESPARSE_PUBLIC void *cs_di_malloc (int32_t n, size_t size) ;
+CS_PUBLIC cs_di *cs_di_spfree (cs_di *A) ;
+CS_PUBLIC int32_t cs_di_sprealloc (cs_di *A, int32_t nzmax) ;
+CS_PUBLIC void *cs_di_malloc (int32_t n, size_t size) ;
 
 /* --- secondary CSparse routines and data structures ----------------------- */
 
@@ -125,68 +151,68 @@ typedef struct cs_di_dmperm_results    /* cs_di_dmperm or cs_di_scc output */
     int32_t cc [5] ; /* coarse column decomposition */
 } cs_did ;
 
-SUITESPARSE_PUBLIC int32_t *cs_di_amd (int32_t order, const cs_di *A) ;
-SUITESPARSE_PUBLIC cs_din *cs_di_chol (const cs_di *A, const cs_dis *S) ;
-SUITESPARSE_PUBLIC cs_did *cs_di_dmperm (const cs_di *A, int32_t seed) ;
-SUITESPARSE_PUBLIC int32_t cs_di_droptol (cs_di *A, double tol) ;
-SUITESPARSE_PUBLIC int32_t cs_di_dropzeros (cs_di *A) ;
-SUITESPARSE_PUBLIC int32_t cs_di_happly (const cs_di *V, int32_t i, double beta, double *x) ;
-SUITESPARSE_PUBLIC int32_t cs_di_ipvec (const int32_t *p, const double *b, double *x, int32_t n) ;
-SUITESPARSE_PUBLIC int32_t cs_di_lsolve (const cs_di *L, double *x) ;
-SUITESPARSE_PUBLIC int32_t cs_di_ltsolve (const cs_di *L, double *x) ;
-SUITESPARSE_PUBLIC cs_din *cs_di_lu (const cs_di *A, const cs_dis *S, double tol) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_permute (const cs_di *A, const int32_t *pinv, const int32_t *q,
+CS_PUBLIC int32_t *cs_di_amd (int32_t order, const cs_di *A) ;
+CS_PUBLIC cs_din *cs_di_chol (const cs_di *A, const cs_dis *S) ;
+CS_PUBLIC cs_did *cs_di_dmperm (const cs_di *A, int32_t seed) ;
+CS_PUBLIC int32_t cs_di_droptol (cs_di *A, double tol) ;
+CS_PUBLIC int32_t cs_di_dropzeros (cs_di *A) ;
+CS_PUBLIC int32_t cs_di_happly (const cs_di *V, int32_t i, double beta, double *x) ;
+CS_PUBLIC int32_t cs_di_ipvec (const int32_t *p, const double *b, double *x, int32_t n) ;
+CS_PUBLIC int32_t cs_di_lsolve (const cs_di *L, double *x) ;
+CS_PUBLIC int32_t cs_di_ltsolve (const cs_di *L, double *x) ;
+CS_PUBLIC cs_din *cs_di_lu (const cs_di *A, const cs_dis *S, double tol) ;
+CS_PUBLIC cs_di *cs_di_permute (const cs_di *A, const int32_t *pinv, const int32_t *q,
     int32_t values) ;
-SUITESPARSE_PUBLIC int32_t *cs_di_pinv (const int32_t *p, int32_t n) ;
-SUITESPARSE_PUBLIC int32_t cs_di_pvec (const int32_t *p, const double *b, double *x, int32_t n) ;
-SUITESPARSE_PUBLIC cs_din *cs_di_qr (const cs_di *A, const cs_dis *S) ;
-SUITESPARSE_PUBLIC cs_dis *cs_di_schol (int32_t order, const cs_di *A) ;
-SUITESPARSE_PUBLIC cs_dis *cs_di_sqr (int32_t order, const cs_di *A, int32_t qr) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_symperm (const cs_di *A, const int32_t *pinv, int32_t values) ;
-SUITESPARSE_PUBLIC int32_t cs_di_usolve (const cs_di *U, double *x) ;
-SUITESPARSE_PUBLIC int32_t cs_di_utsolve (const cs_di *U, double *x) ;
-SUITESPARSE_PUBLIC int32_t cs_di_updown (cs_di *L, int32_t sigma, const cs_di *C,
+CS_PUBLIC int32_t *cs_di_pinv (const int32_t *p, int32_t n) ;
+CS_PUBLIC int32_t cs_di_pvec (const int32_t *p, const double *b, double *x, int32_t n) ;
+CS_PUBLIC cs_din *cs_di_qr (const cs_di *A, const cs_dis *S) ;
+CS_PUBLIC cs_dis *cs_di_schol (int32_t order, const cs_di *A) ;
+CS_PUBLIC cs_dis *cs_di_sqr (int32_t order, const cs_di *A, int32_t qr) ;
+CS_PUBLIC cs_di *cs_di_symperm (const cs_di *A, const int32_t *pinv, int32_t values) ;
+CS_PUBLIC int32_t cs_di_usolve (const cs_di *U, double *x) ;
+CS_PUBLIC int32_t cs_di_utsolve (const cs_di *U, double *x) ;
+CS_PUBLIC int32_t cs_di_updown (cs_di *L, int32_t sigma, const cs_di *C,
     const int32_t *parent) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC cs_dis *cs_di_sfree (cs_dis *S) ;
-SUITESPARSE_PUBLIC cs_din *cs_di_nfree (cs_din *N) ;
-SUITESPARSE_PUBLIC cs_did *cs_di_dfree (cs_did *D) ;
+CS_PUBLIC cs_dis *cs_di_sfree (cs_dis *S) ;
+CS_PUBLIC cs_din *cs_di_nfree (cs_din *N) ;
+CS_PUBLIC cs_did *cs_di_dfree (cs_did *D) ;
 
 /* --- tertiary CSparse routines -------------------------------------------- */
 
-SUITESPARSE_PUBLIC int32_t *cs_di_counts (const cs_di *A, const int32_t *parent,
+CS_PUBLIC int32_t *cs_di_counts (const cs_di *A, const int32_t *parent,
     const int32_t *post, int32_t ata) ;
-SUITESPARSE_PUBLIC double cs_di_cumsum (int32_t *p, int32_t *c, int32_t n) ;
-SUITESPARSE_PUBLIC int32_t cs_di_dfs (int32_t j, cs_di *G, int32_t top, int32_t *xi,
+CS_PUBLIC double cs_di_cumsum (int32_t *p, int32_t *c, int32_t n) ;
+CS_PUBLIC int32_t cs_di_dfs (int32_t j, cs_di *G, int32_t top, int32_t *xi,
     int32_t *pstack, const int32_t *pinv) ;
-SUITESPARSE_PUBLIC int32_t *cs_di_etree (const cs_di *A, int32_t ata) ;
-SUITESPARSE_PUBLIC int32_t cs_di_fkeep (cs_di *A,
+CS_PUBLIC int32_t *cs_di_etree (const cs_di *A, int32_t ata) ;
+CS_PUBLIC int32_t cs_di_fkeep (cs_di *A,
     int32_t (*fkeep) (int32_t, int32_t, double, void *), void *other) ;
-SUITESPARSE_PUBLIC double cs_di_house (double *x, double *beta, int32_t n) ;
-SUITESPARSE_PUBLIC int32_t *cs_di_maxtrans (const cs_di *A, int32_t seed) ;
-SUITESPARSE_PUBLIC int32_t *cs_di_post (const int32_t *parent, int32_t n) ;
-SUITESPARSE_PUBLIC cs_did *cs_di_scc (cs_di *A) ;
-SUITESPARSE_PUBLIC int32_t cs_di_scatter (const cs_di *A, int32_t j, double beta, int32_t *w,
+CS_PUBLIC double cs_di_house (double *x, double *beta, int32_t n) ;
+CS_PUBLIC int32_t *cs_di_maxtrans (const cs_di *A, int32_t seed) ;
+CS_PUBLIC int32_t *cs_di_post (const int32_t *parent, int32_t n) ;
+CS_PUBLIC cs_did *cs_di_scc (cs_di *A) ;
+CS_PUBLIC int32_t cs_di_scatter (const cs_di *A, int32_t j, double beta, int32_t *w,
     double *x, int32_t mark, cs_di *C, int32_t nz) ;
-SUITESPARSE_PUBLIC int32_t cs_di_tdfs (int32_t j, int32_t k, int32_t *head, const int32_t *next,
+CS_PUBLIC int32_t cs_di_tdfs (int32_t j, int32_t k, int32_t *head, const int32_t *next,
     int32_t *post, int32_t *stack) ;
-SUITESPARSE_PUBLIC int32_t cs_di_leaf (int32_t i, int32_t j, const int32_t *first,
+CS_PUBLIC int32_t cs_di_leaf (int32_t i, int32_t j, const int32_t *first,
     int32_t *maxfirst, int32_t *prevleaf, int32_t *ancestor, int32_t *jleaf) ;
-SUITESPARSE_PUBLIC int32_t cs_di_reach (cs_di *G, const cs_di *B, int32_t k, int32_t *xi,
+CS_PUBLIC int32_t cs_di_reach (cs_di *G, const cs_di *B, int32_t k, int32_t *xi,
     const int32_t *pinv) ;
-SUITESPARSE_PUBLIC int32_t cs_di_spsolve (cs_di *L, const cs_di *B, int32_t k, int32_t *xi,
+CS_PUBLIC int32_t cs_di_spsolve (cs_di *L, const cs_di *B, int32_t k, int32_t *xi,
     double *x, const int32_t *pinv, int32_t lo) ;
-SUITESPARSE_PUBLIC int32_t cs_di_ereach (const cs_di *A, int32_t k, const int32_t *parent,
+CS_PUBLIC int32_t cs_di_ereach (const cs_di *A, int32_t k, const int32_t *parent,
     int32_t *s, int32_t *w) ;
-SUITESPARSE_PUBLIC int32_t *cs_di_randperm (int32_t n, int32_t seed) ;
+CS_PUBLIC int32_t *cs_di_randperm (int32_t n, int32_t seed) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC cs_did *cs_di_dalloc (int32_t m, int32_t n) ;
-SUITESPARSE_PUBLIC cs_di *cs_di_done (cs_di *C, void *w, void *x, int32_t ok) ;
-SUITESPARSE_PUBLIC int32_t *cs_di_idone (int32_t *p, cs_di *C, void *w, int32_t ok) ;
-SUITESPARSE_PUBLIC cs_din *cs_di_ndone (cs_din *N, cs_di *C, void *w, void *x, int32_t ok) ;
-SUITESPARSE_PUBLIC cs_did *cs_di_ddone (cs_did *D, cs_di *C, void *w, int32_t ok) ;
+CS_PUBLIC cs_did *cs_di_dalloc (int32_t m, int32_t n) ;
+CS_PUBLIC cs_di *cs_di_done (cs_di *C, void *w, void *x, int32_t ok) ;
+CS_PUBLIC int32_t *cs_di_idone (int32_t *p, cs_di *C, void *w, int32_t ok) ;
+CS_PUBLIC cs_din *cs_di_ndone (cs_din *N, cs_di *C, void *w, void *x, int32_t ok) ;
+CS_PUBLIC cs_did *cs_di_ddone (cs_did *D, cs_di *C, void *w, int32_t ok) ;
 
 
 /* -------------------------------------------------------------------------- */
@@ -206,29 +232,29 @@ typedef struct cs_dl_sparse  /* matrix in compressed-column or triplet form */
     int64_t nz ;  /* # of entries in triplet matrix, -1 for compressed-col */
 } cs_dl ;
 
-SUITESPARSE_PUBLIC cs_dl *cs_dl_add (const cs_dl *A, const cs_dl *B, double alpha, double beta) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_cholsol (int64_t order, const cs_dl *A, double *b) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_dupl (cs_dl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_entry (cs_dl *T, int64_t i, int64_t j, double x) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_lusol (int64_t order, const cs_dl *A, double *b, double tol) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_gaxpy (const cs_dl *A, const double *x, double *y) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_multiply (const cs_dl *A, const cs_dl *B) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_qrsol (int64_t order, const cs_dl *A, double *b) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_transpose (const cs_dl *A, int64_t values) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_compress (const cs_dl *T) ;
-SUITESPARSE_PUBLIC double cs_dl_norm (const cs_dl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_print (const cs_dl *A, int64_t brief) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_load (FILE *f) ;
+CS_PUBLIC cs_dl *cs_dl_add (const cs_dl *A, const cs_dl *B, double alpha, double beta) ;
+CS_PUBLIC int64_t cs_dl_cholsol (int64_t order, const cs_dl *A, double *b) ;
+CS_PUBLIC int64_t cs_dl_dupl (cs_dl *A) ;
+CS_PUBLIC int64_t cs_dl_entry (cs_dl *T, int64_t i, int64_t j, double x) ;
+CS_PUBLIC int64_t cs_dl_lusol (int64_t order, const cs_dl *A, double *b, double tol) ;
+CS_PUBLIC int64_t cs_dl_gaxpy (const cs_dl *A, const double *x, double *y) ;
+CS_PUBLIC cs_dl *cs_dl_multiply (const cs_dl *A, const cs_dl *B) ;
+CS_PUBLIC int64_t cs_dl_qrsol (int64_t order, const cs_dl *A, double *b) ;
+CS_PUBLIC cs_dl *cs_dl_transpose (const cs_dl *A, int64_t values) ;
+CS_PUBLIC cs_dl *cs_dl_compress (const cs_dl *T) ;
+CS_PUBLIC double cs_dl_norm (const cs_dl *A) ;
+CS_PUBLIC int64_t cs_dl_print (const cs_dl *A, int64_t brief) ;
+CS_PUBLIC cs_dl *cs_dl_load (FILE *f) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC void *cs_dl_calloc (int64_t n, size_t size) ;
-SUITESPARSE_PUBLIC void *cs_dl_free (void *p) ;
-SUITESPARSE_PUBLIC void *cs_dl_realloc (void *p, int64_t n, size_t size, int64_t *ok) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_spalloc (int64_t m, int64_t n, int64_t nzmax,
+CS_PUBLIC void *cs_dl_calloc (int64_t n, size_t size) ;
+CS_PUBLIC void *cs_dl_free (void *p) ;
+CS_PUBLIC void *cs_dl_realloc (void *p, int64_t n, size_t size, int64_t *ok) ;
+CS_PUBLIC cs_dl *cs_dl_spalloc (int64_t m, int64_t n, int64_t nzmax,
     int64_t values, int64_t t) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_spfree (cs_dl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_sprealloc (cs_dl *A, int64_t nzmax) ;
-SUITESPARSE_PUBLIC void *cs_dl_malloc (int64_t n, size_t size) ;
+CS_PUBLIC cs_dl *cs_dl_spfree (cs_dl *A) ;
+CS_PUBLIC int64_t cs_dl_sprealloc (cs_dl *A, int64_t nzmax) ;
+CS_PUBLIC void *cs_dl_malloc (int64_t n, size_t size) ;
 
 /* --- secondary CSparse routines and data structures ----------------------- */
 
@@ -263,71 +289,71 @@ typedef struct cs_dl_dmperm_results    /* cs_dl_dmperm or cs_dl_scc output */
     int64_t cc [5] ;    /* coarse column decomposition */
 } cs_dld ;
 
-SUITESPARSE_PUBLIC int64_t *cs_dl_amd (int64_t order, const cs_dl *A) ;
-SUITESPARSE_PUBLIC cs_dln *cs_dl_chol (const cs_dl *A, const cs_dls *S) ;
-SUITESPARSE_PUBLIC cs_dld *cs_dl_dmperm (const cs_dl *A, int64_t seed) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_droptol (cs_dl *A, double tol) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_dropzeros (cs_dl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_happly (const cs_dl *V, int64_t i, double beta, double *x) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_ipvec (const int64_t *p, const double *b, double *x,
+CS_PUBLIC int64_t *cs_dl_amd (int64_t order, const cs_dl *A) ;
+CS_PUBLIC cs_dln *cs_dl_chol (const cs_dl *A, const cs_dls *S) ;
+CS_PUBLIC cs_dld *cs_dl_dmperm (const cs_dl *A, int64_t seed) ;
+CS_PUBLIC int64_t cs_dl_droptol (cs_dl *A, double tol) ;
+CS_PUBLIC int64_t cs_dl_dropzeros (cs_dl *A) ;
+CS_PUBLIC int64_t cs_dl_happly (const cs_dl *V, int64_t i, double beta, double *x) ;
+CS_PUBLIC int64_t cs_dl_ipvec (const int64_t *p, const double *b, double *x,
     int64_t n) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_lsolve (const cs_dl *L, double *x) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_ltsolve (const cs_dl *L, double *x) ;
-SUITESPARSE_PUBLIC cs_dln *cs_dl_lu (const cs_dl *A, const cs_dls *S, double tol) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_permute (const cs_dl *A, const int64_t *pinv, const int64_t *q,
+CS_PUBLIC int64_t cs_dl_lsolve (const cs_dl *L, double *x) ;
+CS_PUBLIC int64_t cs_dl_ltsolve (const cs_dl *L, double *x) ;
+CS_PUBLIC cs_dln *cs_dl_lu (const cs_dl *A, const cs_dls *S, double tol) ;
+CS_PUBLIC cs_dl *cs_dl_permute (const cs_dl *A, const int64_t *pinv, const int64_t *q,
     int64_t values) ;
-SUITESPARSE_PUBLIC int64_t *cs_dl_pinv (const int64_t *p, int64_t n) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_pvec (const int64_t *p, const double *b, double *x,
+CS_PUBLIC int64_t *cs_dl_pinv (const int64_t *p, int64_t n) ;
+CS_PUBLIC int64_t cs_dl_pvec (const int64_t *p, const double *b, double *x,
     int64_t n) ;
-SUITESPARSE_PUBLIC cs_dln *cs_dl_qr (const cs_dl *A, const cs_dls *S) ;
-SUITESPARSE_PUBLIC cs_dls *cs_dl_schol (int64_t order, const cs_dl *A) ;
-SUITESPARSE_PUBLIC cs_dls *cs_dl_sqr (int64_t order, const cs_dl *A, int64_t qr) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_symperm (const cs_dl *A, const int64_t *pinv, int64_t values) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_usolve (const cs_dl *U, double *x) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_utsolve (const cs_dl *U, double *x) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_updown (cs_dl *L, int64_t sigma, const cs_dl *C,
+CS_PUBLIC cs_dln *cs_dl_qr (const cs_dl *A, const cs_dls *S) ;
+CS_PUBLIC cs_dls *cs_dl_schol (int64_t order, const cs_dl *A) ;
+CS_PUBLIC cs_dls *cs_dl_sqr (int64_t order, const cs_dl *A, int64_t qr) ;
+CS_PUBLIC cs_dl *cs_dl_symperm (const cs_dl *A, const int64_t *pinv, int64_t values) ;
+CS_PUBLIC int64_t cs_dl_usolve (const cs_dl *U, double *x) ;
+CS_PUBLIC int64_t cs_dl_utsolve (const cs_dl *U, double *x) ;
+CS_PUBLIC int64_t cs_dl_updown (cs_dl *L, int64_t sigma, const cs_dl *C,
     const int64_t *parent) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC cs_dls *cs_dl_sfree (cs_dls *S) ;
-SUITESPARSE_PUBLIC cs_dln *cs_dl_nfree (cs_dln *N) ;
-SUITESPARSE_PUBLIC cs_dld *cs_dl_dfree (cs_dld *D) ;
+CS_PUBLIC cs_dls *cs_dl_sfree (cs_dls *S) ;
+CS_PUBLIC cs_dln *cs_dl_nfree (cs_dln *N) ;
+CS_PUBLIC cs_dld *cs_dl_dfree (cs_dld *D) ;
 
 /* --- tertiary CSparse routines -------------------------------------------- */
 
-SUITESPARSE_PUBLIC int64_t *cs_dl_counts (const cs_dl *A, const int64_t *parent,
+CS_PUBLIC int64_t *cs_dl_counts (const cs_dl *A, const int64_t *parent,
     const int64_t *post, int64_t ata) ;
-SUITESPARSE_PUBLIC double cs_dl_cumsum (int64_t *p, int64_t *c, int64_t n) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_dfs (int64_t j, cs_dl *G, int64_t top, int64_t *xi,
+CS_PUBLIC double cs_dl_cumsum (int64_t *p, int64_t *c, int64_t n) ;
+CS_PUBLIC int64_t cs_dl_dfs (int64_t j, cs_dl *G, int64_t top, int64_t *xi,
     int64_t *pstack, const int64_t *pinv) ;
-SUITESPARSE_PUBLIC int64_t *cs_dl_etree (const cs_dl *A, int64_t ata) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_fkeep (cs_dl *A,
+CS_PUBLIC int64_t *cs_dl_etree (const cs_dl *A, int64_t ata) ;
+CS_PUBLIC int64_t cs_dl_fkeep (cs_dl *A,
     int64_t (*fkeep) (int64_t, int64_t, double, void *), void *other) ;
-SUITESPARSE_PUBLIC double cs_dl_house (double *x, double *beta, int64_t n) ;
-SUITESPARSE_PUBLIC int64_t *cs_dl_maxtrans (const cs_dl *A, int64_t seed) ;
-SUITESPARSE_PUBLIC int64_t *cs_dl_post (const int64_t *parent, int64_t n) ;
-SUITESPARSE_PUBLIC cs_dld *cs_dl_scc (cs_dl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_scatter (const cs_dl *A, int64_t j, double beta, int64_t *w,
+CS_PUBLIC double cs_dl_house (double *x, double *beta, int64_t n) ;
+CS_PUBLIC int64_t *cs_dl_maxtrans (const cs_dl *A, int64_t seed) ;
+CS_PUBLIC int64_t *cs_dl_post (const int64_t *parent, int64_t n) ;
+CS_PUBLIC cs_dld *cs_dl_scc (cs_dl *A) ;
+CS_PUBLIC int64_t cs_dl_scatter (const cs_dl *A, int64_t j, double beta, int64_t *w,
     double *x, int64_t mark,cs_dl *C, int64_t nz) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_tdfs (int64_t j, int64_t k, int64_t *head,
+CS_PUBLIC int64_t cs_dl_tdfs (int64_t j, int64_t k, int64_t *head,
     const int64_t *next, int64_t *post, int64_t *stack) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_leaf (int64_t i, int64_t j, const int64_t *first,
+CS_PUBLIC int64_t cs_dl_leaf (int64_t i, int64_t j, const int64_t *first,
     int64_t *maxfirst, int64_t *prevleaf, int64_t *ancestor,
     int64_t *jleaf) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_reach (cs_dl *G, const cs_dl *B, int64_t k, int64_t *xi,
+CS_PUBLIC int64_t cs_dl_reach (cs_dl *G, const cs_dl *B, int64_t k, int64_t *xi,
     const int64_t *pinv) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_spsolve (cs_dl *L, const cs_dl *B, int64_t k, int64_t *xi,
+CS_PUBLIC int64_t cs_dl_spsolve (cs_dl *L, const cs_dl *B, int64_t k, int64_t *xi,
     double *x, const int64_t *pinv, int64_t lo) ;
-SUITESPARSE_PUBLIC int64_t cs_dl_ereach (const cs_dl *A, int64_t k, const int64_t *parent,
+CS_PUBLIC int64_t cs_dl_ereach (const cs_dl *A, int64_t k, const int64_t *parent,
     int64_t *s, int64_t *w) ;
-SUITESPARSE_PUBLIC int64_t *cs_dl_randperm (int64_t n, int64_t seed) ;
+CS_PUBLIC int64_t *cs_dl_randperm (int64_t n, int64_t seed) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC cs_dld *cs_dl_dalloc (int64_t m, int64_t n) ;
-SUITESPARSE_PUBLIC cs_dl *cs_dl_done (cs_dl *C, void *w, void *x, int64_t ok) ;
-SUITESPARSE_PUBLIC int64_t *cs_dl_idone (int64_t *p, cs_dl *C, void *w, int64_t ok) ;
-SUITESPARSE_PUBLIC cs_dln *cs_dl_ndone (cs_dln *N, cs_dl *C, void *w, void *x, int64_t ok) ;
-SUITESPARSE_PUBLIC cs_dld *cs_dl_ddone (cs_dld *D, cs_dl *C, void *w, int64_t ok) ;
+CS_PUBLIC cs_dld *cs_dl_dalloc (int64_t m, int64_t n) ;
+CS_PUBLIC cs_dl *cs_dl_done (cs_dl *C, void *w, void *x, int64_t ok) ;
+CS_PUBLIC int64_t *cs_dl_idone (int64_t *p, cs_dl *C, void *w, int64_t ok) ;
+CS_PUBLIC cs_dln *cs_dl_ndone (cs_dln *N, cs_dl *C, void *w, void *x, int64_t ok) ;
+CS_PUBLIC cs_dld *cs_dl_ddone (cs_dld *D, cs_dl *C, void *w, int64_t ok) ;
 
 
 /* -------------------------------------------------------------------------- */
@@ -349,31 +375,31 @@ typedef struct cs_ci_sparse  /* matrix in compressed-column or triplet form */
     int32_t nz ;  /* # of entries in triplet matrix, -1 for compressed-col */
 } cs_ci ;
 
-SUITESPARSE_PUBLIC cs_ci *cs_ci_add (const cs_ci *A, const cs_ci *B, cs_complex_t alpha,
+CS_PUBLIC cs_ci *cs_ci_add (const cs_ci *A, const cs_ci *B, cs_complex_t alpha,
     cs_complex_t beta) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_cholsol (int32_t order, const cs_ci *A, cs_complex_t *b) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_dupl (cs_ci *A) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_entry (cs_ci *T, int32_t i, int32_t j, cs_complex_t x) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_lusol (int32_t order, const cs_ci *A, cs_complex_t *b,
+CS_PUBLIC int32_t cs_ci_cholsol (int32_t order, const cs_ci *A, cs_complex_t *b) ;
+CS_PUBLIC int32_t cs_ci_dupl (cs_ci *A) ;
+CS_PUBLIC int32_t cs_ci_entry (cs_ci *T, int32_t i, int32_t j, cs_complex_t x) ;
+CS_PUBLIC int32_t cs_ci_lusol (int32_t order, const cs_ci *A, cs_complex_t *b,
     double tol) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_gaxpy (const cs_ci *A, const cs_complex_t *x, cs_complex_t *y) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_multiply (const cs_ci *A, const cs_ci *B) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_qrsol (int32_t order, const cs_ci *A, cs_complex_t *b) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_transpose (const cs_ci *A, int32_t values) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_compress (const cs_ci *T) ;
-SUITESPARSE_PUBLIC double cs_ci_norm (const cs_ci *A) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_print (const cs_ci *A, int32_t brief) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_load (FILE *f) ;
+CS_PUBLIC int32_t cs_ci_gaxpy (const cs_ci *A, const cs_complex_t *x, cs_complex_t *y) ;
+CS_PUBLIC cs_ci *cs_ci_multiply (const cs_ci *A, const cs_ci *B) ;
+CS_PUBLIC int32_t cs_ci_qrsol (int32_t order, const cs_ci *A, cs_complex_t *b) ;
+CS_PUBLIC cs_ci *cs_ci_transpose (const cs_ci *A, int32_t values) ;
+CS_PUBLIC cs_ci *cs_ci_compress (const cs_ci *T) ;
+CS_PUBLIC double cs_ci_norm (const cs_ci *A) ;
+CS_PUBLIC int32_t cs_ci_print (const cs_ci *A, int32_t brief) ;
+CS_PUBLIC cs_ci *cs_ci_load (FILE *f) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC void *cs_ci_calloc (int32_t n, size_t size) ;
-SUITESPARSE_PUBLIC void *cs_ci_free (void *p) ;
-SUITESPARSE_PUBLIC void *cs_ci_realloc (void *p, int32_t n, size_t size, int32_t *ok) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_spalloc (int32_t m, int32_t n, int32_t nzmax, int32_t values,
+CS_PUBLIC void *cs_ci_calloc (int32_t n, size_t size) ;
+CS_PUBLIC void *cs_ci_free (void *p) ;
+CS_PUBLIC void *cs_ci_realloc (void *p, int32_t n, size_t size, int32_t *ok) ;
+CS_PUBLIC cs_ci *cs_ci_spalloc (int32_t m, int32_t n, int32_t nzmax, int32_t values,
     int32_t t) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_spfree (cs_ci *A) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_sprealloc (cs_ci *A, int32_t nzmax) ;
-SUITESPARSE_PUBLIC void *cs_ci_malloc (int32_t n, size_t size) ;
+CS_PUBLIC cs_ci *cs_ci_spfree (cs_ci *A) ;
+CS_PUBLIC int32_t cs_ci_sprealloc (cs_ci *A, int32_t nzmax) ;
+CS_PUBLIC void *cs_ci_malloc (int32_t n, size_t size) ;
 
 /* --- secondary CSparse routines and data structures ----------------------- */
 
@@ -408,70 +434,70 @@ typedef struct cs_ci_dmperm_results    /* cs_ci_dmperm or cs_ci_scc output */
     int32_t cc [5] ;  /* coarse column decomposition */
 } cs_cid ;
 
-SUITESPARSE_PUBLIC int32_t *cs_ci_amd (int32_t order, const cs_ci *A) ;
-SUITESPARSE_PUBLIC cs_cin *cs_ci_chol (const cs_ci *A, const cs_cis *S) ;
-SUITESPARSE_PUBLIC cs_cid *cs_ci_dmperm (const cs_ci *A, int32_t seed) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_droptol (cs_ci *A, double tol) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_dropzeros (cs_ci *A) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_happly (const cs_ci *V, int32_t i, double beta, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_ipvec (const int32_t *p, const cs_complex_t *b, cs_complex_t *x,
+CS_PUBLIC int32_t *cs_ci_amd (int32_t order, const cs_ci *A) ;
+CS_PUBLIC cs_cin *cs_ci_chol (const cs_ci *A, const cs_cis *S) ;
+CS_PUBLIC cs_cid *cs_ci_dmperm (const cs_ci *A, int32_t seed) ;
+CS_PUBLIC int32_t cs_ci_droptol (cs_ci *A, double tol) ;
+CS_PUBLIC int32_t cs_ci_dropzeros (cs_ci *A) ;
+CS_PUBLIC int32_t cs_ci_happly (const cs_ci *V, int32_t i, double beta, cs_complex_t *x) ;
+CS_PUBLIC int32_t cs_ci_ipvec (const int32_t *p, const cs_complex_t *b, cs_complex_t *x,
     int32_t n) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_lsolve (const cs_ci *L, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_ltsolve (const cs_ci *L, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC cs_cin *cs_ci_lu (const cs_ci *A, const cs_cis *S, double tol) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_permute (const cs_ci *A, const int32_t *pinv, const int32_t *q,
+CS_PUBLIC int32_t cs_ci_lsolve (const cs_ci *L, cs_complex_t *x) ;
+CS_PUBLIC int32_t cs_ci_ltsolve (const cs_ci *L, cs_complex_t *x) ;
+CS_PUBLIC cs_cin *cs_ci_lu (const cs_ci *A, const cs_cis *S, double tol) ;
+CS_PUBLIC cs_ci *cs_ci_permute (const cs_ci *A, const int32_t *pinv, const int32_t *q,
     int32_t values) ;
-SUITESPARSE_PUBLIC int32_t *cs_ci_pinv (const int32_t *p, int32_t n) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_pvec (const int32_t *p, const cs_complex_t *b, cs_complex_t *x,
+CS_PUBLIC int32_t *cs_ci_pinv (const int32_t *p, int32_t n) ;
+CS_PUBLIC int32_t cs_ci_pvec (const int32_t *p, const cs_complex_t *b, cs_complex_t *x,
     int32_t n) ;
-SUITESPARSE_PUBLIC cs_cin *cs_ci_qr (const cs_ci *A, const cs_cis *S) ;
-SUITESPARSE_PUBLIC cs_cis *cs_ci_schol (int32_t order, const cs_ci *A) ;
-SUITESPARSE_PUBLIC cs_cis *cs_ci_sqr (int32_t order, const cs_ci *A, int32_t qr) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_symperm (const cs_ci *A, const int32_t *pinv, int32_t values) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_usolve (const cs_ci *U, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_utsolve (const cs_ci *U, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_updown (cs_ci *L, int32_t sigma, const cs_ci *C,
+CS_PUBLIC cs_cin *cs_ci_qr (const cs_ci *A, const cs_cis *S) ;
+CS_PUBLIC cs_cis *cs_ci_schol (int32_t order, const cs_ci *A) ;
+CS_PUBLIC cs_cis *cs_ci_sqr (int32_t order, const cs_ci *A, int32_t qr) ;
+CS_PUBLIC cs_ci *cs_ci_symperm (const cs_ci *A, const int32_t *pinv, int32_t values) ;
+CS_PUBLIC int32_t cs_ci_usolve (const cs_ci *U, cs_complex_t *x) ;
+CS_PUBLIC int32_t cs_ci_utsolve (const cs_ci *U, cs_complex_t *x) ;
+CS_PUBLIC int32_t cs_ci_updown (cs_ci *L, int32_t sigma, const cs_ci *C,
     const int32_t *parent) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC cs_cis *cs_ci_sfree (cs_cis *S) ;
-SUITESPARSE_PUBLIC cs_cin *cs_ci_nfree (cs_cin *N) ;
-SUITESPARSE_PUBLIC cs_cid *cs_ci_dfree (cs_cid *D) ;
+CS_PUBLIC cs_cis *cs_ci_sfree (cs_cis *S) ;
+CS_PUBLIC cs_cin *cs_ci_nfree (cs_cin *N) ;
+CS_PUBLIC cs_cid *cs_ci_dfree (cs_cid *D) ;
 
 /* --- tertiary CSparse routines -------------------------------------------- */
 
-SUITESPARSE_PUBLIC int32_t *cs_ci_counts (const cs_ci *A, const int32_t *parent,
+CS_PUBLIC int32_t *cs_ci_counts (const cs_ci *A, const int32_t *parent,
     const int32_t *post, int32_t ata) ;
-SUITESPARSE_PUBLIC double cs_ci_cumsum (int32_t *p, int32_t *c, int32_t n) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_dfs (int32_t j, cs_ci *G, int32_t top, int32_t *xi,
+CS_PUBLIC double cs_ci_cumsum (int32_t *p, int32_t *c, int32_t n) ;
+CS_PUBLIC int32_t cs_ci_dfs (int32_t j, cs_ci *G, int32_t top, int32_t *xi,
     int32_t *pstack, const int32_t *pinv) ;
-SUITESPARSE_PUBLIC int32_t *cs_ci_etree (const cs_ci *A, int32_t ata) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_fkeep (cs_ci *A,
+CS_PUBLIC int32_t *cs_ci_etree (const cs_ci *A, int32_t ata) ;
+CS_PUBLIC int32_t cs_ci_fkeep (cs_ci *A,
     int32_t (*fkeep) (int32_t, int32_t, cs_complex_t, void *), void *other) ;
-SUITESPARSE_PUBLIC cs_complex_t cs_ci_house (cs_complex_t *x, double *beta, int32_t n) ;
-SUITESPARSE_PUBLIC int32_t *cs_ci_maxtrans (const cs_ci *A, int32_t seed) ;
-SUITESPARSE_PUBLIC int32_t *cs_ci_post (const int32_t *parent, int32_t n) ;
-SUITESPARSE_PUBLIC cs_cid *cs_ci_scc (cs_ci *A) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_scatter (const cs_ci *A, int32_t j, cs_complex_t beta, int32_t *w, 
+CS_PUBLIC cs_complex_t cs_ci_house (cs_complex_t *x, double *beta, int32_t n) ;
+CS_PUBLIC int32_t *cs_ci_maxtrans (const cs_ci *A, int32_t seed) ;
+CS_PUBLIC int32_t *cs_ci_post (const int32_t *parent, int32_t n) ;
+CS_PUBLIC cs_cid *cs_ci_scc (cs_ci *A) ;
+CS_PUBLIC int32_t cs_ci_scatter (const cs_ci *A, int32_t j, cs_complex_t beta, int32_t *w,
     cs_complex_t *x, int32_t mark,cs_ci *C, int32_t nz) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_tdfs (int32_t j, int32_t k, int32_t *head, const int32_t *next,
+CS_PUBLIC int32_t cs_ci_tdfs (int32_t j, int32_t k, int32_t *head, const int32_t *next,
     int32_t *post, int32_t *stack) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_leaf (int32_t i, int32_t j, const int32_t *first,
+CS_PUBLIC int32_t cs_ci_leaf (int32_t i, int32_t j, const int32_t *first,
     int32_t *maxfirst, int32_t *prevleaf, int32_t *ancestor, int32_t *jleaf) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_reach (cs_ci *G, const cs_ci *B, int32_t k, int32_t *xi,
+CS_PUBLIC int32_t cs_ci_reach (cs_ci *G, const cs_ci *B, int32_t k, int32_t *xi,
     const int32_t *pinv) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_spsolve (cs_ci *L, const cs_ci *B, int32_t k, int32_t *xi, 
+CS_PUBLIC int32_t cs_ci_spsolve (cs_ci *L, const cs_ci *B, int32_t k, int32_t *xi,
     cs_complex_t *x, const int32_t *pinv, int32_t lo) ;
-SUITESPARSE_PUBLIC int32_t cs_ci_ereach (const cs_ci *A, int32_t k, const int32_t *parent,
+CS_PUBLIC int32_t cs_ci_ereach (const cs_ci *A, int32_t k, const int32_t *parent,
     int32_t *s, int32_t *w) ;
-SUITESPARSE_PUBLIC int32_t *cs_ci_randperm (int32_t n, int32_t seed) ;
+CS_PUBLIC int32_t *cs_ci_randperm (int32_t n, int32_t seed) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC cs_cid *cs_ci_dalloc (int32_t m, int32_t n) ;
-SUITESPARSE_PUBLIC cs_ci *cs_ci_done (cs_ci *C, void *w, void *x, int32_t ok) ;
-SUITESPARSE_PUBLIC int32_t *cs_ci_idone (int32_t *p, cs_ci *C, void *w, int32_t ok) ;
-SUITESPARSE_PUBLIC cs_cin *cs_ci_ndone (cs_cin *N, cs_ci *C, void *w, void *x, int32_t ok) ;
-SUITESPARSE_PUBLIC cs_cid *cs_ci_ddone (cs_cid *D, cs_ci *C, void *w, int32_t ok) ;
+CS_PUBLIC cs_cid *cs_ci_dalloc (int32_t m, int32_t n) ;
+CS_PUBLIC cs_ci *cs_ci_done (cs_ci *C, void *w, void *x, int32_t ok) ;
+CS_PUBLIC int32_t *cs_ci_idone (int32_t *p, cs_ci *C, void *w, int32_t ok) ;
+CS_PUBLIC cs_cin *cs_ci_ndone (cs_cin *N, cs_ci *C, void *w, void *x, int32_t ok) ;
+CS_PUBLIC cs_cid *cs_ci_ddone (cs_cid *D, cs_ci *C, void *w, int32_t ok) ;
 
 
 /* -------------------------------------------------------------------------- */
@@ -491,31 +517,31 @@ typedef struct cs_cl_sparse  /* matrix in compressed-column or triplet form */
     int64_t nz ;   /* # of entries in triplet matrix, -1 for compressed-col */
 } cs_cl ;
 
-SUITESPARSE_PUBLIC cs_cl *cs_cl_add (const cs_cl *A, const cs_cl *B, cs_complex_t alpha,
+CS_PUBLIC cs_cl *cs_cl_add (const cs_cl *A, const cs_cl *B, cs_complex_t alpha,
     cs_complex_t beta) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_cholsol (int64_t order, const cs_cl *A, cs_complex_t *b) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_dupl (cs_cl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_entry (cs_cl *T, int64_t i, int64_t j, cs_complex_t x) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_lusol (int64_t order, const cs_cl *A, cs_complex_t *b,
+CS_PUBLIC int64_t cs_cl_cholsol (int64_t order, const cs_cl *A, cs_complex_t *b) ;
+CS_PUBLIC int64_t cs_cl_dupl (cs_cl *A) ;
+CS_PUBLIC int64_t cs_cl_entry (cs_cl *T, int64_t i, int64_t j, cs_complex_t x) ;
+CS_PUBLIC int64_t cs_cl_lusol (int64_t order, const cs_cl *A, cs_complex_t *b,
     double tol) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_gaxpy (const cs_cl *A, const cs_complex_t *x, cs_complex_t *y) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_multiply (const cs_cl *A, const cs_cl *B) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_qrsol (int64_t order, const cs_cl *A, cs_complex_t *b) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_transpose (const cs_cl *A, int64_t values) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_compress (const cs_cl *T) ;
-SUITESPARSE_PUBLIC double cs_cl_norm (const cs_cl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_print (const cs_cl *A, int64_t brief) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_load (FILE *f) ;
+CS_PUBLIC int64_t cs_cl_gaxpy (const cs_cl *A, const cs_complex_t *x, cs_complex_t *y) ;
+CS_PUBLIC cs_cl *cs_cl_multiply (const cs_cl *A, const cs_cl *B) ;
+CS_PUBLIC int64_t cs_cl_qrsol (int64_t order, const cs_cl *A, cs_complex_t *b) ;
+CS_PUBLIC cs_cl *cs_cl_transpose (const cs_cl *A, int64_t values) ;
+CS_PUBLIC cs_cl *cs_cl_compress (const cs_cl *T) ;
+CS_PUBLIC double cs_cl_norm (const cs_cl *A) ;
+CS_PUBLIC int64_t cs_cl_print (const cs_cl *A, int64_t brief) ;
+CS_PUBLIC cs_cl *cs_cl_load (FILE *f) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC void *cs_cl_calloc (int64_t n, size_t size) ;
-SUITESPARSE_PUBLIC void *cs_cl_free (void *p) ;
-SUITESPARSE_PUBLIC void *cs_cl_realloc (void *p, int64_t n, size_t size, int64_t *ok) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_spalloc (int64_t m, int64_t n, int64_t nzmax,
+CS_PUBLIC void *cs_cl_calloc (int64_t n, size_t size) ;
+CS_PUBLIC void *cs_cl_free (void *p) ;
+CS_PUBLIC void *cs_cl_realloc (void *p, int64_t n, size_t size, int64_t *ok) ;
+CS_PUBLIC cs_cl *cs_cl_spalloc (int64_t m, int64_t n, int64_t nzmax,
     int64_t values, int64_t t) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_spfree (cs_cl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_sprealloc (cs_cl *A, int64_t nzmax) ;
-SUITESPARSE_PUBLIC void *cs_cl_malloc (int64_t n, size_t size) ;
+CS_PUBLIC cs_cl *cs_cl_spfree (cs_cl *A) ;
+CS_PUBLIC int64_t cs_cl_sprealloc (cs_cl *A, int64_t nzmax) ;
+CS_PUBLIC void *cs_cl_malloc (int64_t n, size_t size) ;
 
 /* --- secondary CSparse routines and data structures ----------------------- */
 
@@ -550,73 +576,73 @@ typedef struct cs_cl_dmperm_results    /* cs_cl_dmperm or cs_cl_scc output */
     int64_t cc [5] ;   /* coarse column decomposition */
 } cs_cld ;
 
-SUITESPARSE_PUBLIC int64_t *cs_cl_amd (int64_t order, const cs_cl *A) ;
-SUITESPARSE_PUBLIC cs_cln *cs_cl_chol (const cs_cl *A, const cs_cls *S) ;
-SUITESPARSE_PUBLIC cs_cld *cs_cl_dmperm (const cs_cl *A, int64_t seed) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_droptol (cs_cl *A, double tol) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_dropzeros (cs_cl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_happly (const cs_cl *V, int64_t i, double beta,
+CS_PUBLIC int64_t *cs_cl_amd (int64_t order, const cs_cl *A) ;
+CS_PUBLIC cs_cln *cs_cl_chol (const cs_cl *A, const cs_cls *S) ;
+CS_PUBLIC cs_cld *cs_cl_dmperm (const cs_cl *A, int64_t seed) ;
+CS_PUBLIC int64_t cs_cl_droptol (cs_cl *A, double tol) ;
+CS_PUBLIC int64_t cs_cl_dropzeros (cs_cl *A) ;
+CS_PUBLIC int64_t cs_cl_happly (const cs_cl *V, int64_t i, double beta,
     cs_complex_t *x) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_ipvec (const int64_t *p, const cs_complex_t *b,
+CS_PUBLIC int64_t cs_cl_ipvec (const int64_t *p, const cs_complex_t *b,
     cs_complex_t *x, int64_t n) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_lsolve (const cs_cl *L, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_ltsolve (const cs_cl *L, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC cs_cln *cs_cl_lu (const cs_cl *A, const cs_cls *S, double tol) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_permute (const cs_cl *A, const int64_t *pinv, const int64_t *q,
+CS_PUBLIC int64_t cs_cl_lsolve (const cs_cl *L, cs_complex_t *x) ;
+CS_PUBLIC int64_t cs_cl_ltsolve (const cs_cl *L, cs_complex_t *x) ;
+CS_PUBLIC cs_cln *cs_cl_lu (const cs_cl *A, const cs_cls *S, double tol) ;
+CS_PUBLIC cs_cl *cs_cl_permute (const cs_cl *A, const int64_t *pinv, const int64_t *q,
     int64_t values) ;
-SUITESPARSE_PUBLIC int64_t *cs_cl_pinv (const int64_t *p, int64_t n) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_pvec (const int64_t *p, const cs_complex_t *b,
+CS_PUBLIC int64_t *cs_cl_pinv (const int64_t *p, int64_t n) ;
+CS_PUBLIC int64_t cs_cl_pvec (const int64_t *p, const cs_complex_t *b,
     cs_complex_t *x, int64_t n) ;
-SUITESPARSE_PUBLIC cs_cln *cs_cl_qr (const cs_cl *A, const cs_cls *S) ;
-SUITESPARSE_PUBLIC cs_cls *cs_cl_schol (int64_t order, const cs_cl *A) ;
-SUITESPARSE_PUBLIC cs_cls *cs_cl_sqr (int64_t order, const cs_cl *A, int64_t qr) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_symperm (const cs_cl *A, const int64_t *pinv, int64_t values) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_usolve (const cs_cl *U, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_utsolve (const cs_cl *U, cs_complex_t *x) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_updown (cs_cl *L, int64_t sigma, const cs_cl *C,
+CS_PUBLIC cs_cln *cs_cl_qr (const cs_cl *A, const cs_cls *S) ;
+CS_PUBLIC cs_cls *cs_cl_schol (int64_t order, const cs_cl *A) ;
+CS_PUBLIC cs_cls *cs_cl_sqr (int64_t order, const cs_cl *A, int64_t qr) ;
+CS_PUBLIC cs_cl *cs_cl_symperm (const cs_cl *A, const int64_t *pinv, int64_t values) ;
+CS_PUBLIC int64_t cs_cl_usolve (const cs_cl *U, cs_complex_t *x) ;
+CS_PUBLIC int64_t cs_cl_utsolve (const cs_cl *U, cs_complex_t *x) ;
+CS_PUBLIC int64_t cs_cl_updown (cs_cl *L, int64_t sigma, const cs_cl *C,
     const int64_t *parent) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC cs_cls *cs_cl_sfree (cs_cls *S) ;
-SUITESPARSE_PUBLIC cs_cln *cs_cl_nfree (cs_cln *N) ;
-SUITESPARSE_PUBLIC cs_cld *cs_cl_dfree (cs_cld *D) ;
+CS_PUBLIC cs_cls *cs_cl_sfree (cs_cls *S) ;
+CS_PUBLIC cs_cln *cs_cl_nfree (cs_cln *N) ;
+CS_PUBLIC cs_cld *cs_cl_dfree (cs_cld *D) ;
 
 /* --- tertiary CSparse routines -------------------------------------------- */
 
-SUITESPARSE_PUBLIC int64_t *cs_cl_counts (const cs_cl *A, const int64_t *parent,
+CS_PUBLIC int64_t *cs_cl_counts (const cs_cl *A, const int64_t *parent,
     const int64_t *post, int64_t ata) ;
-SUITESPARSE_PUBLIC double cs_cl_cumsum (int64_t *p, int64_t *c, int64_t n) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_dfs (int64_t j, cs_cl *G, int64_t top, int64_t *xi,
+CS_PUBLIC double cs_cl_cumsum (int64_t *p, int64_t *c, int64_t n) ;
+CS_PUBLIC int64_t cs_cl_dfs (int64_t j, cs_cl *G, int64_t top, int64_t *xi,
     int64_t *pstack, const int64_t *pinv) ;
-SUITESPARSE_PUBLIC int64_t *cs_cl_etree (const cs_cl *A, int64_t ata) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_fkeep (cs_cl *A,
+CS_PUBLIC int64_t *cs_cl_etree (const cs_cl *A, int64_t ata) ;
+CS_PUBLIC int64_t cs_cl_fkeep (cs_cl *A,
     int64_t (*fkeep) (int64_t, int64_t, cs_complex_t, void *),
     void *other) ;
-SUITESPARSE_PUBLIC cs_complex_t cs_cl_house (cs_complex_t *x, double *beta, int64_t n) ;
-SUITESPARSE_PUBLIC int64_t *cs_cl_maxtrans (const cs_cl *A, int64_t seed) ;
-SUITESPARSE_PUBLIC int64_t *cs_cl_post (const int64_t *parent, int64_t n) ;
-SUITESPARSE_PUBLIC cs_cld *cs_cl_scc (cs_cl *A) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_scatter (const cs_cl *A, int64_t j, cs_complex_t beta,
+CS_PUBLIC cs_complex_t cs_cl_house (cs_complex_t *x, double *beta, int64_t n) ;
+CS_PUBLIC int64_t *cs_cl_maxtrans (const cs_cl *A, int64_t seed) ;
+CS_PUBLIC int64_t *cs_cl_post (const int64_t *parent, int64_t n) ;
+CS_PUBLIC cs_cld *cs_cl_scc (cs_cl *A) ;
+CS_PUBLIC int64_t cs_cl_scatter (const cs_cl *A, int64_t j, cs_complex_t beta,
     int64_t *w, cs_complex_t *x, int64_t mark,cs_cl *C, int64_t nz) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_tdfs (int64_t j, int64_t k, int64_t *head,
+CS_PUBLIC int64_t cs_cl_tdfs (int64_t j, int64_t k, int64_t *head,
     const int64_t *next, int64_t *post, int64_t *stack) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_leaf (int64_t i, int64_t j, const int64_t *first,
+CS_PUBLIC int64_t cs_cl_leaf (int64_t i, int64_t j, const int64_t *first,
     int64_t *maxfirst, int64_t *prevleaf, int64_t *ancestor,
     int64_t *jleaf) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_reach (cs_cl *G, const cs_cl *B, int64_t k, int64_t *xi,
+CS_PUBLIC int64_t cs_cl_reach (cs_cl *G, const cs_cl *B, int64_t k, int64_t *xi,
     const int64_t *pinv) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_spsolve (cs_cl *L, const cs_cl *B, int64_t k, int64_t *xi, 
+CS_PUBLIC int64_t cs_cl_spsolve (cs_cl *L, const cs_cl *B, int64_t k, int64_t *xi,
     cs_complex_t *x, const int64_t *pinv, int64_t lo) ;
-SUITESPARSE_PUBLIC int64_t cs_cl_ereach (const cs_cl *A, int64_t k, const int64_t *parent,
+CS_PUBLIC int64_t cs_cl_ereach (const cs_cl *A, int64_t k, const int64_t *parent,
     int64_t *s, int64_t *w) ;
-SUITESPARSE_PUBLIC int64_t *cs_cl_randperm (int64_t n, int64_t seed) ;
+CS_PUBLIC int64_t *cs_cl_randperm (int64_t n, int64_t seed) ;
 
 /* utilities */
-SUITESPARSE_PUBLIC cs_cld *cs_cl_dalloc (int64_t m, int64_t n) ;
-SUITESPARSE_PUBLIC cs_cl *cs_cl_done (cs_cl *C, void *w, void *x, int64_t ok) ;
-SUITESPARSE_PUBLIC int64_t *cs_cl_idone (int64_t *p, cs_cl *C, void *w, int64_t ok) ;
-SUITESPARSE_PUBLIC cs_cln *cs_cl_ndone (cs_cln *N, cs_cl *C, void *w, void *x, int64_t ok) ;
-SUITESPARSE_PUBLIC cs_cld *cs_cl_ddone (cs_cld *D, cs_cl *C, void *w, int64_t ok) ;
+CS_PUBLIC cs_cld *cs_cl_dalloc (int64_t m, int64_t n) ;
+CS_PUBLIC cs_cl *cs_cl_done (cs_cl *C, void *w, void *x, int64_t ok) ;
+CS_PUBLIC int64_t *cs_cl_idone (int64_t *p, cs_cl *C, void *w, int64_t ok) ;
+CS_PUBLIC cs_cln *cs_cl_ndone (cs_cln *N, cs_cl *C, void *w, void *x, int64_t ok) ;
+CS_PUBLIC cs_cld *cs_cl_ddone (cs_cld *D, cs_cl *C, void *w, int64_t ok) ;
 
 #endif
 
@@ -760,10 +786,10 @@ SUITESPARSE_PUBLIC cs_cld *cs_cl_ddone (cs_cld *D, cs_cl *C, void *w, int64_t ok
 /* -------------------------------------------------------------------------- */
 
 #ifndef NCOMPLEX
-SUITESPARSE_PUBLIC cs_di *cs_i_real (cs_ci *A, int32_t real) ;
-SUITESPARSE_PUBLIC cs_ci *cs_i_complex (cs_di *A, int32_t real) ;
-SUITESPARSE_PUBLIC cs_dl *cs_l_real (cs_cl *A, int64_t real) ;
-SUITESPARSE_PUBLIC cs_cl *cs_l_complex (cs_dl *A, int64_t real) ;
+CS_PUBLIC cs_di *cs_i_real (cs_ci *A, int32_t real) ;
+CS_PUBLIC cs_ci *cs_i_complex (cs_di *A, int32_t real) ;
+CS_PUBLIC cs_dl *cs_l_real (cs_cl *A, int64_t real) ;
+CS_PUBLIC cs_cl *cs_l_complex (cs_dl *A, int64_t real) ;
 #endif
 
 #ifdef __cplusplus

--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -100,6 +100,8 @@ set_target_properties ( klu PROPERTIES
     SOVERSION ${KLU_VERSION_MAJOR}
     PUBLIC_HEADER "Include/klu.h" )
 
+target_compile_definitions ( klu PRIVATE KLU_LIBRARY )
+
 #-------------------------------------------------------------------------------
 # static klu library properties
 #-------------------------------------------------------------------------------
@@ -112,6 +114,8 @@ set_target_properties ( klu_static PROPERTIES
     C_STANDARD_REQUIRED 11
     OUTPUT_NAME klu
     SOVERSION ${KLU_VERSION_MAJOR} )
+
+target_compile_definitions ( klu_static PUBLIC KLU_STATIC )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -154,7 +158,7 @@ if ( NOT NSTATIC )
 endif ( )
 
 # libm:
-if ( NOT MSVC )
+if ( NOT WIN32 )
     target_link_libraries ( klu PUBLIC m )
     if ( NOT NSTATIC )
         target_link_libraries ( klu_static PUBLIC m )

--- a/KLU/Config/klu.h.in
+++ b/KLU/Config/klu.h.in
@@ -18,6 +18,33 @@
 extern "C" {
 #endif
 
+#include "SuiteSparse_config.h"
+
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( KLU_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define KLU_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( KLU_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define KLU_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define KLU_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other compilers
+    #define KLU_PUBLIC extern
+
+#endif
+
 #include "amd.h"
 #include "colamd.h"
 #include "btf.h"
@@ -232,13 +259,13 @@ typedef struct klu_l_common_struct /* 64-bit version (otherwise same as above)*/
 /* klu_defaults: sets default control parameters */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_defaults
 (
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_defaults (klu_l_common *Common) ;
 
 /* -------------------------------------------------------------------------- */
@@ -248,7 +275,7 @@ int klu_l_defaults (klu_l_common *Common) ;
 /* Order the matrix with BTF (or not), then order each block with AMD, COLAMD,
  * a natural ordering, or with a user-provided ordering function */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 klu_symbolic *klu_analyze
 (
     /* inputs, not modified */
@@ -258,7 +285,7 @@ klu_symbolic *klu_analyze
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 klu_l_symbolic *klu_l_analyze (int64_t, int64_t *, int64_t *,
     klu_l_common *Common) ;
 
@@ -271,7 +298,7 @@ klu_l_symbolic *klu_l_analyze (int64_t, int64_t *, int64_t *,
  * P and Q on the blocks.  P and Q are interpretted as identity
  * if NULL. */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 klu_symbolic *klu_analyze_given
 (
     /* inputs, not modified */
@@ -283,7 +310,7 @@ klu_symbolic *klu_analyze_given
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 klu_l_symbolic *klu_l_analyze_given (int64_t, int64_t *, int64_t *, int64_t *,
     int64_t *, klu_l_common *) ;
 
@@ -292,7 +319,7 @@ klu_l_symbolic *klu_l_analyze_given (int64_t, int64_t *, int64_t *, int64_t *,
 /* klu_factor:  factors a matrix using the klu_analyze results */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 klu_numeric *klu_factor /* returns KLU_OK if OK, < 0 if error */
 (
     /* inputs, not modified */
@@ -303,7 +330,7 @@ klu_numeric *klu_factor /* returns KLU_OK if OK, < 0 if error */
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 klu_numeric *klu_z_factor      /* returns KLU_OK if OK, < 0 if error */
 (
      /* inputs, not modified */
@@ -315,12 +342,12 @@ klu_numeric *klu_z_factor      /* returns KLU_OK if OK, < 0 if error */
 ) ;
 
 /* int64_t / real version */
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 klu_l_numeric *klu_l_factor (int64_t *, int64_t *, double *,
     klu_l_symbolic *, klu_l_common *) ;
 
 /* int64_t / complex version */
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 klu_l_numeric *klu_zl_factor (int64_t *, int64_t *, double *,
     klu_l_symbolic *, klu_l_common *) ;
 
@@ -329,7 +356,7 @@ klu_l_numeric *klu_zl_factor (int64_t *, int64_t *, double *,
 /* klu_solve: solves Ax=b using the Symbolic and Numeric objects */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_solve
 (
     /* inputs, not modified */
@@ -343,7 +370,7 @@ int klu_solve
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_solve
 (
      /* inputs, not modified */
@@ -357,11 +384,11 @@ int klu_z_solve
      klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_solve (klu_l_symbolic *, klu_l_numeric *,
     int64_t, int64_t, double *, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_solve (klu_l_symbolic *, klu_l_numeric *,
     int64_t, int64_t, double *, klu_l_common *) ;
 
@@ -370,7 +397,7 @@ int klu_zl_solve (klu_l_symbolic *, klu_l_numeric *,
 /* klu_tsolve: solves A'x=b using the Symbolic and Numeric objects */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_tsolve
 (
     /* inputs, not modified */
@@ -384,7 +411,7 @@ int klu_tsolve
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_tsolve
 (
     /* inputs, not modified */
@@ -400,11 +427,11 @@ int klu_z_tsolve
      
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_tsolve (klu_l_symbolic *, klu_l_numeric *,
     int64_t, int64_t, double *, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_tsolve (klu_l_symbolic *, klu_l_numeric *,
     int64_t, int64_t, double *, int, klu_l_common * ) ;
 
@@ -413,7 +440,7 @@ int klu_zl_tsolve (klu_l_symbolic *, klu_l_numeric *,
 /* klu_refactor: refactorizes matrix with same ordering as klu_factor */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_refactor            /* return TRUE if successful, FALSE otherwise */
 (
     /* inputs, not modified */
@@ -426,7 +453,7 @@ int klu_refactor            /* return TRUE if successful, FALSE otherwise */
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_refactor          /* return TRUE if successful, FALSE otherwise */
 (
      /* inputs, not modified */
@@ -439,11 +466,11 @@ int klu_z_refactor          /* return TRUE if successful, FALSE otherwise */
      klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_refactor (int64_t *, int64_t *,
     double *, klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_refactor (int64_t *, int64_t *,
     double *, klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 
@@ -452,14 +479,14 @@ int klu_zl_refactor (int64_t *, int64_t *,
 /* klu_free_symbolic: destroys the Symbolic object */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_free_symbolic
 (
     klu_symbolic **Symbolic,
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_free_symbolic (klu_l_symbolic **, klu_l_common *) ;
 
 
@@ -470,23 +497,23 @@ int klu_l_free_symbolic (klu_l_symbolic **, klu_l_common *) ;
 /* Note that klu_free_numeric and klu_z_free_numeric are identical; each can
  * free both kinds of Numeric objects (real and complex) */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_free_numeric
 (
     klu_numeric **Numeric,
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_free_numeric
 (
      klu_numeric **Numeric,
      klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_free_numeric (klu_l_numeric **, klu_l_common *) ;
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_free_numeric (klu_l_numeric **, klu_l_common *) ;
 
 
@@ -496,7 +523,7 @@ int klu_zl_free_numeric (klu_l_numeric **, klu_l_common *) ;
 
 /* this is not needed except for the MATLAB interface */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_sort
 (
     /* inputs, not modified */
@@ -506,7 +533,7 @@ int klu_sort
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_sort
 (
     /* inputs, not modified */
@@ -516,9 +543,9 @@ int klu_z_sort
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_sort  (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_sort (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 
 
@@ -526,7 +553,7 @@ int klu_zl_sort (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 /* klu_flops: determines # of flops performed in numeric factorzation */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_flops
 (
     /* inputs, not modified */
@@ -536,7 +563,7 @@ int klu_flops
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_flops
 (
     /* inputs, not modified */
@@ -546,9 +573,9 @@ int klu_z_flops
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_flops  (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_flops (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 
 
@@ -569,7 +596,7 @@ int klu_zl_flops (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
  *
  * rgrowth = min (max (abs ((R \ A(p,q)) - F)) ./ max (abs (U))) */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_rgrowth
 (
     int32_t Ap [ ],
@@ -580,7 +607,7 @@ int klu_rgrowth
     klu_common *Common          /* Common->rgrowth = reciprocal pivot growth */
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_rgrowth
 (
     int32_t Ap [ ],
@@ -591,11 +618,11 @@ int klu_z_rgrowth
     klu_common *Common          /* Common->rgrowth = reciprocal pivot growth */
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_rgrowth (int64_t *, int64_t *,
     double *, klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_rgrowth (int64_t *, int64_t *,
     double *, klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 
@@ -608,7 +635,7 @@ int klu_zl_rgrowth (int64_t *, int64_t *,
  * Hager's method, as modified by Higham and Tisseur (same method as used in
  * MATLAB's condest */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_condest
 (
     int32_t Ap [ ],         /* size n+1, column pointers, not modified */
@@ -618,7 +645,7 @@ int klu_condest
     klu_common *Common      /* result returned in Common->condest */
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_condest
 (
     int32_t Ap [ ],
@@ -628,11 +655,11 @@ int klu_z_condest
     klu_common *Common      /* result returned in Common->condest */
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_condest (int64_t *, double *, klu_l_symbolic *,
     klu_l_numeric *, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_condest (int64_t *, double *, klu_l_symbolic *,
     klu_l_numeric *, klu_l_common *) ;
 
@@ -641,7 +668,7 @@ int klu_zl_condest (int64_t *, double *, klu_l_symbolic *,
 /* klu_rcond: compute min(abs(diag(U))) / max(abs(diag(U))) */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_rcond
 (
     klu_symbolic *Symbolic,         /* input, not modified */
@@ -649,7 +676,7 @@ int klu_rcond
     klu_common *Common              /* result in Common->rcond */
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_rcond
 (
     klu_symbolic *Symbolic,         /* input, not modified */
@@ -657,10 +684,10 @@ int klu_z_rcond
     klu_common *Common              /* result in Common->rcond */
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_rcond  (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_rcond (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 
 
@@ -668,7 +695,7 @@ int klu_zl_rcond (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 /* klu_scale */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_scale           /* return TRUE if successful, FALSE otherwise */
 (
     /* inputs, not modified */
@@ -684,7 +711,7 @@ int klu_scale           /* return TRUE if successful, FALSE otherwise */
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_scale         /* return TRUE if successful, FALSE otherwise */
 (
     /* inputs, not modified */
@@ -700,11 +727,11 @@ int klu_z_scale         /* return TRUE if successful, FALSE otherwise */
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_scale (int, int64_t, int64_t *, int64_t *, double *,
     double *, int64_t *, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_scale (int, int64_t, int64_t *, int64_t *, double *,
     double *, int64_t *, klu_l_common *) ;
 
@@ -713,7 +740,7 @@ int klu_zl_scale (int, int64_t, int64_t *, int64_t *, double *,
 /* klu_extract  */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_extract     /* returns TRUE if successful, FALSE otherwise */
 (
     /* inputs: */
@@ -753,7 +780,7 @@ int klu_extract     /* returns TRUE if successful, FALSE otherwise */
 ) ;
 
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_extract           /* returns TRUE if successful, FALSE otherwise */
 (
     /* inputs: */
@@ -795,7 +822,7 @@ int klu_z_extract           /* returns TRUE if successful, FALSE otherwise */
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_extract (klu_l_numeric *, klu_l_symbolic *,
     int64_t *, int64_t *, double *,
     int64_t *, int64_t *, double *,
@@ -803,7 +830,7 @@ int klu_l_extract (klu_l_numeric *, klu_l_symbolic *,
     int64_t *, int64_t *, double *,
     int64_t *, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_extract (klu_l_numeric *, klu_l_symbolic *,
     int64_t *, int64_t *, double *, double *,
     int64_t *, int64_t *, double *, double *,
@@ -816,7 +843,7 @@ int klu_zl_extract (klu_l_numeric *, klu_l_symbolic *,
 /* KLU memory management routines */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 void *klu_malloc        /* returns pointer to the newly malloc'd block */
 (
     /* ---- input ---- */
@@ -826,7 +853,7 @@ void *klu_malloc        /* returns pointer to the newly malloc'd block */
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 void *klu_free          /* always returns NULL */
 (
     /* ---- in/out --- */
@@ -837,7 +864,7 @@ void *klu_free          /* always returns NULL */
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 void *klu_realloc       /* returns pointer to reallocated block */
 (
     /* ---- input ---- */
@@ -850,13 +877,13 @@ void *klu_realloc       /* returns pointer to reallocated block */
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 void *klu_l_malloc (size_t, size_t, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 void *klu_l_free (void *, size_t, size_t, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 void *klu_l_realloc (size_t, size_t, size_t, void *, klu_l_common *) ;
 
 

--- a/KLU/Config/klu.h.in
+++ b/KLU/Config/klu.h.in
@@ -21,10 +21,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( KLU_LIBRARY )

--- a/KLU/Include/klu.h
+++ b/KLU/Include/klu.h
@@ -18,6 +18,33 @@
 extern "C" {
 #endif
 
+#include "SuiteSparse_config.h"
+
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( KLU_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define KLU_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( KLU_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define KLU_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define KLU_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other compilers
+    #define KLU_PUBLIC extern
+
+#endif
+
 #include "amd.h"
 #include "colamd.h"
 #include "btf.h"
@@ -232,13 +259,13 @@ typedef struct klu_l_common_struct /* 64-bit version (otherwise same as above)*/
 /* klu_defaults: sets default control parameters */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_defaults
 (
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_defaults (klu_l_common *Common) ;
 
 /* -------------------------------------------------------------------------- */
@@ -248,7 +275,7 @@ int klu_l_defaults (klu_l_common *Common) ;
 /* Order the matrix with BTF (or not), then order each block with AMD, COLAMD,
  * a natural ordering, or with a user-provided ordering function */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 klu_symbolic *klu_analyze
 (
     /* inputs, not modified */
@@ -258,7 +285,7 @@ klu_symbolic *klu_analyze
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 klu_l_symbolic *klu_l_analyze (int64_t, int64_t *, int64_t *,
     klu_l_common *Common) ;
 
@@ -271,7 +298,7 @@ klu_l_symbolic *klu_l_analyze (int64_t, int64_t *, int64_t *,
  * P and Q on the blocks.  P and Q are interpretted as identity
  * if NULL. */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 klu_symbolic *klu_analyze_given
 (
     /* inputs, not modified */
@@ -283,7 +310,7 @@ klu_symbolic *klu_analyze_given
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 klu_l_symbolic *klu_l_analyze_given (int64_t, int64_t *, int64_t *, int64_t *,
     int64_t *, klu_l_common *) ;
 
@@ -292,7 +319,7 @@ klu_l_symbolic *klu_l_analyze_given (int64_t, int64_t *, int64_t *, int64_t *,
 /* klu_factor:  factors a matrix using the klu_analyze results */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 klu_numeric *klu_factor /* returns KLU_OK if OK, < 0 if error */
 (
     /* inputs, not modified */
@@ -303,7 +330,7 @@ klu_numeric *klu_factor /* returns KLU_OK if OK, < 0 if error */
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 klu_numeric *klu_z_factor      /* returns KLU_OK if OK, < 0 if error */
 (
      /* inputs, not modified */
@@ -315,12 +342,12 @@ klu_numeric *klu_z_factor      /* returns KLU_OK if OK, < 0 if error */
 ) ;
 
 /* int64_t / real version */
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 klu_l_numeric *klu_l_factor (int64_t *, int64_t *, double *,
     klu_l_symbolic *, klu_l_common *) ;
 
 /* int64_t / complex version */
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 klu_l_numeric *klu_zl_factor (int64_t *, int64_t *, double *,
     klu_l_symbolic *, klu_l_common *) ;
 
@@ -329,7 +356,7 @@ klu_l_numeric *klu_zl_factor (int64_t *, int64_t *, double *,
 /* klu_solve: solves Ax=b using the Symbolic and Numeric objects */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_solve
 (
     /* inputs, not modified */
@@ -343,7 +370,7 @@ int klu_solve
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_solve
 (
      /* inputs, not modified */
@@ -357,11 +384,11 @@ int klu_z_solve
      klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_solve (klu_l_symbolic *, klu_l_numeric *,
     int64_t, int64_t, double *, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_solve (klu_l_symbolic *, klu_l_numeric *,
     int64_t, int64_t, double *, klu_l_common *) ;
 
@@ -370,7 +397,7 @@ int klu_zl_solve (klu_l_symbolic *, klu_l_numeric *,
 /* klu_tsolve: solves A'x=b using the Symbolic and Numeric objects */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_tsolve
 (
     /* inputs, not modified */
@@ -384,7 +411,7 @@ int klu_tsolve
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_tsolve
 (
     /* inputs, not modified */
@@ -400,11 +427,11 @@ int klu_z_tsolve
      
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_tsolve (klu_l_symbolic *, klu_l_numeric *,
     int64_t, int64_t, double *, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_tsolve (klu_l_symbolic *, klu_l_numeric *,
     int64_t, int64_t, double *, int, klu_l_common * ) ;
 
@@ -413,7 +440,7 @@ int klu_zl_tsolve (klu_l_symbolic *, klu_l_numeric *,
 /* klu_refactor: refactorizes matrix with same ordering as klu_factor */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_refactor            /* return TRUE if successful, FALSE otherwise */
 (
     /* inputs, not modified */
@@ -426,7 +453,7 @@ int klu_refactor            /* return TRUE if successful, FALSE otherwise */
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_refactor          /* return TRUE if successful, FALSE otherwise */
 (
      /* inputs, not modified */
@@ -439,11 +466,11 @@ int klu_z_refactor          /* return TRUE if successful, FALSE otherwise */
      klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_refactor (int64_t *, int64_t *,
     double *, klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_refactor (int64_t *, int64_t *,
     double *, klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 
@@ -452,14 +479,14 @@ int klu_zl_refactor (int64_t *, int64_t *,
 /* klu_free_symbolic: destroys the Symbolic object */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_free_symbolic
 (
     klu_symbolic **Symbolic,
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_free_symbolic (klu_l_symbolic **, klu_l_common *) ;
 
 
@@ -470,23 +497,23 @@ int klu_l_free_symbolic (klu_l_symbolic **, klu_l_common *) ;
 /* Note that klu_free_numeric and klu_z_free_numeric are identical; each can
  * free both kinds of Numeric objects (real and complex) */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_free_numeric
 (
     klu_numeric **Numeric,
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_free_numeric
 (
      klu_numeric **Numeric,
      klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_free_numeric (klu_l_numeric **, klu_l_common *) ;
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_free_numeric (klu_l_numeric **, klu_l_common *) ;
 
 
@@ -496,7 +523,7 @@ int klu_zl_free_numeric (klu_l_numeric **, klu_l_common *) ;
 
 /* this is not needed except for the MATLAB interface */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_sort
 (
     /* inputs, not modified */
@@ -506,7 +533,7 @@ int klu_sort
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_sort
 (
     /* inputs, not modified */
@@ -516,9 +543,9 @@ int klu_z_sort
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_sort  (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_sort (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 
 
@@ -526,7 +553,7 @@ int klu_zl_sort (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 /* klu_flops: determines # of flops performed in numeric factorzation */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_flops
 (
     /* inputs, not modified */
@@ -536,7 +563,7 @@ int klu_flops
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_flops
 (
     /* inputs, not modified */
@@ -546,9 +573,9 @@ int klu_z_flops
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_flops  (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_flops (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 
 
@@ -569,7 +596,7 @@ int klu_zl_flops (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
  *
  * rgrowth = min (max (abs ((R \ A(p,q)) - F)) ./ max (abs (U))) */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_rgrowth
 (
     int32_t Ap [ ],
@@ -580,7 +607,7 @@ int klu_rgrowth
     klu_common *Common          /* Common->rgrowth = reciprocal pivot growth */
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_rgrowth
 (
     int32_t Ap [ ],
@@ -591,11 +618,11 @@ int klu_z_rgrowth
     klu_common *Common          /* Common->rgrowth = reciprocal pivot growth */
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_rgrowth (int64_t *, int64_t *,
     double *, klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_rgrowth (int64_t *, int64_t *,
     double *, klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 
@@ -608,7 +635,7 @@ int klu_zl_rgrowth (int64_t *, int64_t *,
  * Hager's method, as modified by Higham and Tisseur (same method as used in
  * MATLAB's condest */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_condest
 (
     int32_t Ap [ ],         /* size n+1, column pointers, not modified */
@@ -618,7 +645,7 @@ int klu_condest
     klu_common *Common      /* result returned in Common->condest */
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_condest
 (
     int32_t Ap [ ],
@@ -628,11 +655,11 @@ int klu_z_condest
     klu_common *Common      /* result returned in Common->condest */
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_condest (int64_t *, double *, klu_l_symbolic *,
     klu_l_numeric *, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_condest (int64_t *, double *, klu_l_symbolic *,
     klu_l_numeric *, klu_l_common *) ;
 
@@ -641,7 +668,7 @@ int klu_zl_condest (int64_t *, double *, klu_l_symbolic *,
 /* klu_rcond: compute min(abs(diag(U))) / max(abs(diag(U))) */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_rcond
 (
     klu_symbolic *Symbolic,         /* input, not modified */
@@ -649,7 +676,7 @@ int klu_rcond
     klu_common *Common              /* result in Common->rcond */
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_rcond
 (
     klu_symbolic *Symbolic,         /* input, not modified */
@@ -657,10 +684,10 @@ int klu_z_rcond
     klu_common *Common              /* result in Common->rcond */
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_rcond  (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_rcond (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 
 
@@ -668,7 +695,7 @@ int klu_zl_rcond (klu_l_symbolic *, klu_l_numeric *, klu_l_common *) ;
 /* klu_scale */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_scale           /* return TRUE if successful, FALSE otherwise */
 (
     /* inputs, not modified */
@@ -684,7 +711,7 @@ int klu_scale           /* return TRUE if successful, FALSE otherwise */
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_scale         /* return TRUE if successful, FALSE otherwise */
 (
     /* inputs, not modified */
@@ -700,11 +727,11 @@ int klu_z_scale         /* return TRUE if successful, FALSE otherwise */
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_scale (int, int64_t, int64_t *, int64_t *, double *,
     double *, int64_t *, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_scale (int, int64_t, int64_t *, int64_t *, double *,
     double *, int64_t *, klu_l_common *) ;
 
@@ -713,7 +740,7 @@ int klu_zl_scale (int, int64_t, int64_t *, int64_t *, double *,
 /* klu_extract  */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_extract     /* returns TRUE if successful, FALSE otherwise */
 (
     /* inputs: */
@@ -753,7 +780,7 @@ int klu_extract     /* returns TRUE if successful, FALSE otherwise */
 ) ;
 
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_z_extract           /* returns TRUE if successful, FALSE otherwise */
 (
     /* inputs: */
@@ -795,7 +822,7 @@ int klu_z_extract           /* returns TRUE if successful, FALSE otherwise */
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_l_extract (klu_l_numeric *, klu_l_symbolic *,
     int64_t *, int64_t *, double *,
     int64_t *, int64_t *, double *,
@@ -803,7 +830,7 @@ int klu_l_extract (klu_l_numeric *, klu_l_symbolic *,
     int64_t *, int64_t *, double *,
     int64_t *, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 int klu_zl_extract (klu_l_numeric *, klu_l_symbolic *,
     int64_t *, int64_t *, double *, double *,
     int64_t *, int64_t *, double *, double *,
@@ -816,7 +843,7 @@ int klu_zl_extract (klu_l_numeric *, klu_l_symbolic *,
 /* KLU memory management routines */
 /* -------------------------------------------------------------------------- */
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 void *klu_malloc        /* returns pointer to the newly malloc'd block */
 (
     /* ---- input ---- */
@@ -826,7 +853,7 @@ void *klu_malloc        /* returns pointer to the newly malloc'd block */
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 void *klu_free          /* always returns NULL */
 (
     /* ---- in/out --- */
@@ -837,7 +864,7 @@ void *klu_free          /* always returns NULL */
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 void *klu_realloc       /* returns pointer to reallocated block */
 (
     /* ---- input ---- */
@@ -850,13 +877,13 @@ void *klu_realloc       /* returns pointer to reallocated block */
     klu_common *Common
 ) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 void *klu_l_malloc (size_t, size_t, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 void *klu_l_free (void *, size_t, size_t, klu_l_common *) ;
 
-SUITESPARSE_PUBLIC
+KLU_PUBLIC
 void *klu_l_realloc (size_t, size_t, size_t, void *, klu_l_common *) ;
 
 

--- a/KLU/Include/klu.h
+++ b/KLU/Include/klu.h
@@ -21,10 +21,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( KLU_LIBRARY )

--- a/LDL/CMakeLists.txt
+++ b/LDL/CMakeLists.txt
@@ -76,6 +76,8 @@ set_target_properties ( ldl PROPERTIES
     SOVERSION ${LDL_VERSION_MAJOR}
     PUBLIC_HEADER "Include/ldl.h" )
 
+target_compile_definitions ( ldl PRIVATE LDL_LIBRARY )
+
 #-------------------------------------------------------------------------------
 # static ldl library properties
 #-------------------------------------------------------------------------------
@@ -88,6 +90,8 @@ set_target_properties ( ldl_static PROPERTIES
     C_STANDARD_REQUIRED 11
     OUTPUT_NAME ldl
     SOVERSION ${LDL_VERSION_MAJOR} )
+
+target_compile_definitions ( ldl_static PUBLIC LDL_STATIC )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -95,7 +99,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 # libm:
-if ( NOT MSVC )
+if ( NOT WIN32 )
     set ( M_LIB "" )
 else ( )
     set ( M_LIB "m" )

--- a/LDL/Config/ldl.h.in
+++ b/LDL/Config/ldl.h.in
@@ -9,6 +9,32 @@
 
 #include "SuiteSparse_config.h"
 
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( LDL_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define LDL_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( LDL_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define LDL_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define LDL_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define LDL_PUBLIC extern
+
+#endif
+
+
 #ifdef LDL_LONG
 #define LDL_int int64_t
 #define LDL_ID  "%" PRId64
@@ -43,72 +69,74 @@
 /* === int32_t version ========================================================== */
 /* ========================================================================== */
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_symbolic (int32_t n, int32_t Ap [ ], int32_t Ai [ ], int32_t Lp [ ],
     int32_t Parent [ ], int32_t Lnz [ ], int32_t Flag [ ], int32_t P [ ],
     int32_t Pinv [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 int32_t ldl_numeric (int32_t n, int32_t Ap [ ], int32_t Ai [ ], double Ax [ ],
     int32_t Lp [ ], int32_t Parent [ ], int32_t Lnz [ ], int32_t Li [ ],
     double Lx [ ], double D [ ], double Y [ ], int32_t Pattern [ ],
     int32_t Flag [ ], int32_t P [ ], int32_t Pinv [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_lsolve (int32_t n, double X [ ], int32_t Lp [ ], int32_t Li [ ],
     double Lx [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_dsolve (int32_t n, double X [ ], double D [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_ltsolve (int32_t n, double X [ ], int32_t Lp [ ], int32_t Li [ ],
     double Lx [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_perm  (int32_t n, double X [ ], double B [ ], int32_t P [ ]) ;
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_permt (int32_t n, double X [ ], double B [ ], int32_t P [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 int32_t ldl_valid_perm (int32_t n, int32_t P [ ], int32_t Flag [ ]) ;
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 int32_t ldl_valid_matrix ( int32_t n, int32_t Ap [ ], int32_t Ai [ ]) ;
 
 /* ========================================================================== */
 /* === int64_t version ====================================================== */
 /* ========================================================================== */
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_l_symbolic (int64_t n, int64_t Ap [ ], int64_t Ai [ ], int64_t Lp [ ],
     int64_t Parent [ ], int64_t Lnz [ ], int64_t Flag [ ], int64_t P [ ],
     int64_t Pinv [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 int64_t ldl_l_numeric (int64_t n, int64_t Ap [ ], int64_t Ai [ ], double Ax [ ],
     int64_t Lp [ ], int64_t Parent [ ], int64_t Lnz [ ], int64_t Li [ ],
     double Lx [ ], double D [ ], double Y [ ], int64_t Pattern [ ],
     int64_t Flag [ ], int64_t P [ ], int64_t Pinv [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_l_lsolve (int64_t n, double X [ ], int64_t Lp [ ], int64_t Li [ ],
     double Lx [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_l_dsolve (int64_t n, double X [ ], double D [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_l_ltsolve (int64_t n, double X [ ], int64_t Lp [ ], int64_t Li [ ],
     double Lx [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_l_perm  (int64_t n, double X [ ], double B [ ], int64_t P [ ]) ;
+
+LDL_PUBLIC
 void ldl_l_permt (int64_t n, double X [ ], double B [ ], int64_t P [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 int64_t ldl_l_valid_perm (int64_t n, int64_t P [ ], int64_t Flag [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 int64_t ldl_l_valid_matrix ( int64_t n, int64_t Ap [ ], int64_t Ai [ ]) ;
 
 /* ========================================================================== */

--- a/LDL/Config/ldl.h.in
+++ b/LDL/Config/ldl.h.in
@@ -10,10 +10,10 @@
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( LDL_LIBRARY )
@@ -29,7 +29,7 @@
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define LDL_PUBLIC extern
 
 #endif

--- a/LDL/Include/ldl.h
+++ b/LDL/Include/ldl.h
@@ -9,6 +9,32 @@
 
 #include "SuiteSparse_config.h"
 
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( LDL_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define LDL_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( LDL_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define LDL_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define LDL_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define LDL_PUBLIC extern
+
+#endif
+
+
 #ifdef LDL_LONG
 #define LDL_int int64_t
 #define LDL_ID  "%" PRId64
@@ -43,72 +69,74 @@
 /* === int32_t version ========================================================== */
 /* ========================================================================== */
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_symbolic (int32_t n, int32_t Ap [ ], int32_t Ai [ ], int32_t Lp [ ],
     int32_t Parent [ ], int32_t Lnz [ ], int32_t Flag [ ], int32_t P [ ],
     int32_t Pinv [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 int32_t ldl_numeric (int32_t n, int32_t Ap [ ], int32_t Ai [ ], double Ax [ ],
     int32_t Lp [ ], int32_t Parent [ ], int32_t Lnz [ ], int32_t Li [ ],
     double Lx [ ], double D [ ], double Y [ ], int32_t Pattern [ ],
     int32_t Flag [ ], int32_t P [ ], int32_t Pinv [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_lsolve (int32_t n, double X [ ], int32_t Lp [ ], int32_t Li [ ],
     double Lx [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_dsolve (int32_t n, double X [ ], double D [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_ltsolve (int32_t n, double X [ ], int32_t Lp [ ], int32_t Li [ ],
     double Lx [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_perm  (int32_t n, double X [ ], double B [ ], int32_t P [ ]) ;
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_permt (int32_t n, double X [ ], double B [ ], int32_t P [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 int32_t ldl_valid_perm (int32_t n, int32_t P [ ], int32_t Flag [ ]) ;
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 int32_t ldl_valid_matrix ( int32_t n, int32_t Ap [ ], int32_t Ai [ ]) ;
 
 /* ========================================================================== */
 /* === int64_t version ====================================================== */
 /* ========================================================================== */
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_l_symbolic (int64_t n, int64_t Ap [ ], int64_t Ai [ ], int64_t Lp [ ],
     int64_t Parent [ ], int64_t Lnz [ ], int64_t Flag [ ], int64_t P [ ],
     int64_t Pinv [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 int64_t ldl_l_numeric (int64_t n, int64_t Ap [ ], int64_t Ai [ ], double Ax [ ],
     int64_t Lp [ ], int64_t Parent [ ], int64_t Lnz [ ], int64_t Li [ ],
     double Lx [ ], double D [ ], double Y [ ], int64_t Pattern [ ],
     int64_t Flag [ ], int64_t P [ ], int64_t Pinv [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_l_lsolve (int64_t n, double X [ ], int64_t Lp [ ], int64_t Li [ ],
     double Lx [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_l_dsolve (int64_t n, double X [ ], double D [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_l_ltsolve (int64_t n, double X [ ], int64_t Lp [ ], int64_t Li [ ],
     double Lx [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 void ldl_l_perm  (int64_t n, double X [ ], double B [ ], int64_t P [ ]) ;
+
+LDL_PUBLIC
 void ldl_l_permt (int64_t n, double X [ ], double B [ ], int64_t P [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 int64_t ldl_l_valid_perm (int64_t n, int64_t P [ ], int64_t Flag [ ]) ;
 
-SUITESPARSE_PUBLIC 
+LDL_PUBLIC
 int64_t ldl_l_valid_matrix ( int64_t n, int64_t Ap [ ], int64_t Ai [ ]) ;
 
 /* ========================================================================== */

--- a/LDL/Include/ldl.h
+++ b/LDL/Include/ldl.h
@@ -10,10 +10,10 @@
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( LDL_LIBRARY )
@@ -29,7 +29,7 @@
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define LDL_PUBLIC extern
 
 #endif

--- a/RBio/CMakeLists.txt
+++ b/RBio/CMakeLists.txt
@@ -71,6 +71,8 @@ set_target_properties ( rbio PROPERTIES
     SOVERSION ${RBIO_VERSION_MAJOR}
     PUBLIC_HEADER "Include/RBio.h" )
 
+target_compile_definitions ( rbio PRIVATE RBIO_LIBRARY )
+
 #-------------------------------------------------------------------------------
 # static rbio library properties
 #-------------------------------------------------------------------------------
@@ -83,6 +85,8 @@ set_target_properties ( rbio_static PROPERTIES
     C_STANDARD_REQUIRED 11
     OUTPUT_NAME rbio
     SOVERSION ${RBIO_VERSION_MAJOR} )
+
+target_compile_definitions ( rbio_static PUBLIC RBIO_STATIC )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -96,7 +100,7 @@ target_link_libraries ( rbio_static PUBLIC ${SUITESPARSE_CONFIG_LIBRARIES} )
 endif ( )
 
 # libm:
-if ( NOT MSVC )
+if ( NOT WIN32 )
     target_link_libraries ( rbio PUBLIC m )
     if ( NOT NSTATIC )
     target_link_libraries ( rbio_static PUBLIC m )
@@ -115,7 +119,7 @@ if ( GLOBAL_INSTALL )
         LIBRARY       DESTINATION ${CMAKE_INSTALL_LIBDIR}
         PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} )
     install ( FILES ${CMAKE_SOURCE_DIR}/cmake_modules/FindRBio.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SuiteSparse 
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SuiteSparse
         COMPONENT Development )
     if ( NOT NSTATIC )
     install ( TARGETS rbio_static
@@ -132,7 +136,7 @@ if ( INSIDE_SUITESPARSE )
         LIBRARY       DESTINATION ${SUITESPARSE_LIBDIR}
         PUBLIC_HEADER DESTINATION ${SUITESPARSE_INCLUDEDIR} )
     install ( FILES ${CMAKE_SOURCE_DIR}/cmake_modules/FindRBio.cmake
-        DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SuiteSparse 
+        DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SuiteSparse
         COMPONENT Development )
     if ( NOT NSTATIC )
     install ( TARGETS rbio_static

--- a/RBio/Config/RBio.h.in
+++ b/RBio/Config/RBio.h.in
@@ -53,6 +53,31 @@ extern "C" {
 
 #include "SuiteSparse_config.h"
 
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( RBIO_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define RBIO_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( RBIO_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define RBIO_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define RBIO_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define RBIO_PUBLIC extern
+
+#endif
+
 /* -------------------------------------------------------------------------- */
 /* error codes */
 /* -------------------------------------------------------------------------- */
@@ -111,7 +136,7 @@ extern "C" {
     integers have the _i suffix appended to their names.
 */
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBkind_i        /* 0: OK, < 0: error, > 0: warning */
 (
     /* input */
@@ -135,13 +160,13 @@ int RBkind_i        /* 0: OK, < 0: error, > 0: warning */
     int32_t *cp     /* workspace of size ncol+1, undefined on input and output*/
 ) ;
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBkind (int64_t nrow, int64_t ncol,
     int64_t *Ap, int64_t *Ai, double *Ax, double *Az,
     int64_t mkind_in, int64_t *mkind, int64_t *skind,
     char mtype [4], double *xmin, double *xmax, int64_t *cp) ;
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBread_i            /* 0: OK, < 0: error, > 0: warning */
 (
     /* input */
@@ -169,7 +194,7 @@ int RBread_i            /* 0: OK, < 0: error, > 0: warning */
     int32_t **Zi        /* row indices of Z */
 ) ;
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBread (char *filename, int64_t build_upper,
     int64_t zero_handling, char title [73], char key [9],
     char mtype [4], int64_t *nrow, int64_t *ncol,
@@ -178,7 +203,7 @@ int RBread (char *filename, int64_t build_upper,
     double **Ax, double **Az, int64_t **Zp, int64_t **Zi) ;
 
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBreadraw_i         /* 0: OK, < 0: error, > 0: warning */
 (
     /* input */
@@ -204,7 +229,7 @@ int RBreadraw_i         /* 0: OK, < 0: error, > 0: warning */
 ) ;
 
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBreadraw (char *filename, char title [73], char key [9],
     char mtype[4], int64_t *nrow, int64_t *ncol,
     int64_t *nnz, int64_t *nelnz, int64_t *mkind,
@@ -212,7 +237,7 @@ int RBreadraw (char *filename, char title [73], char key [9],
     int64_t **p_Ap, int64_t **p_Ai, double **p_Ax) ;
 
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBwrite_i       /* 0:OK, < 0: error, > 0: warning */
 (
     /* input */
@@ -233,14 +258,14 @@ int RBwrite_i       /* 0:OK, < 0: error, > 0: warning */
     char mtype [4]  /* matrix type (RUA, RSA, etc), may be NULL */
 ) ;
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBwrite (char *filename, char *title, char *key,
     int64_t nrow, int64_t ncol, int64_t *Ap,
     int64_t *Ai, double *Ax, double *Az, int64_t *Zp,
     int64_t *Zi, int64_t mkind_in, char mtype [4]) ;
 
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 void RBget_entry_i
 (
     int32_t mkind,      /* R: 0, P: 1, C: 2, I: 3 */
@@ -251,12 +276,12 @@ void RBget_entry_i
     double *xz          /* imaginary part */
 ) ;
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 void RBget_entry (int64_t mkind, double *Ax, double *Az,
     int64_t p, double *xr, double *xz) ;
 
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 void RBput_entry_i
 (
     int32_t mkind,      /* R: 0, P: 1, C: 2, I: 3 */
@@ -267,12 +292,12 @@ void RBput_entry_i
     double xz           /* imaginary part */
 ) ;
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 void RBput_entry (int64_t mkind, double *Ax, double *Az,
     int64_t p, double xr, double xz) ;
 
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBok_i          /* 0:OK, < 0: error, > 0: warning */
 (
     /* inputs, not modified */
@@ -292,14 +317,14 @@ int RBok_i          /* 0:OK, < 0: error, > 0: warning */
     int32_t *p_nzeros      /* number of explicit zeros (-1 if not computed) */
 ) ;
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBok (int64_t nrow, int64_t ncol,
     int64_t nzmax, int64_t *Ap, int64_t *Ai,
     double *Ax, double *Az, char *As, int64_t mkind,
     int64_t *p_njumbled, int64_t *p_nzeros) ;
 
 #ifdef MATLAB_MEX_FILE
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 void RBerror (int status) ;     /* only for MATLAB mexFunctions */
 #endif
 

--- a/RBio/Config/RBio.h.in
+++ b/RBio/Config/RBio.h.in
@@ -54,10 +54,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( RBIO_LIBRARY )
@@ -73,7 +73,7 @@ extern "C" {
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define RBIO_PUBLIC extern
 
 #endif

--- a/RBio/Include/RBio.h
+++ b/RBio/Include/RBio.h
@@ -53,6 +53,31 @@ extern "C" {
 
 #include "SuiteSparse_config.h"
 
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( RBIO_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define RBIO_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( RBIO_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define RBIO_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define RBIO_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define RBIO_PUBLIC extern
+
+#endif
+
 /* -------------------------------------------------------------------------- */
 /* error codes */
 /* -------------------------------------------------------------------------- */
@@ -111,7 +136,7 @@ extern "C" {
     integers have the _i suffix appended to their names.
 */
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBkind_i        /* 0: OK, < 0: error, > 0: warning */
 (
     /* input */
@@ -135,13 +160,13 @@ int RBkind_i        /* 0: OK, < 0: error, > 0: warning */
     int32_t *cp     /* workspace of size ncol+1, undefined on input and output*/
 ) ;
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBkind (int64_t nrow, int64_t ncol,
     int64_t *Ap, int64_t *Ai, double *Ax, double *Az,
     int64_t mkind_in, int64_t *mkind, int64_t *skind,
     char mtype [4], double *xmin, double *xmax, int64_t *cp) ;
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBread_i            /* 0: OK, < 0: error, > 0: warning */
 (
     /* input */
@@ -169,7 +194,7 @@ int RBread_i            /* 0: OK, < 0: error, > 0: warning */
     int32_t **Zi        /* row indices of Z */
 ) ;
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBread (char *filename, int64_t build_upper,
     int64_t zero_handling, char title [73], char key [9],
     char mtype [4], int64_t *nrow, int64_t *ncol,
@@ -178,7 +203,7 @@ int RBread (char *filename, int64_t build_upper,
     double **Ax, double **Az, int64_t **Zp, int64_t **Zi) ;
 
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBreadraw_i         /* 0: OK, < 0: error, > 0: warning */
 (
     /* input */
@@ -204,7 +229,7 @@ int RBreadraw_i         /* 0: OK, < 0: error, > 0: warning */
 ) ;
 
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBreadraw (char *filename, char title [73], char key [9],
     char mtype[4], int64_t *nrow, int64_t *ncol,
     int64_t *nnz, int64_t *nelnz, int64_t *mkind,
@@ -212,7 +237,7 @@ int RBreadraw (char *filename, char title [73], char key [9],
     int64_t **p_Ap, int64_t **p_Ai, double **p_Ax) ;
 
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBwrite_i       /* 0:OK, < 0: error, > 0: warning */
 (
     /* input */
@@ -233,14 +258,14 @@ int RBwrite_i       /* 0:OK, < 0: error, > 0: warning */
     char mtype [4]  /* matrix type (RUA, RSA, etc), may be NULL */
 ) ;
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBwrite (char *filename, char *title, char *key,
     int64_t nrow, int64_t ncol, int64_t *Ap,
     int64_t *Ai, double *Ax, double *Az, int64_t *Zp,
     int64_t *Zi, int64_t mkind_in, char mtype [4]) ;
 
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 void RBget_entry_i
 (
     int32_t mkind,      /* R: 0, P: 1, C: 2, I: 3 */
@@ -251,12 +276,12 @@ void RBget_entry_i
     double *xz          /* imaginary part */
 ) ;
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 void RBget_entry (int64_t mkind, double *Ax, double *Az,
     int64_t p, double *xr, double *xz) ;
 
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 void RBput_entry_i
 (
     int32_t mkind,      /* R: 0, P: 1, C: 2, I: 3 */
@@ -267,12 +292,12 @@ void RBput_entry_i
     double xz           /* imaginary part */
 ) ;
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 void RBput_entry (int64_t mkind, double *Ax, double *Az,
     int64_t p, double xr, double xz) ;
 
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBok_i          /* 0:OK, < 0: error, > 0: warning */
 (
     /* inputs, not modified */
@@ -292,14 +317,14 @@ int RBok_i          /* 0:OK, < 0: error, > 0: warning */
     int32_t *p_nzeros      /* number of explicit zeros (-1 if not computed) */
 ) ;
 
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 int RBok (int64_t nrow, int64_t ncol,
     int64_t nzmax, int64_t *Ap, int64_t *Ai,
     double *Ax, double *Az, char *As, int64_t mkind,
     int64_t *p_njumbled, int64_t *p_nzeros) ;
 
 #ifdef MATLAB_MEX_FILE
-SUITESPARSE_PUBLIC 
+RBIO_PUBLIC
 void RBerror (int status) ;     /* only for MATLAB mexFunctions */
 #endif
 

--- a/RBio/Include/RBio.h
+++ b/RBio/Include/RBio.h
@@ -54,10 +54,10 @@ extern "C" {
 #include "SuiteSparse_config.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( RBIO_LIBRARY )
@@ -73,7 +73,7 @@ extern "C" {
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define RBIO_PUBLIC extern
 
 #endif

--- a/RBio/Source/RBio.c
+++ b/RBio/Source/RBio.c
@@ -39,7 +39,7 @@
 #define ISNAN(a) ((a) != (a))
 
 #define PRIVATE static
-#define PUBLIC SUITESPARSE_PUBLIC
+#define PUBLIC RBIO_PUBLIC
 
 #define SLEN 4096
 #define FREE_WORK   { SuiteSparse_free (w) ; \

--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -76,6 +76,8 @@ set_target_properties ( suitesparseconfig PROPERTIES
     SOVERSION ${SUITESPARSE_VERSION_MAJOR}
     PUBLIC_HEADER "SuiteSparse_config.h" )
 
+target_compile_definitions ( suitesparseconfig PRIVATE SUITESPARSE_LIBRARY )
+
 #-------------------------------------------------------------------------------
 # static suitesparseconfig library properties
 #-------------------------------------------------------------------------------
@@ -88,6 +90,8 @@ if ( NOT NSTATIC )
         C_STANDARD_REQUIRED 11
         OUTPUT_NAME suitesparseconfig
         SOVERSION ${SUITESPARSE_VERSION_MAJOR} )
+
+target_compile_definitions ( suitesparseconfig_static PUBLIC SUITESPARSE_STATIC )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -95,7 +99,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 # libm:
-if ( NOT MSVC )
+if ( NOT WIN32 )
     target_link_libraries ( suitesparseconfig PUBLIC m )
     if ( NOT NSTATIC )
         target_link_libraries ( suitesparseconfig_static PUBLIC m )

--- a/SuiteSparse_config/Config/SuiteSparse_config.h.in
+++ b/SuiteSparse_config/Config/SuiteSparse_config.h.in
@@ -115,7 +115,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_GCC     0
     #define SUITESPARSE_COMPILER_MSC     0
     #define SUITESPARSE_COMPILER_XLC     0
-    #define SUITESPARSE_COMPILER_MINGW   0
 
     #define SUITESPARSE_COMPILER_MAJOR __CUDACC_VER_MAJOR__
     #define SUITESPARSE_COMPILER_MINOR __CUDACC_VER_MINOR__
@@ -132,7 +131,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_GCC     0
     #define SUITESPARSE_COMPILER_MSC     0
     #define SUITESPARSE_COMPILER_XLC     0
-    #define SUITESPARSE_COMPILER_MINGW   0
 
     #define SUITESPARSE_COMPILER_MAJOR __INTEL_CLANG_COMPILER
     #define SUITESPARSE_COMPILER_MINOR 0
@@ -149,7 +147,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_GCC     0
     #define SUITESPARSE_COMPILER_MSC     0
     #define SUITESPARSE_COMPILER_XLC     0
-    #define SUITESPARSE_COMPILER_MINGW   0
 
     #define SUITESPARSE_COMPILER_MAJOR __INTEL_COMPILER
     #define SUITESPARSE_COMPILER_MINOR __INTEL_COMPILER_UPDATE
@@ -166,7 +163,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_GCC     0
     #define SUITESPARSE_COMPILER_MSC     0
     #define SUITESPARSE_COMPILER_XLC     0
-    #define SUITESPARSE_COMPILER_MINGW   0
 
     #define SUITESPARSE_COMPILER_MAJOR __clang_major__
     #define SUITESPARSE_COMPILER_MINOR __clang_minor__
@@ -183,7 +179,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_GCC     0
     #define SUITESPARSE_COMPILER_MSC     0
     #define SUITESPARSE_COMPILER_XLC     1
-    #define SUITESPARSE_COMPILER_MINGW   0
 
     #define SUITESPARSE_COMPILER_MAJOR ( __xlC__ / 256 )
     #define SUITESPARSE_COMPILER_MINOR \
@@ -201,7 +196,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_GCC     1
     #define SUITESPARSE_COMPILER_MSC     0
     #define SUITESPARSE_COMPILER_XLC     0
-    #define SUITESPARSE_COMPILER_MINGW   0
 
     #define SUITESPARSE_COMPILER_MAJOR __GNUC__
     #define SUITESPARSE_COMPILER_MINOR __GNUC_MINOR__
@@ -221,7 +215,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_GCC     0
     #define SUITESPARSE_COMPILER_MSC     1
     #define SUITESPARSE_COMPILER_XLC     0
-    #define SUITESPARSE_COMPILER_MINGW   0
 
     #define SUITESPARSE_COMPILER_MAJOR ( _MSC_VER / 100 )
     #define SUITESPARSE_COMPILER_MINOR \
@@ -229,28 +222,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_SUB   0
     #define SUITESPARSE_COMPILER_NAME  \
         "Microsoft Visual Studio " SUITESPARSE_XSTR (_MSC_VER)
-
-#elif defined ( __MINGW32__ ) || defined ( __MINGW64__ )
-
-    // MinGW (32-bit or 64-bit)
-    #define SUITESPARSE_COMPILER_NVCC    0
-    #define SUITESPARSE_COMPILER_ICX     0
-    #define SUITESPARSE_COMPILER_ICC     0
-    #define SUITESPARSE_COMPILER_CLANG   0
-    #define SUITESPARSE_COMPILER_GCC     0
-    #define SUITESPARSE_COMPILER_MSC     0
-    #define SUITESPARSE_COMPILER_XLC     0
-    #define SUITESPARSE_COMPILER_MINGW   1
-
-    #if defined ( __MINGW32__ )
-    #define SUITESPARSE_COMPILER_MAJOR ( __MINGW32_MAJOR_VERSION )
-    #define SUITESPARSE_COMPILER_MINOR ( __MINGW32_MINOR_VERSION )
-    #else
-    #define SUITESPARSE_COMPILER_MAJOR ( __MINGW64_MAJOR_VERSION )
-    #define SUITESPARSE_COMPILER_MINOR ( __MINGW64_MINOR_VERSION )
-    #endif
-    #define SUITESPARSE_COMPILER_SUB   0
-    #define SUITESPARSE_COMPILER_NAME  "MinGW"
 
 #else
 
@@ -262,7 +233,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_GCC     0
     #define SUITESPARSE_COMPILER_MSC     0
     #define SUITESPARSE_COMPILER_XLC     0
-    #define SUITESPARSE_COMPILER_MINGW   0
 
     #define SUITESPARSE_COMPILER_MAJOR 0
     #define SUITESPARSE_COMPILER_MINOR 0
@@ -280,15 +250,18 @@ extern "C"
 #endif
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols for Microsoft Visual Studio
+// importing/exporting symbols on Windows
 //------------------------------------------------------------------------------
 
-#if SUITESPARSE_COMPILER_MSC
+#if defined ( _WIN32 )
 
-    // import/export for MS Visual Studio
-    #ifdef SUITESPARSE_LIBRARY
+    // dllimport/dllexport on Windows
+    #if defined ( SUITESPARSE_LIBRARY )
         // compiling SuiteSparse itself, exporting symbols to user apps
         #define SUITESPARSE_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( SUITESPARSE_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define SUITESPARSE_PUBLIC extern
     #else
         // compiling the user application, importing symbols from SuiteSparse
         #define SUITESPARSE_PUBLIC extern __declspec ( dllimport )
@@ -296,7 +269,7 @@ extern "C"
 
 #else
 
-    // for other compilers
+    // for other platforms
     #define SUITESPARSE_PUBLIC extern
 
 #endif
@@ -1469,12 +1442,14 @@ void SUITESPARSE_LAPACK_ZLARF       // apply Householder reflector
 
 // Returns the name of the BLAS library found by SuiteSparse_config
 
+SUITESPARSE_PUBLIC
 const char *SuiteSparse_BLAS_library ( void ) ;
 
 //------------------------------------------------------------------------------
 // SuiteSparse_BLAS_integer_size: return sizeof (SUITESPARSE_BLAS_INT)
 //------------------------------------------------------------------------------
 
+SUITESPARSE_PUBLIC
 size_t SuiteSparse_BLAS_integer_size ( void ) ;
 
 #ifdef __cplusplus

--- a/SuiteSparse_config/Config/SuiteSparse_config.h.in
+++ b/SuiteSparse_config/Config/SuiteSparse_config.h.in
@@ -250,10 +250,10 @@ extern "C"
 #endif
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( SUITESPARSE_LIBRARY )
@@ -269,7 +269,7 @@ extern "C"
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define SUITESPARSE_PUBLIC extern
 
 #endif

--- a/SuiteSparse_config/SuiteSparse_config.c
+++ b/SuiteSparse_config/SuiteSparse_config.c
@@ -11,7 +11,6 @@
 /* SuiteSparse configuration : memory manager and printf functions.
  */
 
-#define SUITESPARSE_LIBRARY
 #include "SuiteSparse_config.h"
 
 /* -------------------------------------------------------------------------- */

--- a/SuiteSparse_config/SuiteSparse_config.h
+++ b/SuiteSparse_config/SuiteSparse_config.h
@@ -115,7 +115,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_GCC     0
     #define SUITESPARSE_COMPILER_MSC     0
     #define SUITESPARSE_COMPILER_XLC     0
-    #define SUITESPARSE_COMPILER_MINGW   0
 
     #define SUITESPARSE_COMPILER_MAJOR __CUDACC_VER_MAJOR__
     #define SUITESPARSE_COMPILER_MINOR __CUDACC_VER_MINOR__
@@ -132,7 +131,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_GCC     0
     #define SUITESPARSE_COMPILER_MSC     0
     #define SUITESPARSE_COMPILER_XLC     0
-    #define SUITESPARSE_COMPILER_MINGW   0
 
     #define SUITESPARSE_COMPILER_MAJOR __INTEL_CLANG_COMPILER
     #define SUITESPARSE_COMPILER_MINOR 0
@@ -149,7 +147,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_GCC     0
     #define SUITESPARSE_COMPILER_MSC     0
     #define SUITESPARSE_COMPILER_XLC     0
-    #define SUITESPARSE_COMPILER_MINGW   0
 
     #define SUITESPARSE_COMPILER_MAJOR __INTEL_COMPILER
     #define SUITESPARSE_COMPILER_MINOR __INTEL_COMPILER_UPDATE
@@ -166,7 +163,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_GCC     0
     #define SUITESPARSE_COMPILER_MSC     0
     #define SUITESPARSE_COMPILER_XLC     0
-    #define SUITESPARSE_COMPILER_MINGW   0
 
     #define SUITESPARSE_COMPILER_MAJOR __clang_major__
     #define SUITESPARSE_COMPILER_MINOR __clang_minor__
@@ -183,7 +179,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_GCC     0
     #define SUITESPARSE_COMPILER_MSC     0
     #define SUITESPARSE_COMPILER_XLC     1
-    #define SUITESPARSE_COMPILER_MINGW   0
 
     #define SUITESPARSE_COMPILER_MAJOR ( __xlC__ / 256 )
     #define SUITESPARSE_COMPILER_MINOR \
@@ -201,7 +196,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_GCC     1
     #define SUITESPARSE_COMPILER_MSC     0
     #define SUITESPARSE_COMPILER_XLC     0
-    #define SUITESPARSE_COMPILER_MINGW   0
 
     #define SUITESPARSE_COMPILER_MAJOR __GNUC__
     #define SUITESPARSE_COMPILER_MINOR __GNUC_MINOR__
@@ -221,7 +215,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_GCC     0
     #define SUITESPARSE_COMPILER_MSC     1
     #define SUITESPARSE_COMPILER_XLC     0
-    #define SUITESPARSE_COMPILER_MINGW   0
 
     #define SUITESPARSE_COMPILER_MAJOR ( _MSC_VER / 100 )
     #define SUITESPARSE_COMPILER_MINOR \
@@ -229,28 +222,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_SUB   0
     #define SUITESPARSE_COMPILER_NAME  \
         "Microsoft Visual Studio " SUITESPARSE_XSTR (_MSC_VER)
-
-#elif defined ( __MINGW32__ ) || defined ( __MINGW64__ )
-
-    // MinGW (32-bit or 64-bit)
-    #define SUITESPARSE_COMPILER_NVCC    0
-    #define SUITESPARSE_COMPILER_ICX     0
-    #define SUITESPARSE_COMPILER_ICC     0
-    #define SUITESPARSE_COMPILER_CLANG   0
-    #define SUITESPARSE_COMPILER_GCC     0
-    #define SUITESPARSE_COMPILER_MSC     0
-    #define SUITESPARSE_COMPILER_XLC     0
-    #define SUITESPARSE_COMPILER_MINGW   1
-
-    #if defined ( __MINGW32__ )
-    #define SUITESPARSE_COMPILER_MAJOR ( __MINGW32_MAJOR_VERSION )
-    #define SUITESPARSE_COMPILER_MINOR ( __MINGW32_MINOR_VERSION )
-    #else
-    #define SUITESPARSE_COMPILER_MAJOR ( __MINGW64_MAJOR_VERSION )
-    #define SUITESPARSE_COMPILER_MINOR ( __MINGW64_MINOR_VERSION )
-    #endif
-    #define SUITESPARSE_COMPILER_SUB   0
-    #define SUITESPARSE_COMPILER_NAME  "MinGW"
 
 #else
 
@@ -262,7 +233,6 @@ extern "C"
     #define SUITESPARSE_COMPILER_GCC     0
     #define SUITESPARSE_COMPILER_MSC     0
     #define SUITESPARSE_COMPILER_XLC     0
-    #define SUITESPARSE_COMPILER_MINGW   0
 
     #define SUITESPARSE_COMPILER_MAJOR 0
     #define SUITESPARSE_COMPILER_MINOR 0
@@ -280,15 +250,18 @@ extern "C"
 #endif
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols for Microsoft Visual Studio
+// importing/exporting symbols on Windows
 //------------------------------------------------------------------------------
 
-#if SUITESPARSE_COMPILER_MSC
+#if defined ( _WIN32 )
 
-    // import/export for MS Visual Studio
-    #ifdef SUITESPARSE_LIBRARY
+    // dllimport/dllexport on Windows
+    #if defined ( SUITESPARSE_LIBRARY )
         // compiling SuiteSparse itself, exporting symbols to user apps
         #define SUITESPARSE_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( SUITESPARSE_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define SUITESPARSE_PUBLIC extern
     #else
         // compiling the user application, importing symbols from SuiteSparse
         #define SUITESPARSE_PUBLIC extern __declspec ( dllimport )
@@ -296,7 +269,7 @@ extern "C"
 
 #else
 
-    // for other compilers
+    // for other platforms
     #define SUITESPARSE_PUBLIC extern
 
 #endif
@@ -1469,12 +1442,14 @@ void SUITESPARSE_LAPACK_ZLARF       // apply Householder reflector
 
 // Returns the name of the BLAS library found by SuiteSparse_config
 
+SUITESPARSE_PUBLIC
 const char *SuiteSparse_BLAS_library ( void ) ;
 
 //------------------------------------------------------------------------------
 // SuiteSparse_BLAS_integer_size: return sizeof (SUITESPARSE_BLAS_INT)
 //------------------------------------------------------------------------------
 
+SUITESPARSE_PUBLIC
 size_t SuiteSparse_BLAS_integer_size ( void ) ;
 
 #ifdef __cplusplus

--- a/SuiteSparse_config/SuiteSparse_config.h
+++ b/SuiteSparse_config/SuiteSparse_config.h
@@ -250,10 +250,10 @@ extern "C"
 #endif
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( SUITESPARSE_LIBRARY )
@@ -269,7 +269,7 @@ extern "C"
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define SUITESPARSE_PUBLIC extern
 
 #endif

--- a/UMFPACK/CMakeLists.txt
+++ b/UMFPACK/CMakeLists.txt
@@ -108,6 +108,8 @@ set_target_properties ( umfpack PROPERTIES
     SOVERSION ${UMFPACK_VERSION_MAJOR}
     PUBLIC_HEADER "Include/umfpack.h" )
 
+target_compile_definitions ( umfpack PRIVATE UMFPACK_LIBRARY )
+
 #-------------------------------------------------------------------------------
 # static umfpack library properties
 #-------------------------------------------------------------------------------
@@ -120,6 +122,8 @@ set_target_properties ( umfpack_static PROPERTIES
     C_STANDARD_REQUIRED 11
     OUTPUT_NAME umfpack
     SOVERSION ${UMFPACK_VERSION_MAJOR} )
+
+target_compile_definitions ( umfpack_static PUBLIC UMFPACK_STATIC )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -146,7 +150,7 @@ if ( OPENMP_FOUND )
 endif ( )
 
 # libm:
-if ( NOT MSVC )
+if ( NOT WIN32 )
     target_link_libraries ( umfpack PUBLIC m )
     if ( NOT NSTATIC )
         target_link_libraries ( umfpack_static PUBLIC m )

--- a/UMFPACK/Config/umfpack.h.in
+++ b/UMFPACK/Config/umfpack.h.in
@@ -34,10 +34,10 @@ extern "C" {
 #include "amd.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( UMFPACK_LIBRARY )
@@ -53,7 +53,7 @@ extern "C" {
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define UMFPACK_PUBLIC extern
 
 #endif

--- a/UMFPACK/Config/umfpack.h.in
+++ b/UMFPACK/Config/umfpack.h.in
@@ -33,6 +33,31 @@ extern "C" {
 #include "SuiteSparse_config.h"
 #include "amd.h"
 
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( UMFPACK_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define UMFPACK_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( UMFPACK_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define UMFPACK_PUBLIC extern
+    #else
+        // compiling the user application, importing symbols from SuiteSparse
+        #define UMFPACK_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define UMFPACK_PUBLIC extern
+
+#endif
+
 /* -------------------------------------------------------------------------- */
 /* size of Info and Control arrays */
 /* -------------------------------------------------------------------------- */
@@ -53,7 +78,7 @@ extern "C" {
 #define UMFPACK_LICENSE_PART1 \
 "\nUMFPACK License: SPDX-License-Identifier: GPL-2.0+\n" \
 "   UMFPACK is available under alternate licenses,\n" \
-"   contact T. Davis for details.\n" 
+"   contact T. Davis for details.\n"
 
 #define UMFPACK_LICENSE_PART2 "\n"
 
@@ -385,7 +410,7 @@ extern "C" {
 // umfpack_symbolic
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_symbolic
 (
     int32_t n_row,
@@ -398,7 +423,7 @@ int umfpack_di_symbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_symbolic
 (
     int64_t n_row,
@@ -411,7 +436,7 @@ int umfpack_dl_symbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_symbolic
 (
     int32_t n_row,
@@ -424,7 +449,7 @@ int umfpack_zi_symbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_symbolic
 (
     int64_t n_row,
@@ -924,7 +949,7 @@ Arguments:
 // umfpack_numeric
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_numeric
 (
     const int32_t Ap [ ],
@@ -936,7 +961,7 @@ int umfpack_di_numeric
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_numeric
 (
     const int64_t Ap [ ],
@@ -948,7 +973,7 @@ int umfpack_dl_numeric
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_numeric
 (
     const int32_t Ap [ ],
@@ -960,7 +985,7 @@ int umfpack_zi_numeric
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_numeric
 (
     const int64_t Ap [ ],
@@ -1468,7 +1493,7 @@ Arguments:
 // umfpack_solve
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_solve
 (
     int sys,
@@ -1482,7 +1507,7 @@ int umfpack_di_solve
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_solve
 (
     int sys,
@@ -1496,7 +1521,7 @@ int umfpack_dl_solve
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_solve
 (
     int sys,
@@ -1510,7 +1535,7 @@ int umfpack_zi_solve
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_solve
 (
     int sys,
@@ -1774,25 +1799,25 @@ Arguments:
 // umfpack_free_symbolic
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_di_free_symbolic
 (
     void **Symbolic
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_dl_free_symbolic
 (
     void **Symbolic
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zi_free_symbolic
 (
     void **Symbolic
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zl_free_symbolic
 (
     void **Symbolic
@@ -1840,25 +1865,25 @@ Arguments:
 // umfpack_free_numeric
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_di_free_numeric
 (
     void **Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_dl_free_numeric
 (
     void **Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zi_free_numeric
 (
     void **Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zl_free_numeric
 (
     void **Numeric
@@ -1910,25 +1935,25 @@ Arguments:
 // umfpack_defaults
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_di_defaults
 (
     double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_dl_defaults
 (
     double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zi_defaults
 (
     double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zl_defaults
 (
     double Control [UMFPACK_CONTROL]
@@ -1978,7 +2003,7 @@ Arguments:
 // umfpack_qsymbolic
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_qsymbolic
 (
     int32_t n_row,
@@ -1992,7 +2017,7 @@ int umfpack_di_qsymbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_qsymbolic
 (
     int64_t n_row,
@@ -2006,7 +2031,7 @@ int umfpack_dl_qsymbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_qsymbolic
 (
     int32_t n_row,
@@ -2020,7 +2045,7 @@ int umfpack_zi_qsymbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_qsymbolic
 (
     int64_t n_row,
@@ -2034,7 +2059,7 @@ int umfpack_zl_qsymbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_fsymbolic
 (
     int32_t n_row,
@@ -2050,7 +2075,7 @@ int umfpack_di_fsymbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_fsymbolic
 (
     int64_t n_row,
@@ -2066,7 +2091,7 @@ int umfpack_dl_fsymbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_fsymbolic
 (
     int32_t n_row,
@@ -2082,7 +2107,7 @@ int umfpack_zi_fsymbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_fsymbolic
 (
     int64_t n_row,
@@ -2218,7 +2243,7 @@ to the user_ordering (user_params).  The arguments have the following syntax
 // umfpack_paru: support functions for ParU
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_paru_symbolic
 (
     int32_t n_row,
@@ -2236,7 +2261,7 @@ int umfpack_di_paru_symbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_paru_symbolic
 (
     int64_t n_row,
@@ -2254,7 +2279,7 @@ int umfpack_dl_paru_symbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_paru_symbolic
 (
     int32_t n_row,
@@ -2272,7 +2297,7 @@ int umfpack_zi_paru_symbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_paru_symbolic
 (
     int64_t n_row,
@@ -2290,25 +2315,25 @@ int umfpack_zl_paru_symbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_di_paru_free_sw
 (
     void **SW
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_dl_paru_free_sw
 (
     void **SW
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zi_paru_free_sw
 (
     void **SW
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zl_paru_free_sw
 (
     void **SW
@@ -2319,7 +2344,7 @@ void umfpack_zl_paru_free_sw
 // umfpack_wsolve
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_wsolve
 (
     int sys,
@@ -2335,7 +2360,7 @@ int umfpack_di_wsolve
     double W [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_wsolve
 (
     int sys,
@@ -2351,7 +2376,7 @@ int umfpack_dl_wsolve
     double W [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_wsolve
 (
     int32_t sys,
@@ -2367,7 +2392,7 @@ int umfpack_zi_wsolve
     double W [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_wsolve
 (
     int sys,
@@ -2408,7 +2433,7 @@ complex int32_t Syntax:
 
     #include "umfpack.h"
     void *Numeric ;
-    int32_t *Ap, *Ai, *Wi ; 
+    int32_t *Ap, *Ai, *Wi ;
     int sys ;
     double *Bx, *Bz, *Xx, *Xz, *Ax, *Az, *W,
         Info [UMFPACK_INFO], Control [UMFPACK_CONTROL] ;
@@ -2498,7 +2523,7 @@ Arguments:
 // umfpack_triplet_to_col
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_triplet_to_col
 (
     int32_t n_row,
@@ -2513,7 +2538,7 @@ int umfpack_di_triplet_to_col
     int32_t Map [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_triplet_to_col
 (
     int64_t n_row,
@@ -2528,7 +2553,7 @@ int umfpack_dl_triplet_to_col
     int64_t Map [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_triplet_to_col
 (
     int32_t n_row,
@@ -2543,7 +2568,7 @@ int umfpack_zi_triplet_to_col
     int32_t Map [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_triplet_to_col
 (
     int64_t n_row,
@@ -2760,7 +2785,7 @@ Arguments:
 // umfpack_col_to_triplet
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_col_to_triplet
 (
     int32_t n_col,
@@ -2768,7 +2793,7 @@ int umfpack_di_col_to_triplet
     int32_t Tj [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_col_to_triplet
 (
     int64_t n_col,
@@ -2776,7 +2801,7 @@ int umfpack_dl_col_to_triplet
     int64_t Tj [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_col_to_triplet
 (
     int32_t n_col,
@@ -2784,7 +2809,7 @@ int umfpack_zi_col_to_triplet
     int32_t Tj [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_col_to_triplet
 (
     int64_t n_col,
@@ -2869,7 +2894,7 @@ Arguments:
 // umfpack_transpose
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_transpose
 (
     int32_t n_row,
@@ -2884,7 +2909,7 @@ int umfpack_di_transpose
     double Rx [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_transpose
 (
     int64_t n_row,
@@ -2899,7 +2924,7 @@ int umfpack_dl_transpose
     double Rx [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_transpose
 (
     int32_t n_row,
@@ -2915,7 +2940,7 @@ int umfpack_zi_transpose
     int do_conjugate
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_transpose
 (
     int64_t n_row,
@@ -3088,7 +3113,7 @@ Arguments:
 // umfpack_scale
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_scale
 (
     double X [ ],
@@ -3096,7 +3121,7 @@ int umfpack_di_scale
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_scale
 (
     double X [ ],
@@ -3104,7 +3129,7 @@ int umfpack_dl_scale
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_scale
 (
     double Xx [ ],       double Xz [ ],
@@ -3112,7 +3137,7 @@ int umfpack_zi_scale
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_scale
 (
     double Xx [ ],       double Xz [ ],
@@ -3203,7 +3228,7 @@ Arguments:
 // umfpack_get_lunz
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_get_lunz
 (
     int32_t *lnz,
@@ -3214,7 +3239,7 @@ int umfpack_di_get_lunz
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_get_lunz
 (
     int64_t *lnz,
@@ -3225,7 +3250,7 @@ int umfpack_dl_get_lunz
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_get_lunz
 (
     int32_t *lnz,
@@ -3236,7 +3261,7 @@ int umfpack_zi_get_lunz
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_get_lunz
 (
     int64_t *lnz,
@@ -3339,7 +3364,7 @@ Arguments:
 // umfpack_get_numeric
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_get_numeric
 (
     int32_t Lp [ ],
@@ -3356,7 +3381,7 @@ int umfpack_di_get_numeric
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_get_numeric
 (
     int64_t Lp [ ],
@@ -3373,7 +3398,7 @@ int umfpack_dl_get_numeric
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_get_numeric
 (
     int32_t Lp [ ],
@@ -3390,7 +3415,7 @@ int umfpack_zi_get_numeric
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_get_numeric
 (
     int64_t Lp [ ],
@@ -3590,7 +3615,7 @@ Arguments:
 // umfpack_get_symbolic
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_get_symbolic
 (
     int32_t *n_row,
@@ -3612,7 +3637,7 @@ int umfpack_di_get_symbolic
     void *Symbolic
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_get_symbolic
 (
     int64_t *n_row,
@@ -3634,7 +3659,7 @@ int umfpack_dl_get_symbolic
     void *Symbolic
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_get_symbolic
 (
     int32_t *n_row,
@@ -3656,7 +3681,7 @@ int umfpack_zi_get_symbolic
     void *Symbolic
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_get_symbolic
 (
     int64_t *n_row,
@@ -3940,28 +3965,28 @@ Arguments:
 // umfpack_save_numeric
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_save_numeric
 (
     void *Numeric,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_save_numeric
 (
     void *Numeric,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_save_numeric
 (
     void *Numeric,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_save_numeric
 (
     void *Numeric,
@@ -4025,28 +4050,28 @@ Arguments:
 // umfpack_load_numeric
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_load_numeric
 (
     void **Numeric,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_load_numeric
 (
     void **Numeric,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_load_numeric
 (
     void **Numeric,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_load_numeric
 (
     void **Numeric,
@@ -4115,28 +4140,28 @@ Arguments:
 // umfpack_save_symbolic
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_save_symbolic
 (
     void *Symbolic,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_save_symbolic
 (
     void *Symbolic,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_save_symbolic
 (
     void *Symbolic,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_save_symbolic
 (
     void *Symbolic,
@@ -4200,28 +4225,28 @@ Arguments:
 // umfpack_load_symbolic
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_load_symbolic
 (
     void **Symbolic,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_load_symbolic
 (
     void **Symbolic,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_load_symbolic
 (
     void **Symbolic,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_load_symbolic
 (
     void **Symbolic,
@@ -4290,7 +4315,7 @@ Arguments:
 // umfpack_get_determinant
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_get_determinant
 (
     double *Mx,
@@ -4299,7 +4324,7 @@ int umfpack_di_get_determinant
     double User_Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_get_determinant
 (
     double *Mx,
@@ -4308,7 +4333,7 @@ int umfpack_dl_get_determinant
     double User_Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_get_determinant
 (
     double *Mx,
@@ -4318,7 +4343,7 @@ int umfpack_zi_get_determinant
     double User_Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_get_determinant
 (
     double *Mx,
@@ -4484,28 +4509,28 @@ Arguments:
 // umfpack_report_status
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_di_report_status
 (
     const double Control [UMFPACK_CONTROL],
     int status
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_dl_report_status
 (
     const double Control [UMFPACK_CONTROL],
     int status
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zi_report_status
 (
     const double Control [UMFPACK_CONTROL],
     int status
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zl_report_status
 (
     const double Control [UMFPACK_CONTROL],
@@ -4573,28 +4598,28 @@ Arguments:
 // umfpack_report_info
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_di_report_info
 (
     const double Control [UMFPACK_CONTROL],
     const double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_dl_report_info
 (
     const double Control [UMFPACK_CONTROL],
     const double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zi_report_info
 (
     const double Control [UMFPACK_CONTROL],
     const double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zl_report_info
 (
     const double Control [UMFPACK_CONTROL],
@@ -4658,25 +4683,25 @@ Arguments:
 // umfpack_report_control
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_di_report_control
 (
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_dl_report_control
 (
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zi_report_control
 (
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zl_report_control
 (
     const double Control [UMFPACK_CONTROL]
@@ -4733,7 +4758,7 @@ Arguments:
 // umfpack_report_matrix
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_report_matrix
 (
     int32_t n_row,
@@ -4745,7 +4770,7 @@ int umfpack_di_report_matrix
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_report_matrix
 (
     int64_t n_row,
@@ -4757,7 +4782,7 @@ int umfpack_dl_report_matrix
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_report_matrix
 (
     int32_t n_row,
@@ -4769,7 +4794,7 @@ int umfpack_zi_report_matrix
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_report_matrix
 (
     int64_t n_row,
@@ -4939,7 +4964,7 @@ Arguments:
 // umfpack_report_triplet
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_report_triplet
 (
     int32_t n_row,
@@ -4951,7 +4976,7 @@ int umfpack_di_report_triplet
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_report_triplet
 (
     int64_t n_row,
@@ -4963,7 +4988,7 @@ int umfpack_dl_report_triplet
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_report_triplet
 (
     int32_t n_row,
@@ -4975,7 +5000,7 @@ int umfpack_zi_report_triplet
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_report_triplet
 (
     int64_t n_row,
@@ -5093,7 +5118,7 @@ Arguments:
 // umfpack_report_vector
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_report_vector
 (
     int32_t n,
@@ -5101,7 +5126,7 @@ int umfpack_di_report_vector
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_report_vector
 (
     int64_t n,
@@ -5109,7 +5134,7 @@ int umfpack_dl_report_vector
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_report_vector
 (
     int32_t n,
@@ -5117,7 +5142,7 @@ int umfpack_zi_report_vector
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_report_vector
 (
     int64_t n,
@@ -5225,28 +5250,28 @@ Arguments:
 // umfpack_report_symbolic
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_report_symbolic
 (
     void *Symbolic,
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_report_symbolic
 (
     void *Symbolic,
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_report_symbolic
 (
     void *Symbolic,
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_report_symbolic
 (
     void *Symbolic,
@@ -5331,28 +5356,28 @@ Arguments:
 // umfpack_report_numeric
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_report_numeric
 (
     void *Numeric,
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_report_numeric
 (
     void *Numeric,
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_report_numeric
 (
     void *Numeric,
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_report_numeric
 (
     void *Numeric,
@@ -5438,7 +5463,7 @@ Arguments:
 // umfpack_report_perm
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_report_perm
 (
     int32_t np,
@@ -5446,7 +5471,7 @@ int umfpack_di_report_perm
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_report_perm
 (
     int64_t np,
@@ -5454,7 +5479,7 @@ int umfpack_dl_report_perm
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_report_perm
 (
     int32_t np,
@@ -5462,7 +5487,7 @@ int umfpack_zi_report_perm
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_report_perm
 (
     int64_t np,
@@ -5575,10 +5600,10 @@ Arguments:
 // umfpack_tic and umfpack_toc
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_tic (double stats [2]) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_toc (double stats [2]) ;
 
 /*

--- a/UMFPACK/Include/umfpack.h
+++ b/UMFPACK/Include/umfpack.h
@@ -33,6 +33,32 @@ extern "C" {
 #include "SuiteSparse_config.h"
 #include "amd.h"
 
+//------------------------------------------------------------------------------
+// importing/exporting symbols on Windows
+//------------------------------------------------------------------------------
+
+#if defined ( _WIN32 )
+
+    // dllimport/dllexport on Windows
+    #if defined ( UMFPACK_LIBRARY )
+        // compiling SuiteSparse itself, exporting symbols to user apps
+        #define UMFPACK_PUBLIC extern __declspec ( dllexport )
+    #elif defined ( UMFPACK_STATIC )
+        // compiling static library, no dllimport or dllexport
+        #define UMFPACK_PUBLIC extern
+    #else
+#error "NO DEFINES"
+        // compiling the user application, importing symbols from SuiteSparse
+        #define UMFPACK_PUBLIC extern __declspec ( dllimport )
+    #endif
+
+#else
+
+    // for other platforms
+    #define UMFPACK_PUBLIC extern
+
+#endif
+
 /* -------------------------------------------------------------------------- */
 /* size of Info and Control arrays */
 /* -------------------------------------------------------------------------- */
@@ -53,7 +79,7 @@ extern "C" {
 #define UMFPACK_LICENSE_PART1 \
 "\nUMFPACK License: SPDX-License-Identifier: GPL-2.0+\n" \
 "   UMFPACK is available under alternate licenses,\n" \
-"   contact T. Davis for details.\n" 
+"   contact T. Davis for details.\n"
 
 #define UMFPACK_LICENSE_PART2 "\n"
 
@@ -385,7 +411,7 @@ extern "C" {
 // umfpack_symbolic
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_symbolic
 (
     int32_t n_row,
@@ -398,7 +424,7 @@ int umfpack_di_symbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_symbolic
 (
     int64_t n_row,
@@ -411,7 +437,7 @@ int umfpack_dl_symbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_symbolic
 (
     int32_t n_row,
@@ -424,7 +450,7 @@ int umfpack_zi_symbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_symbolic
 (
     int64_t n_row,
@@ -924,7 +950,7 @@ Arguments:
 // umfpack_numeric
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_numeric
 (
     const int32_t Ap [ ],
@@ -936,7 +962,7 @@ int umfpack_di_numeric
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_numeric
 (
     const int64_t Ap [ ],
@@ -948,7 +974,7 @@ int umfpack_dl_numeric
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_numeric
 (
     const int32_t Ap [ ],
@@ -960,7 +986,7 @@ int umfpack_zi_numeric
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_numeric
 (
     const int64_t Ap [ ],
@@ -1468,7 +1494,7 @@ Arguments:
 // umfpack_solve
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_solve
 (
     int sys,
@@ -1482,7 +1508,7 @@ int umfpack_di_solve
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_solve
 (
     int sys,
@@ -1496,7 +1522,7 @@ int umfpack_dl_solve
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_solve
 (
     int sys,
@@ -1510,7 +1536,7 @@ int umfpack_zi_solve
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_solve
 (
     int sys,
@@ -1774,25 +1800,25 @@ Arguments:
 // umfpack_free_symbolic
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_di_free_symbolic
 (
     void **Symbolic
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_dl_free_symbolic
 (
     void **Symbolic
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zi_free_symbolic
 (
     void **Symbolic
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zl_free_symbolic
 (
     void **Symbolic
@@ -1840,25 +1866,25 @@ Arguments:
 // umfpack_free_numeric
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_di_free_numeric
 (
     void **Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_dl_free_numeric
 (
     void **Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zi_free_numeric
 (
     void **Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zl_free_numeric
 (
     void **Numeric
@@ -1910,25 +1936,25 @@ Arguments:
 // umfpack_defaults
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_di_defaults
 (
     double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_dl_defaults
 (
     double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zi_defaults
 (
     double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zl_defaults
 (
     double Control [UMFPACK_CONTROL]
@@ -1978,7 +2004,7 @@ Arguments:
 // umfpack_qsymbolic
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_qsymbolic
 (
     int32_t n_row,
@@ -1992,7 +2018,7 @@ int umfpack_di_qsymbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_qsymbolic
 (
     int64_t n_row,
@@ -2006,7 +2032,7 @@ int umfpack_dl_qsymbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_qsymbolic
 (
     int32_t n_row,
@@ -2020,7 +2046,7 @@ int umfpack_zi_qsymbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_qsymbolic
 (
     int64_t n_row,
@@ -2034,7 +2060,7 @@ int umfpack_zl_qsymbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_fsymbolic
 (
     int32_t n_row,
@@ -2050,7 +2076,7 @@ int umfpack_di_fsymbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_fsymbolic
 (
     int64_t n_row,
@@ -2066,7 +2092,7 @@ int umfpack_dl_fsymbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_fsymbolic
 (
     int32_t n_row,
@@ -2082,7 +2108,7 @@ int umfpack_zi_fsymbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_fsymbolic
 (
     int64_t n_row,
@@ -2218,7 +2244,7 @@ to the user_ordering (user_params).  The arguments have the following syntax
 // umfpack_paru: support functions for ParU
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_paru_symbolic
 (
     int32_t n_row,
@@ -2236,7 +2262,7 @@ int umfpack_di_paru_symbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_paru_symbolic
 (
     int64_t n_row,
@@ -2254,7 +2280,7 @@ int umfpack_dl_paru_symbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_paru_symbolic
 (
     int32_t n_row,
@@ -2272,7 +2298,7 @@ int umfpack_zi_paru_symbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_paru_symbolic
 (
     int64_t n_row,
@@ -2290,25 +2316,25 @@ int umfpack_zl_paru_symbolic
     double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_di_paru_free_sw
 (
     void **SW
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_dl_paru_free_sw
 (
     void **SW
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zi_paru_free_sw
 (
     void **SW
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zl_paru_free_sw
 (
     void **SW
@@ -2319,7 +2345,7 @@ void umfpack_zl_paru_free_sw
 // umfpack_wsolve
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_wsolve
 (
     int sys,
@@ -2335,7 +2361,7 @@ int umfpack_di_wsolve
     double W [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_wsolve
 (
     int sys,
@@ -2351,7 +2377,7 @@ int umfpack_dl_wsolve
     double W [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_wsolve
 (
     int32_t sys,
@@ -2367,7 +2393,7 @@ int umfpack_zi_wsolve
     double W [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_wsolve
 (
     int sys,
@@ -2408,7 +2434,7 @@ complex int32_t Syntax:
 
     #include "umfpack.h"
     void *Numeric ;
-    int32_t *Ap, *Ai, *Wi ; 
+    int32_t *Ap, *Ai, *Wi ;
     int sys ;
     double *Bx, *Bz, *Xx, *Xz, *Ax, *Az, *W,
         Info [UMFPACK_INFO], Control [UMFPACK_CONTROL] ;
@@ -2498,7 +2524,7 @@ Arguments:
 // umfpack_triplet_to_col
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_triplet_to_col
 (
     int32_t n_row,
@@ -2513,7 +2539,7 @@ int umfpack_di_triplet_to_col
     int32_t Map [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_triplet_to_col
 (
     int64_t n_row,
@@ -2528,7 +2554,7 @@ int umfpack_dl_triplet_to_col
     int64_t Map [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_triplet_to_col
 (
     int32_t n_row,
@@ -2543,7 +2569,7 @@ int umfpack_zi_triplet_to_col
     int32_t Map [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_triplet_to_col
 (
     int64_t n_row,
@@ -2760,7 +2786,7 @@ Arguments:
 // umfpack_col_to_triplet
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_col_to_triplet
 (
     int32_t n_col,
@@ -2768,7 +2794,7 @@ int umfpack_di_col_to_triplet
     int32_t Tj [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_col_to_triplet
 (
     int64_t n_col,
@@ -2776,7 +2802,7 @@ int umfpack_dl_col_to_triplet
     int64_t Tj [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_col_to_triplet
 (
     int32_t n_col,
@@ -2784,7 +2810,7 @@ int umfpack_zi_col_to_triplet
     int32_t Tj [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_col_to_triplet
 (
     int64_t n_col,
@@ -2869,7 +2895,7 @@ Arguments:
 // umfpack_transpose
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_transpose
 (
     int32_t n_row,
@@ -2884,7 +2910,7 @@ int umfpack_di_transpose
     double Rx [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_transpose
 (
     int64_t n_row,
@@ -2899,7 +2925,7 @@ int umfpack_dl_transpose
     double Rx [ ]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_transpose
 (
     int32_t n_row,
@@ -2915,7 +2941,7 @@ int umfpack_zi_transpose
     int do_conjugate
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_transpose
 (
     int64_t n_row,
@@ -3088,7 +3114,7 @@ Arguments:
 // umfpack_scale
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_scale
 (
     double X [ ],
@@ -3096,7 +3122,7 @@ int umfpack_di_scale
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_scale
 (
     double X [ ],
@@ -3104,7 +3130,7 @@ int umfpack_dl_scale
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_scale
 (
     double Xx [ ],       double Xz [ ],
@@ -3112,7 +3138,7 @@ int umfpack_zi_scale
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_scale
 (
     double Xx [ ],       double Xz [ ],
@@ -3203,7 +3229,7 @@ Arguments:
 // umfpack_get_lunz
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_get_lunz
 (
     int32_t *lnz,
@@ -3214,7 +3240,7 @@ int umfpack_di_get_lunz
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_get_lunz
 (
     int64_t *lnz,
@@ -3225,7 +3251,7 @@ int umfpack_dl_get_lunz
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_get_lunz
 (
     int32_t *lnz,
@@ -3236,7 +3262,7 @@ int umfpack_zi_get_lunz
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_get_lunz
 (
     int64_t *lnz,
@@ -3339,7 +3365,7 @@ Arguments:
 // umfpack_get_numeric
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_get_numeric
 (
     int32_t Lp [ ],
@@ -3356,7 +3382,7 @@ int umfpack_di_get_numeric
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_get_numeric
 (
     int64_t Lp [ ],
@@ -3373,7 +3399,7 @@ int umfpack_dl_get_numeric
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_get_numeric
 (
     int32_t Lp [ ],
@@ -3390,7 +3416,7 @@ int umfpack_zi_get_numeric
     void *Numeric
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_get_numeric
 (
     int64_t Lp [ ],
@@ -3590,7 +3616,7 @@ Arguments:
 // umfpack_get_symbolic
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_get_symbolic
 (
     int32_t *n_row,
@@ -3612,7 +3638,7 @@ int umfpack_di_get_symbolic
     void *Symbolic
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_get_symbolic
 (
     int64_t *n_row,
@@ -3634,7 +3660,7 @@ int umfpack_dl_get_symbolic
     void *Symbolic
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_get_symbolic
 (
     int32_t *n_row,
@@ -3656,7 +3682,7 @@ int umfpack_zi_get_symbolic
     void *Symbolic
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_get_symbolic
 (
     int64_t *n_row,
@@ -3940,28 +3966,28 @@ Arguments:
 // umfpack_save_numeric
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_save_numeric
 (
     void *Numeric,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_save_numeric
 (
     void *Numeric,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_save_numeric
 (
     void *Numeric,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_save_numeric
 (
     void *Numeric,
@@ -4025,28 +4051,28 @@ Arguments:
 // umfpack_load_numeric
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_load_numeric
 (
     void **Numeric,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_load_numeric
 (
     void **Numeric,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_load_numeric
 (
     void **Numeric,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_load_numeric
 (
     void **Numeric,
@@ -4115,28 +4141,28 @@ Arguments:
 // umfpack_save_symbolic
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_save_symbolic
 (
     void *Symbolic,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_save_symbolic
 (
     void *Symbolic,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_save_symbolic
 (
     void *Symbolic,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_save_symbolic
 (
     void *Symbolic,
@@ -4200,28 +4226,28 @@ Arguments:
 // umfpack_load_symbolic
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_load_symbolic
 (
     void **Symbolic,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_load_symbolic
 (
     void **Symbolic,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_load_symbolic
 (
     void **Symbolic,
     char *filename
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_load_symbolic
 (
     void **Symbolic,
@@ -4290,7 +4316,7 @@ Arguments:
 // umfpack_get_determinant
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_get_determinant
 (
     double *Mx,
@@ -4299,7 +4325,7 @@ int umfpack_di_get_determinant
     double User_Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_get_determinant
 (
     double *Mx,
@@ -4308,7 +4334,7 @@ int umfpack_dl_get_determinant
     double User_Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_get_determinant
 (
     double *Mx,
@@ -4318,7 +4344,7 @@ int umfpack_zi_get_determinant
     double User_Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_get_determinant
 (
     double *Mx,
@@ -4484,28 +4510,28 @@ Arguments:
 // umfpack_report_status
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_di_report_status
 (
     const double Control [UMFPACK_CONTROL],
     int status
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_dl_report_status
 (
     const double Control [UMFPACK_CONTROL],
     int status
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zi_report_status
 (
     const double Control [UMFPACK_CONTROL],
     int status
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zl_report_status
 (
     const double Control [UMFPACK_CONTROL],
@@ -4573,28 +4599,28 @@ Arguments:
 // umfpack_report_info
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_di_report_info
 (
     const double Control [UMFPACK_CONTROL],
     const double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_dl_report_info
 (
     const double Control [UMFPACK_CONTROL],
     const double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zi_report_info
 (
     const double Control [UMFPACK_CONTROL],
     const double Info [UMFPACK_INFO]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zl_report_info
 (
     const double Control [UMFPACK_CONTROL],
@@ -4658,25 +4684,25 @@ Arguments:
 // umfpack_report_control
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_di_report_control
 (
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_dl_report_control
 (
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zi_report_control
 (
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_zl_report_control
 (
     const double Control [UMFPACK_CONTROL]
@@ -4733,7 +4759,7 @@ Arguments:
 // umfpack_report_matrix
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_report_matrix
 (
     int32_t n_row,
@@ -4745,7 +4771,7 @@ int umfpack_di_report_matrix
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_report_matrix
 (
     int64_t n_row,
@@ -4757,7 +4783,7 @@ int umfpack_dl_report_matrix
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_report_matrix
 (
     int32_t n_row,
@@ -4769,7 +4795,7 @@ int umfpack_zi_report_matrix
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_report_matrix
 (
     int64_t n_row,
@@ -4939,7 +4965,7 @@ Arguments:
 // umfpack_report_triplet
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_report_triplet
 (
     int32_t n_row,
@@ -4951,7 +4977,7 @@ int umfpack_di_report_triplet
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_report_triplet
 (
     int64_t n_row,
@@ -4963,7 +4989,7 @@ int umfpack_dl_report_triplet
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_report_triplet
 (
     int32_t n_row,
@@ -4975,7 +5001,7 @@ int umfpack_zi_report_triplet
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_report_triplet
 (
     int64_t n_row,
@@ -5093,7 +5119,7 @@ Arguments:
 // umfpack_report_vector
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_report_vector
 (
     int32_t n,
@@ -5101,7 +5127,7 @@ int umfpack_di_report_vector
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_report_vector
 (
     int64_t n,
@@ -5109,7 +5135,7 @@ int umfpack_dl_report_vector
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_report_vector
 (
     int32_t n,
@@ -5117,7 +5143,7 @@ int umfpack_zi_report_vector
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_report_vector
 (
     int64_t n,
@@ -5225,28 +5251,28 @@ Arguments:
 // umfpack_report_symbolic
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_report_symbolic
 (
     void *Symbolic,
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_report_symbolic
 (
     void *Symbolic,
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_report_symbolic
 (
     void *Symbolic,
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_report_symbolic
 (
     void *Symbolic,
@@ -5331,28 +5357,28 @@ Arguments:
 // umfpack_report_numeric
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_report_numeric
 (
     void *Numeric,
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_report_numeric
 (
     void *Numeric,
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_report_numeric
 (
     void *Numeric,
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_report_numeric
 (
     void *Numeric,
@@ -5438,7 +5464,7 @@ Arguments:
 // umfpack_report_perm
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_di_report_perm
 (
     int32_t np,
@@ -5446,7 +5472,7 @@ int umfpack_di_report_perm
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_dl_report_perm
 (
     int64_t np,
@@ -5454,7 +5480,7 @@ int umfpack_dl_report_perm
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zi_report_perm
 (
     int32_t np,
@@ -5462,7 +5488,7 @@ int umfpack_zi_report_perm
     const double Control [UMFPACK_CONTROL]
 ) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 int umfpack_zl_report_perm
 (
     int64_t np,
@@ -5575,10 +5601,10 @@ Arguments:
 // umfpack_tic and umfpack_toc
 //------------------------------------------------------------------------------
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_tic (double stats [2]) ;
 
-SUITESPARSE_PUBLIC
+UMFPACK_PUBLIC
 void umfpack_toc (double stats [2]) ;
 
 /*

--- a/UMFPACK/Include/umfpack.h
+++ b/UMFPACK/Include/umfpack.h
@@ -34,10 +34,10 @@ extern "C" {
 #include "amd.h"
 
 //------------------------------------------------------------------------------
-// importing/exporting symbols on Windows
+// importing/exporting symbols for Microsoft Visual Studio
 //------------------------------------------------------------------------------
 
-#if defined ( _WIN32 )
+#if SUITESPARSE_COMPILER_MSC
 
     // dllimport/dllexport on Windows
     #if defined ( UMFPACK_LIBRARY )
@@ -47,14 +47,13 @@ extern "C" {
         // compiling static library, no dllimport or dllexport
         #define UMFPACK_PUBLIC extern
     #else
-#error "NO DEFINES"
         // compiling the user application, importing symbols from SuiteSparse
         #define UMFPACK_PUBLIC extern __declspec ( dllimport )
     #endif
 
 #else
 
-    // for other platforms
+    // for other compilers
     #define UMFPACK_PUBLIC extern
 
 #endif

--- a/UMFPACK/Source/umf_internal.h
+++ b/UMFPACK/Source/umf_internal.h
@@ -97,7 +97,7 @@
 #if defined (GLOBAL)
 #undef GLOBAL
 #endif
-#define GLOBAL UMFPACK_PUBLIC
+#define GLOBAL
 
 /* -------------------------------------------------------------------------- */
 /* MATLAB include files */
@@ -741,8 +741,8 @@ typedef struct	/* SWType */
 /* for testing out-of-memory conditions: */
 #define UMF_TCOV_TEST
 
-GLOBAL int umf_fail, umf_fail_lo, umf_fail_hi ;
-GLOBAL int umf_realloc_fail, umf_realloc_lo, umf_realloc_hi ;
+UMFPACK_PUBLIC int umf_fail, umf_fail_lo, umf_fail_hi ;
+UMFPACK_PUBLIC int umf_realloc_fail, umf_realloc_lo, umf_realloc_hi ;
 
 /* for testing malloc count: */
 #define UMF_MALLOC_COUNT

--- a/UMFPACK/Source/umf_internal.h
+++ b/UMFPACK/Source/umf_internal.h
@@ -94,6 +94,11 @@
 #define SUITESPARSE_BLAS_DEFINITIONS
 #include "amd_internal.h"
 
+#if defined (GLOBAL)
+#undef GLOBAL
+#endif
+#define GLOBAL UMFPACK_PUBLIC
+
 /* -------------------------------------------------------------------------- */
 /* MATLAB include files */
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
The `dllimport`/`dllexport` mechanism that is currently used doesn't look correct. The same macros are used for a number of different libraries. But it needs to be dealt with on a per library basis.
E.g., for the functions exported by the `suitesparse_config` library: When a library that links to `suitesparse_config` is compiled, it must `dllexport` its own functions, but `dllimport` the functions from `suitesparse_config`.
Additionally, for static libraries, the `dllimport`/`dllexport` mechanism mustn't be used. (Neither when compiling nor when consuming the static library.)

The proposed changes use dedicated "API" flags for each library and deal with static libraries.

I also took the opportunity to remove the (unused) `SUITESPARSE_COMPILER_MINGW` because MinGW isn't a compiler.
Additionally, I stopped linking to `libm` on Windows in the `CMakeLists.txt` files that are touched by this PR.

I tested with `gcc`/`gfortran` and also made sure that it compiles with `clang`/`flang`. I don't have MSVC. But I hope it should be working with that family of compilers now, too. (At least, for the libraries that were already using those "API" flags.)

MinGW doesn't *need* `dllimport`/`dllexport`. So, I reverted to using that mechanism only for MSVC in a final commit.
