### PR TITLE
Linefeed

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# line endings in repository match line endings on disc
+* -text

--- a/AMD/CMakeLists.txt
+++ b/AMD/CMakeLists.txt
@@ -63,8 +63,10 @@ find_package ( SuiteSparse_config 6.0.2 REQUIRED )
 # configure files
 #-------------------------------------------------------------------------------
 
-configure_file ( "Config/amd.h.in" "${PROJECT_SOURCE_DIR}/Include/amd.h")
-configure_file ( "Config/amd_version.tex.in" "${PROJECT_SOURCE_DIR}/Doc/amd_version.tex")
+configure_file ( "Config/amd.h.in" "${PROJECT_SOURCE_DIR}/Include/amd.h"
+    NEWLINE_STYLE LF )
+configure_file ( "Config/amd_version.tex.in" "${PROJECT_SOURCE_DIR}/Doc/amd_version.tex"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # include directories

--- a/BTF/CMakeLists.txt
+++ b/BTF/CMakeLists.txt
@@ -50,7 +50,8 @@ find_package ( SuiteSparse_config 6.0.2 REQUIRED )
 # configure files
 #-------------------------------------------------------------------------------
 
-configure_file ( "Config/btf.h.in" "${PROJECT_SOURCE_DIR}/Include/btf.h")
+configure_file ( "Config/btf.h.in" "${PROJECT_SOURCE_DIR}/Include/btf.h"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # include directories

--- a/CAMD/CMakeLists.txt
+++ b/CAMD/CMakeLists.txt
@@ -49,8 +49,12 @@ find_package ( SuiteSparse_config 6.0.2 REQUIRED )
 # configure files
 #-------------------------------------------------------------------------------
 
-configure_file ( "Config/camd.h.in" "${PROJECT_SOURCE_DIR}/Include/camd.h" )
-configure_file ( "Config/camd_version.tex.in" "${PROJECT_SOURCE_DIR}/Doc/camd_version.tex" )
+configure_file ( "Config/camd.h.in"
+    "${PROJECT_SOURCE_DIR}/Include/camd.h"
+    NEWLINE_STYLE LF )
+configure_file ( "Config/camd_version.tex.in"
+    "${PROJECT_SOURCE_DIR}/Doc/camd_version.tex"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # include directories

--- a/CCOLAMD/CMakeLists.txt
+++ b/CCOLAMD/CMakeLists.txt
@@ -50,7 +50,8 @@ find_package ( SuiteSparse_config 6.0.2 REQUIRED )
 #-------------------------------------------------------------------------------
 
 configure_file ( "Config/ccolamd.h.in"
-    "${PROJECT_SOURCE_DIR}/Include/ccolamd.h" )
+    "${PROJECT_SOURCE_DIR}/Include/ccolamd.h"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # include directories

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -257,8 +257,12 @@ endif ( )
 # configure files
 #-------------------------------------------------------------------------------
 
-configure_file ( "Config/cholmod.h.in" "${PROJECT_SOURCE_DIR}/Include/cholmod.h")
-configure_file ( "Config/cholmod_version.tex.in" "${PROJECT_SOURCE_DIR}/Doc/cholmod_version.tex")
+configure_file ( "Config/cholmod.h.in"
+    "${PROJECT_SOURCE_DIR}/Include/cholmod.h"
+    NEWLINE_STYLE LF )
+configure_file ( "Config/cholmod_version.tex.in"
+    "${PROJECT_SOURCE_DIR}/Doc/cholmod_version.tex"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # include directories

--- a/COLAMD/CMakeLists.txt
+++ b/COLAMD/CMakeLists.txt
@@ -49,7 +49,9 @@ find_package ( SuiteSparse_config 6.0.2 REQUIRED )
 # configure files
 #-------------------------------------------------------------------------------
 
-configure_file ( "Config/colamd.h.in" "${PROJECT_SOURCE_DIR}/Include/colamd.h" )
+configure_file ( "Config/colamd.h.in"
+    "${PROJECT_SOURCE_DIR}/Include/colamd.h"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # include directories

--- a/CSparse/CMakeLists.txt
+++ b/CSparse/CMakeLists.txt
@@ -60,7 +60,9 @@ project ( csparse
 # Configure cs.h with version number
 #-------------------------------------------------------------------------------
 
-configure_file ( "Config/cs.h.in" "${PROJECT_SOURCE_DIR}/Include/cs.h" )
+configure_file ( "Config/cs.h.in"
+    "${PROJECT_SOURCE_DIR}/Include/cs.h"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # include directories

--- a/CXSparse/CMakeLists.txt
+++ b/CXSparse/CMakeLists.txt
@@ -49,7 +49,9 @@ find_package ( SuiteSparse_config 6.0.2 REQUIRED )
 # Configure cs.h with version number
 #-------------------------------------------------------------------------------
 
-configure_file ( "Config/cs.h.in" "${PROJECT_SOURCE_DIR}/Include/cs.h" )
+configure_file ( "Config/cs.h.in"
+    "${PROJECT_SOURCE_DIR}/Include/cs.h"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # include directories

--- a/Example/CMakeLists.txt
+++ b/Example/CMakeLists.txt
@@ -87,7 +87,9 @@ find_package ( MPFR 4.0.2 REQUIRED )
 # configure files
 #-------------------------------------------------------------------------------
 
-configure_file ( "Config/my.h.in" "${PROJECT_SOURCE_DIR}/Include/my.h")
+configure_file ( "Config/my.h.in"
+    "${PROJECT_SOURCE_DIR}/Include/my.h"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # include directories

--- a/GPUQREngine/CMakeLists.txt
+++ b/GPUQREngine/CMakeLists.txt
@@ -91,7 +91,9 @@ endif ( )
 # configure files
 #-------------------------------------------------------------------------------
 
-configure_file ( "Config/GPUQREngine.hpp.in" "${PROJECT_SOURCE_DIR}/Include/GPUQREngine.hpp")
+configure_file ( "Config/GPUQREngine.hpp.in"
+    "${PROJECT_SOURCE_DIR}/Include/GPUQREngine.hpp"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 

--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -159,11 +159,18 @@ endif ( )
 # Configure Include/GraphBLAS.h and documentation with version number
 #-------------------------------------------------------------------------------
 
-configure_file ( "Config/GraphBLAS.h.in" "${PROJECT_SOURCE_DIR}/Include/GraphBLAS.h" )
-configure_file ( "Config/GraphBLAS_version.tex.in" "${PROJECT_SOURCE_DIR}/Doc/GraphBLAS_version.tex" )
+configure_file ( "Config/GraphBLAS.h.in"
+    "${PROJECT_SOURCE_DIR}/Include/GraphBLAS.h"
+    NEWLINE_STYLE LF )
+configure_file ( "Config/GraphBLAS_version.tex.in"
+    "${PROJECT_SOURCE_DIR}/Doc/GraphBLAS_version.tex"
+    NEWLINE_STYLE LF )
 configure_file ( "Config/GraphBLAS_API_version.tex.in"
-    "${PROJECT_SOURCE_DIR}/Doc/GraphBLAS_API_version.tex" )
-configure_file ( "Config/README.md.in" "${PROJECT_SOURCE_DIR}/README.md" )
+    "${PROJECT_SOURCE_DIR}/Doc/GraphBLAS_API_version.tex"
+    NEWLINE_STYLE LF )
+configure_file ( "Config/README.md.in"
+    "${PROJECT_SOURCE_DIR}/README.md"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # include directories for both graphblas and graphblasdemo libraries

--- a/GraphBLAS/cpu_features/CMakeLists.txt
+++ b/GraphBLAS/cpu_features/CMakeLists.txt
@@ -177,6 +177,7 @@ if(BUILD_TESTING)
     configure_file(
       cmake/googletest.CMakeLists.txt.in
       googletest-download/CMakeLists.txt
+      NEWLINE_STYLE LF
     )
 
     execute_process(

--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -76,8 +76,12 @@ endif ( )
 # configure files
 #-------------------------------------------------------------------------------
 
-configure_file ( "Config/klu.h.in" "${PROJECT_SOURCE_DIR}/Include/klu.h")
-configure_file ( "Config/klu_version.tex.in" "${PROJECT_SOURCE_DIR}/Doc/klu_version.tex")
+configure_file ( "Config/klu.h.in"
+    "${PROJECT_SOURCE_DIR}/Include/klu.h"
+    NEWLINE_STYLE LF )
+configure_file ( "Config/klu_version.tex.in"
+    "${PROJECT_SOURCE_DIR}/Doc/klu_version.tex"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # include directories

--- a/LDL/CMakeLists.txt
+++ b/LDL/CMakeLists.txt
@@ -52,9 +52,11 @@ find_package ( AMD 3.0.2 REQUIRED )
 #-------------------------------------------------------------------------------
 
 configure_file ( "Config/ldl.h.in"
-                 "${PROJECT_SOURCE_DIR}/Include/ldl.h" )
+    "${PROJECT_SOURCE_DIR}/Include/ldl.h"
+    NEWLINE_STYLE LF )
 configure_file ( "Config/ldl_version.tex.in"
-                 "${PROJECT_SOURCE_DIR}/Doc/ldl_version.tex" )
+    "${PROJECT_SOURCE_DIR}/Doc/ldl_version.tex"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # include directories

--- a/Mongoose/CMakeLists.txt
+++ b/Mongoose/CMakeLists.txt
@@ -63,14 +63,17 @@ include ( GNUInstallDirs )
 configure_file (
         "Version/Mongoose_Version.hpp.in"
         "${PROJECT_SOURCE_DIR}/Include/Mongoose_Version.hpp"
+        NEWLINE_STYLE LF
 )
 configure_file (
         "Version/title-info.tex.in"
         "${PROJECT_SOURCE_DIR}/Doc/title-info.tex"
+        NEWLINE_STYLE LF
 )
 configure_file (
         "Version/codemeta.json.in"
         "${PROJECT_SOURCE_DIR}/codemeta.json"
+        NEWLINE_STYLE LF
 )
 
 find_package ( SuiteSparse_config 6.0.2 REQUIRED )

--- a/RBio/CMakeLists.txt
+++ b/RBio/CMakeLists.txt
@@ -49,7 +49,9 @@ find_package ( SuiteSparse_config 6.0.2 REQUIRED )
 # configure files
 #-------------------------------------------------------------------------------
 
-configure_file ( "Config/RBio.h.in" "${PROJECT_SOURCE_DIR}/Include/RBio.h")
+configure_file ( "Config/RBio.h.in"
+    "${PROJECT_SOURCE_DIR}/Include/RBio.h"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # include directories

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -56,8 +56,12 @@ find_package ( MPFR 4.0.2 REQUIRED )    # from SPEX/cmake_modules
 # configure files
 #-------------------------------------------------------------------------------
 
-configure_file ( "Config/SPEX.h.in" "${PROJECT_SOURCE_DIR}/Include/SPEX.h")
-configure_file ( "Config/SPEX_version.tex.in" "${PROJECT_SOURCE_DIR}/Doc/SPEX_version.tex")
+configure_file ( "Config/SPEX.h.in"
+    "${PROJECT_SOURCE_DIR}/Include/SPEX.h"
+    NEWLINE_STYLE LF )
+configure_file ( "Config/SPEX_version.tex.in"
+    "${PROJECT_SOURCE_DIR}/Doc/SPEX_version.tex"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # include directories

--- a/SPQR/CMakeLists.txt
+++ b/SPQR/CMakeLists.txt
@@ -98,9 +98,11 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 configure_file ( "Config/SuiteSparseQR_definitions.h.in"
-    "${PROJECT_SOURCE_DIR}/Include/SuiteSparseQR_definitions.h" )
+    "${PROJECT_SOURCE_DIR}/Include/SuiteSparseQR_definitions.h"
+    NEWLINE_STYLE LF )
 configure_file ( "Config/spqr_version.tex.in"
-    "${PROJECT_SOURCE_DIR}/Doc/spqr_version.tex" )
+    "${PROJECT_SOURCE_DIR}/Doc/spqr_version.tex"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # include directories

--- a/SuiteSparse_GPURuntime/CMakeLists.txt
+++ b/SuiteSparse_GPURuntime/CMakeLists.txt
@@ -60,7 +60,9 @@ find_package ( SuiteSparse_config 6.0.2 REQUIRED )
 # configure files
 #-------------------------------------------------------------------------------
 
-configure_file ( "Config/SuiteSparse_GPURuntime.hpp.in" "${PROJECT_SOURCE_DIR}/Include/SuiteSparse_GPURuntime.hpp")
+configure_file ( "Config/SuiteSparse_GPURuntime.hpp.in"
+    "${PROJECT_SOURCE_DIR}/Include/SuiteSparse_GPURuntime.hpp"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 

--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -61,7 +61,8 @@ include ( SuiteSparseBLAS )
 #-------------------------------------------------------------------------------
 
 configure_file ( "Config/SuiteSparse_config.h.in"
-    "${PROJECT_SOURCE_DIR}/SuiteSparse_config.h" )
+    "${PROJECT_SOURCE_DIR}/SuiteSparse_config.h"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # dynamic suitesparseconfig library properties

--- a/UMFPACK/CMakeLists.txt
+++ b/UMFPACK/CMakeLists.txt
@@ -82,9 +82,11 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 configure_file ( "Config/umfpack.h.in"
-    "${PROJECT_SOURCE_DIR}/Include/umfpack.h" )
+    "${PROJECT_SOURCE_DIR}/Include/umfpack.h"
+    NEWLINE_STYLE LF )
 configure_file ( "Config/umfpack_version.tex.in"
-    "${PROJECT_SOURCE_DIR}/Doc/umfpack_version.tex" )
+    "${PROJECT_SOURCE_DIR}/Doc/umfpack_version.tex"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # include directories


### PR DESCRIPTION
Some (or all?) of the text files that are generated when building are also checked in into the repository.
By default, `cmake` uses `CRLF` (`\r\n`) line endings on Windows. That makes dealing with local checkouts on Windows difficult that are used both for making changes and testing them: A lot of files are differing that don't actually contain changes (apart from the line endings).
Also, Windows is (slowly) migrating away from `CRLF` line endings (see the `*printf` family of functions in UCRT).

This PR explicitly specifies the line ending to be used for generated files to `LF` (which is already the default for `cmake` on Linux - so no changes there).

Alternatively, generated files could be removed from the repository.

Additionally, this PR adds a `.gitattributes` file that specifies that all files should be checked out as is (no encoding translation or line feed changes).
