### PR TITLE
Run CI on PR or on push to feature branches.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches-ignore:
       - '**/dev2'
+      - '**/dev'
+      - '**/stable'
+  pull_request:
 
 concurrency: ci-${{ github.ref }}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,8 +66,10 @@ jobs:
         with:
           path: ~/.ccache
           key: ccache:ubuntu:${{ matrix.compiler }}:${{ github.ref }}:${{ steps.ccache_cache_timestamp.outputs.timestamp }}:${{ github.sha }}
+          # Prefer caches from the same branch. Fall back to caches from the dev branch.
           restore-keys: |
             ccache:ubuntu:${{ matrix.compiler }}:${{ github.ref }}
+            ccache:ubuntu:${{ matrix.compiler }}:refs/head/dev
 
       - name: configure ccache
         env:
@@ -136,8 +138,10 @@ jobs:
         with:
           path: /Users/runner/Library/Caches/ccache
           key: ccache:macos-latest:${{ github.ref }}:${{ steps.ccache_cache_timestamp.outputs.timestamp }}:${{ github.sha }}
+          # Prefer caches from the same branch. Fall back to caches from the dev branch.
           restore-keys: |
             ccache:macos-latest:${{ github.ref }}
+            ccache:macos-latest:refs/head/dev
 
       - name: configure ccache
         # Limit the maximum size to avoid exceeding the total cache limits.
@@ -242,8 +246,10 @@ jobs:
         with:
           path: ${{ steps.ccache_cache_timestamp.outputs.ccachedir }}
           key: ccache:mingw:${{ matrix.msystem }}:${{ github.ref }}:${{ steps.ccache_cache_timestamp.outputs.timestamp }}:${{ github.sha }}
+          # Prefer caches from the same branch. Fall back to caches from the dev branch.
           restore-keys: |
             ccache:mingw:${{ matrix.msystem }}:${{ github.ref }}
+            ccache:mingw:${{ matrix.msystem }}:refs/head/dev
 
       - name: configure ccache
         # Limit the maximum size and switch on compression to avoid exceeding the total disk or cache quota.


### PR DESCRIPTION
Instead of having the CI run after a PR has been merged, it might be better to check if it passes before actually merging the PR. To avoid having the CI run twice (once for the PR and then again after merging), disable running the CI on pushes to any of the "main" branches.

At the same time, it is useful for contributors to check if their changes pass on feature branches. So, continue running the CI for those.