### PR TITLE
Avoid name conflict of static libraries with MSVC

### DIFF
--- a/AMD/CMakeLists.txt
+++ b/AMD/CMakeLists.txt
@@ -104,6 +104,11 @@ if ( NOT NSTATIC )
         C_STANDARD_REQUIRED 11
         OUTPUT_NAME amd
         SOVERSION ${AMD_VERSION_MAJOR} )
+
+    if ( MSVC )
+        set_target_properties ( amd_static PROPERTIES
+            OUTPUT_NAME amd_static )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/BTF/CMakeLists.txt
+++ b/BTF/CMakeLists.txt
@@ -79,13 +79,18 @@ set_target_properties ( btf PROPERTIES
 #-------------------------------------------------------------------------------
 
 if ( NOT NSTATIC )
-add_library ( btf_static STATIC ${BTF_SOURCES} )
+    add_library ( btf_static STATIC ${BTF_SOURCES} )
 
-set_target_properties ( btf_static PROPERTIES
-    VERSION ${BTF_VERSION_MAJOR}.${BTF_VERSION_MINOR}.${BTF_VERSION_SUB}
-    C_STANDARD_REQUIRED 11
-    OUTPUT_NAME btf
-    SOVERSION ${BTF_VERSION_MAJOR} )
+    set_target_properties ( btf_static PROPERTIES
+        VERSION ${BTF_VERSION_MAJOR}.${BTF_VERSION_MINOR}.${BTF_VERSION_SUB}
+        C_STANDARD_REQUIRED 11
+        OUTPUT_NAME btf
+        SOVERSION ${BTF_VERSION_MAJOR} )
+
+    if ( MSVC )
+        set_target_properties ( btf_static PROPERTIES
+            OUTPUT_NAME btf_static )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/CAMD/CMakeLists.txt
+++ b/CAMD/CMakeLists.txt
@@ -82,13 +82,18 @@ set_target_properties ( camd PROPERTIES
 #-------------------------------------------------------------------------------
 
 if ( NOT NSTATIC )
-add_library ( camd_static STATIC ${CAMD_SOURCES} )
+    add_library ( camd_static STATIC ${CAMD_SOURCES} )
 
-set_target_properties ( camd_static PROPERTIES
-    VERSION ${CAMD_VERSION_MAJOR}.${CAMD_VERSION_MINOR}.${CAMD_VERSION_SUB}
-    C_STANDARD_REQUIRED 11
-    OUTPUT_NAME camd
-    SOVERSION ${CAMD_VERSION_MAJOR} )
+    set_target_properties ( camd_static PROPERTIES
+        VERSION ${CAMD_VERSION_MAJOR}.${CAMD_VERSION_MINOR}.${CAMD_VERSION_SUB}
+        C_STANDARD_REQUIRED 11
+        OUTPUT_NAME camd
+        SOVERSION ${CAMD_VERSION_MAJOR} )
+
+    if ( MSVC )
+        set_target_properties ( camd_static PROPERTIES
+            OUTPUT_NAME camd_static )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/CCOLAMD/CMakeLists.txt
+++ b/CCOLAMD/CMakeLists.txt
@@ -79,13 +79,18 @@ set_target_properties ( ccolamd PROPERTIES
 #-------------------------------------------------------------------------------
 
 if ( NOT NSTATIC )
-add_library ( ccolamd_static STATIC ${CCOLAMD_SOURCES} )
+    add_library ( ccolamd_static STATIC ${CCOLAMD_SOURCES} )
 
-set_target_properties ( ccolamd_static PROPERTIES
-    VERSION ${CCOLAMD_VERSION_MAJOR}.${CCOLAMD_VERSION_MINOR}.${CCOLAMD_VERSION_SUB}
-    OUTPUT_NAME ccolamd
-    C_STANDARD_REQUIRED 11
-    SOVERSION ${CCOLAMD_VERSION_MAJOR} )
+    set_target_properties ( ccolamd_static PROPERTIES
+        VERSION ${CCOLAMD_VERSION_MAJOR}.${CCOLAMD_VERSION_MINOR}.${CCOLAMD_VERSION_SUB}
+        OUTPUT_NAME ccolamd
+        C_STANDARD_REQUIRED 11
+        SOVERSION ${CCOLAMD_VERSION_MAJOR} )
+
+    if ( MSVC )
+        set_target_properties ( ccolamd_static PROPERTIES
+            OUTPUT_NAME ccolamd_static )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -300,18 +300,23 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( NOT NSTATIC )
-add_library ( cholmod_static STATIC ${CHOLMOD_SOURCES} )
+    add_library ( cholmod_static STATIC ${CHOLMOD_SOURCES} )
 
-set_target_properties ( cholmod_static PROPERTIES
-    VERSION ${CHOLMOD_VERSION_MAJOR}.${CHOLMOD_VERSION_MINOR}.${CHOLMOD_VERSION_SUB}
-    C_STANDARD_REQUIRED 11
-    OUTPUT_NAME cholmod
-    SOVERSION ${CHOLMOD_VERSION_MAJOR} )
+    set_target_properties ( cholmod_static PROPERTIES
+        VERSION ${CHOLMOD_VERSION_MAJOR}.${CHOLMOD_VERSION_MINOR}.${CHOLMOD_VERSION_SUB}
+        C_STANDARD_REQUIRED 11
+        OUTPUT_NAME cholmod
+        SOVERSION ${CHOLMOD_VERSION_MAJOR} )
 
-if ( SUITESPARSE_CUDA )
-    set_target_properties ( cholmod_static PROPERTIES CUDA_SEPARABLE_COMPILATION on )
-    set_target_properties ( cholmod_static PROPERTIES POSITION_INDEPENDENT_CODE on )
-endif ( )
+    if ( MSVC )
+        set_target_properties ( cholmod_static PROPERTIES
+            OUTPUT_NAME cholmod_static )
+    endif ( )
+
+    if ( SUITESPARSE_CUDA )
+        set_target_properties ( cholmod_static PROPERTIES CUDA_SEPARABLE_COMPILATION on )
+        set_target_properties ( cholmod_static PROPERTIES POSITION_INDEPENDENT_CODE on )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/COLAMD/CMakeLists.txt
+++ b/COLAMD/CMakeLists.txt
@@ -79,13 +79,18 @@ set_target_properties ( colamd PROPERTIES
 #-------------------------------------------------------------------------------
 
 if ( NOT NSTATIC )
-add_library ( colamd_static STATIC ${COLAMD_SOURCES} )
+    add_library ( colamd_static STATIC ${COLAMD_SOURCES} )
 
-set_target_properties ( colamd_static PROPERTIES
-    VERSION ${COLAMD_VERSION_MAJOR}.${COLAMD_VERSION_MINOR}.${COLAMD_VERSION_SUB}
-    OUTPUT_NAME colamd
-    C_STANDARD_REQUIRED 11
-    SOVERSION ${COLAMD_VERSION_MAJOR} )
+    set_target_properties ( colamd_static PROPERTIES
+        VERSION ${COLAMD_VERSION_MAJOR}.${COLAMD_VERSION_MINOR}.${COLAMD_VERSION_SUB}
+        OUTPUT_NAME colamd
+        C_STANDARD_REQUIRED 11
+        SOVERSION ${COLAMD_VERSION_MAJOR} )
+
+    if ( MSVC )
+        set_target_properties ( colamd_static PROPERTIES
+            OUTPUT_NAME colamd_static )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/CSparse/CMakeLists.txt
+++ b/CSparse/CMakeLists.txt
@@ -95,13 +95,18 @@ set_target_properties ( csparse PROPERTIES
 #-------------------------------------------------------------------------------
 
 if ( NOT NSTATIC )
-add_library ( csparse_static STATIC ${CSPARSE_SOURCES} )
+    add_library ( csparse_static STATIC ${CSPARSE_SOURCES} )
 
-set_target_properties ( csparse_static PROPERTIES
-    VERSION ${CSPARSE_VERSION_MAJOR}.${CSPARSE_VERSION_MINOR}.${CSPARSE_VERSION_SUB}
-    OUTPUT_NAME csparse
-    C_STANDARD_REQUIRED 11
-    SOVERSION ${CSPARSE_VERSION_MAJOR} )
+    set_target_properties ( csparse_static PROPERTIES
+        VERSION ${CSPARSE_VERSION_MAJOR}.${CSPARSE_VERSION_MINOR}.${CSPARSE_VERSION_SUB}
+        OUTPUT_NAME csparse
+        C_STANDARD_REQUIRED 11
+        SOVERSION ${CSPARSE_VERSION_MAJOR} )
+
+    if ( MSVC )
+        set_target_properties ( csparse_static PROPERTIES
+            OUTPUT_NAME csparse_static )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/CXSparse/CMakeLists.txt
+++ b/CXSparse/CMakeLists.txt
@@ -79,13 +79,18 @@ set_target_properties ( cxsparse PROPERTIES
 #-------------------------------------------------------------------------------
 
 if ( NOT NSTATIC )
-add_library ( cxsparse_static STATIC ${CXSPARSE_SOURCES} )
+    add_library ( cxsparse_static STATIC ${CXSPARSE_SOURCES} )
 
-set_target_properties ( cxsparse_static PROPERTIES
-    VERSION ${CXSPARSE_VERSION_MAJOR}.${CXSPARSE_VERSION_MINOR}.${CXSPARSE_VERSION_SUB}
-    OUTPUT_NAME cxsparse
-    C_STANDARD_REQUIRED 11
-    SOVERSION ${CXSPARSE_VERSION_MAJOR} )
+    set_target_properties ( cxsparse_static PROPERTIES
+        VERSION ${CXSPARSE_VERSION_MAJOR}.${CXSPARSE_VERSION_MINOR}.${CXSPARSE_VERSION_SUB}
+        OUTPUT_NAME cxsparse
+        C_STANDARD_REQUIRED 11
+        SOVERSION ${CXSPARSE_VERSION_MAJOR} )
+
+    if ( MSVC )
+        set_target_properties ( cxsparse_static PROPERTIES
+            OUTPUT_NAME cxsparse_static )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/Example/CMakeLists.txt
+++ b/Example/CMakeLists.txt
@@ -124,6 +124,11 @@ set_target_properties ( my_static PROPERTIES
     OUTPUT_NAME my
     SOVERSION ${MY_VERSION_MAJOR} )
 
+if ( MSVC )
+    set_target_properties ( my_static PROPERTIES
+        OUTPUT_NAME my_static )
+endif ( )
+
 #-------------------------------------------------------------------------------
 # add the library dependencies
 #-------------------------------------------------------------------------------

--- a/GPUQREngine/CMakeLists.txt
+++ b/GPUQREngine/CMakeLists.txt
@@ -150,23 +150,28 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( NOT NSTATIC )
-add_library ( gpuqrengine_static STATIC ${GPUQRENGINE_SOURCES} )
+    add_library ( gpuqrengine_static STATIC ${GPUQRENGINE_SOURCES} )
 
-set_target_properties ( gpuqrengine_static PROPERTIES
-    VERSION ${GPUQRENGINE_VERSION_MAJOR}.${GPUQRENGINE_VERSION_MINOR}.${GPUQRENGINE_VERSION_SUB}
-    CXX_STANDARD_REQUIRED 17
-    SOVERSION ${GPUQRENGINE_VERSION_MAJOR} )
+    set_target_properties ( gpuqrengine_static PROPERTIES
+        VERSION ${GPUQRENGINE_VERSION_MAJOR}.${GPUQRENGINE_VERSION_MINOR}.${GPUQRENGINE_VERSION_SUB}
+        CXX_STANDARD_REQUIRED 17
+        SOVERSION ${GPUQRENGINE_VERSION_MAJOR} )
 
-target_include_directories ( gpuqrengine_static PUBLIC
-        ${CUDAToolkit_INCLUDE_DIRS}
-        ${GPUQRENGINE_INCLUDES} )
+    if ( MSVC )
+        set_target_properties ( gpuqrengine_static PROPERTIES
+            OUTPUT_NAME gpuqrengine_static )
+    endif ( )
 
-if ( SUITESPARSE_CUDA )
-    set_target_properties ( gpuqrengine_static PROPERTIES CUDA_SEPARABLE_COMPILATION on )
-    set_target_properties ( gpuqrengine_static PROPERTIES POSITION_INDEPENDENT_CODE on )
-    target_link_libraries ( gpuqrengine_static CUDA::nvrtc CUDA::cudart_static
-        CUDA::nvToolsExt CUDA::cublas )
-endif ( )
+    target_include_directories ( gpuqrengine_static PUBLIC
+            ${CUDAToolkit_INCLUDE_DIRS}
+            ${GPUQRENGINE_INCLUDES} )
+
+    if ( SUITESPARSE_CUDA )
+        set_target_properties ( gpuqrengine_static PROPERTIES CUDA_SEPARABLE_COMPILATION on )
+        set_target_properties ( gpuqrengine_static PROPERTIES POSITION_INDEPENDENT_CODE on )
+        target_link_libraries ( gpuqrengine_static CUDA::nvrtc CUDA::cudart_static
+            CUDA::nvToolsExt CUDA::cublas )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -315,6 +315,12 @@ if ( NOT NSTATIC )
        OUTPUT_NAME graphblas
        SOVERSION ${GraphBLAS_VERSION_MAJOR}
        C_STANDARD_REQUIRED 11 )
+
+    if ( MSVC )
+        set_target_properties ( graphblas_static PROPERTIES
+            OUTPUT_NAME graphblas_static )
+    endif ( )
+
     set_property ( TARGET graphblas_static PROPERTY C_STANDARD 11 )
 
     if ( SUITESPARSE_CUDA )

--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -117,13 +117,18 @@ set_target_properties ( klu PROPERTIES
 #-------------------------------------------------------------------------------
 
 if ( NOT NSTATIC )
-add_library ( klu_static STATIC ${KLU_SOURCES} )
+    add_library ( klu_static STATIC ${KLU_SOURCES} )
 
-set_target_properties ( klu_static PROPERTIES
-    VERSION ${KLU_VERSION_MAJOR}.${KLU_VERSION_MINOR}.${KLU_VERSION_SUB}
-    C_STANDARD_REQUIRED 11
-    OUTPUT_NAME klu
-    SOVERSION ${KLU_VERSION_MAJOR} )
+    set_target_properties ( klu_static PROPERTIES
+        VERSION ${KLU_VERSION_MAJOR}.${KLU_VERSION_MINOR}.${KLU_VERSION_SUB}
+        C_STANDARD_REQUIRED 11
+        OUTPUT_NAME klu
+        SOVERSION ${KLU_VERSION_MAJOR} )
+
+    if ( MSVC )
+        set_target_properties ( klu_static PROPERTIES
+            OUTPUT_NAME klu_static )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/LDL/CMakeLists.txt
+++ b/LDL/CMakeLists.txt
@@ -85,13 +85,18 @@ set_target_properties ( ldl PROPERTIES
 #-------------------------------------------------------------------------------
 
 if ( NOT NSTATIC )
-add_library ( ldl_static STATIC ${LDL_SOURCES} )
+    add_library ( ldl_static STATIC ${LDL_SOURCES} )
 
-set_target_properties ( ldl_static PROPERTIES
-    VERSION ${LDL_VERSION_MAJOR}.${LDL_VERSION_MINOR}.${LDL_VERSION_SUB}
-    C_STANDARD_REQUIRED 11
-    OUTPUT_NAME ldl
-    SOVERSION ${LDL_VERSION_MAJOR} )
+    set_target_properties ( ldl_static PROPERTIES
+        VERSION ${LDL_VERSION_MAJOR}.${LDL_VERSION_MINOR}.${LDL_VERSION_SUB}
+        C_STANDARD_REQUIRED 11
+        OUTPUT_NAME ldl
+        SOVERSION ${LDL_VERSION_MAJOR} )
+
+    if ( MSVC )
+        set_target_properties ( ldl_static PROPERTIES
+            OUTPUT_NAME ldl_static )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/Mongoose/CMakeLists.txt
+++ b/Mongoose/CMakeLists.txt
@@ -183,6 +183,11 @@ set_property(TARGET mongoose_lib PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_target_properties(mongoose_lib
         PROPERTIES OUTPUT_NAME mongoose)
 
+if ( MSVC )
+    set_target_properties ( mongoose_lib PROPERTIES
+        OUTPUT_NAME mongoose_static )
+endif ( )
+
 target_link_libraries(mongoose_lib ${SUITESPARSE_CONFIG_LIBRARY})
 
 if (UNIX AND NOT APPLE)

--- a/RBio/CMakeLists.txt
+++ b/RBio/CMakeLists.txt
@@ -79,13 +79,18 @@ set_target_properties ( rbio PROPERTIES
 #-------------------------------------------------------------------------------
 
 if ( NOT NSTATIC )
-add_library ( rbio_static STATIC ${RBIO_SOURCES} )
+    add_library ( rbio_static STATIC ${RBIO_SOURCES} )
 
-set_target_properties ( rbio_static PROPERTIES
-    VERSION ${RBIO_VERSION_MAJOR}.${RBIO_VERSION_MINOR}.${RBIO_VERSION_SUB}
-    C_STANDARD_REQUIRED 11
-    OUTPUT_NAME rbio
-    SOVERSION ${RBIO_VERSION_MAJOR} )
+    set_target_properties ( rbio_static PROPERTIES
+        VERSION ${RBIO_VERSION_MAJOR}.${RBIO_VERSION_MINOR}.${RBIO_VERSION_SUB}
+        C_STANDARD_REQUIRED 11
+        OUTPUT_NAME rbio
+        SOVERSION ${RBIO_VERSION_MAJOR} )
+
+    if ( MSVC )
+        set_target_properties ( rbio_static PROPERTIES
+            OUTPUT_NAME rbio_static )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -93,13 +93,18 @@ set_target_properties ( spex PROPERTIES
 #-------------------------------------------------------------------------------
 
 if ( NOT NSTATIC )
-add_library ( spex_static STATIC ${SPEX_SOURCES} )
+    add_library ( spex_static STATIC ${SPEX_SOURCES} )
 
-set_target_properties ( spex_static PROPERTIES
-    VERSION ${SPEX_VERSION_MAJOR}.${SPEX_VERSION_MINOR}.${SPEX_VERSION_SUB}
-    C_STANDARD_REQUIRED 11
-    OUTPUT_NAME spex
-    SOVERSION ${SPEX_VERSION_MAJOR} )
+    set_target_properties ( spex_static PROPERTIES
+        VERSION ${SPEX_VERSION_MAJOR}.${SPEX_VERSION_MINOR}.${SPEX_VERSION_SUB}
+        C_STANDARD_REQUIRED 11
+        OUTPUT_NAME spex
+        SOVERSION ${SPEX_VERSION_MAJOR} )
+
+    if ( MSVC )
+        set_target_properties ( spex_static PROPERTIES
+            OUTPUT_NAME spex_static )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/SPQR/CMakeLists.txt
+++ b/SPQR/CMakeLists.txt
@@ -144,14 +144,19 @@ set_target_properties ( spqr PROPERTIES
 #-------------------------------------------------------------------------------
 
 if ( NOT NSTATIC )
-add_library ( spqr_static STATIC ${SPQR_SOURCES} )
+    add_library ( spqr_static STATIC ${SPQR_SOURCES} )
 
-set_target_properties ( spqr_static PROPERTIES
-    VERSION ${SPQR_VERSION_MAJOR}.${SPQR_VERSION_MINOR}.${SPQR_VERSION_SUB}
-    CXX_STANDARD_REQUIRED 11
-    C_STANDARD_REQUIRED 11
-    OUTPUT_NAME spqr
-    SOVERSION ${SPQR_VERSION_MAJOR} )
+    set_target_properties ( spqr_static PROPERTIES
+        VERSION ${SPQR_VERSION_MAJOR}.${SPQR_VERSION_MINOR}.${SPQR_VERSION_SUB}
+        CXX_STANDARD_REQUIRED 11
+        C_STANDARD_REQUIRED 11
+        OUTPUT_NAME spqr
+        SOVERSION ${SPQR_VERSION_MAJOR} )
+
+    if ( MSVC )
+        set_target_properties ( spqr_static PROPERTIES
+            OUTPUT_NAME spqr_static )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/SuiteSparse_GPURuntime/CMakeLists.txt
+++ b/SuiteSparse_GPURuntime/CMakeLists.txt
@@ -112,23 +112,28 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( NOT NSTATIC )
-add_library ( suitesparse_gpuruntime_static STATIC ${SUITESPARSE_GPURUNTIME_SOURCES} )
+    add_library ( suitesparse_gpuruntime_static STATIC ${SUITESPARSE_GPURUNTIME_SOURCES} )
 
-set_target_properties ( suitesparse_gpuruntime_static PROPERTIES
-    VERSION ${SUITESPARSE_GPURUNTIME_VERSION_MAJOR}.${SUITESPARSE_GPURUNTIME_VERSION_MINOR}.${SUITESPARSE_GPURUNTIME_VERSION_SUB}
-    CXX_STANDARD_REQUIRED 17
-    SOVERSION ${SUITESPARSE_GPURUNTIME_VERSION_MAJOR} )
+    set_target_properties ( suitesparse_gpuruntime_static PROPERTIES
+        VERSION ${SUITESPARSE_GPURUNTIME_VERSION_MAJOR}.${SUITESPARSE_GPURUNTIME_VERSION_MINOR}.${SUITESPARSE_GPURUNTIME_VERSION_SUB}
+        CXX_STANDARD_REQUIRED 17
+        SOVERSION ${SUITESPARSE_GPURUNTIME_VERSION_MAJOR} )
 
-target_include_directories ( suitesparse_gpuruntime_static PUBLIC
-        ${CUDAToolkit_INCLUDE_DIRS}
-        ${SUITESPARSE_GPURUNTIME_INCLUDES} )
+    if ( MSVC )
+        set_target_properties ( suitesparse_gpuruntime_static PROPERTIES
+            OUTPUT_NAME suitesparse_gpuruntime_static )
+    endif ( )
 
-if ( SUITESPARSE_CUDA )
-    set_target_properties ( suitesparse_gpuruntime_static PROPERTIES CUDA_SEPARABLE_COMPILATION on )
-    set_target_properties ( suitesparse_gpuruntime_static PROPERTIES POSITION_INDEPENDENT_CODE on )
-    target_link_libraries ( suitesparse_gpuruntime_static CUDA::nvrtc CUDA::cudart_static
-        CUDA::nvToolsExt CUDA::cublas )
-endif ( )
+    target_include_directories ( suitesparse_gpuruntime_static PUBLIC
+            ${CUDAToolkit_INCLUDE_DIRS}
+            ${SUITESPARSE_GPURUNTIME_INCLUDES} )
+
+    if ( SUITESPARSE_CUDA )
+        set_target_properties ( suitesparse_gpuruntime_static PROPERTIES CUDA_SEPARABLE_COMPILATION on )
+        set_target_properties ( suitesparse_gpuruntime_static PROPERTIES POSITION_INDEPENDENT_CODE on )
+        target_link_libraries ( suitesparse_gpuruntime_static CUDA::nvrtc CUDA::cudart_static
+            CUDA::nvToolsExt CUDA::cublas )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -103,6 +103,11 @@ if ( NOT NSTATIC )
         C_STANDARD_REQUIRED 11
         OUTPUT_NAME suitesparseconfig
         SOVERSION ${SUITESPARSE_VERSION_MAJOR} )
+
+    if ( MSVC )
+        set_target_properties ( suitesparseconfig_static PROPERTIES
+            OUTPUT_NAME suitesparseconfig_static )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/UMFPACK/CMakeLists.txt
+++ b/UMFPACK/CMakeLists.txt
@@ -126,13 +126,18 @@ set_target_properties ( umfpack PROPERTIES
 #-------------------------------------------------------------------------------
 
 if ( NOT NSTATIC )
-add_library ( umfpack_static STATIC ${UMFPACK_SOURCES} )
+    add_library ( umfpack_static STATIC ${UMFPACK_SOURCES} )
 
-set_target_properties ( umfpack_static PROPERTIES
-    VERSION ${UMFPACK_VERSION_MAJOR}.${UMFPACK_VERSION_MINOR}.${UMFPACK_VERSION_SUB}
-    C_STANDARD_REQUIRED 11
-    OUTPUT_NAME umfpack
-    SOVERSION ${UMFPACK_VERSION_MAJOR} )
+    set_target_properties ( umfpack_static PROPERTIES
+        VERSION ${UMFPACK_VERSION_MAJOR}.${UMFPACK_VERSION_MINOR}.${UMFPACK_VERSION_SUB}
+        C_STANDARD_REQUIRED 11
+        OUTPUT_NAME umfpack
+        SOVERSION ${UMFPACK_VERSION_MAJOR} )
+
+    if ( MSVC )
+        set_target_properties ( umfpack_static PROPERTIES
+            OUTPUT_NAME umfpack_static )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
During some early attempts to use MSVC to compile SuiteSparse, I ran into errors when building static libraries is not disabled.

There are three "types" of libraries on Windows:
1. static libraries (like on POSIX)
2. dynamic libraries (mostly comparable to shared libraries on POSIX)
3. import libraries

There is no equivalent for the last one on POSIX. To get a rough idea: All symbols must be resolved on link-time on Windows (similar to linking with `-no-undefined` on POSIX). The import libraries are static libraries that provide "glue" at link time that allows using the symbols exported by the dynamic libraries on runtime. (GCC uses some tricks to allow linking to the dynamic libraries "directly" without import libraries. But for some reason it is "better" to link using import libraries.)

For MinGW the default file extensions for those libraries are:
1. `.a`
2. `.dll`
3. `.dll.a`

MSVC uses the following default file extension:
1. `.lib`
2. `.dll`
3. `.lib`

That means, there is a name collision for the static and import libraries if they use the same names. And indeed, ninja fails with an error that multiple rules exist for the same target.

This PR proposes changes to avoid that name conflict by renaming the static libraries for MSVC.

