### PR TITLE
Fix detecting static libraries with MSVC

### DIFF
--- a/AMD/cmake_modules/FindAMD.cmake
+++ b/AMD/cmake_modules/FindAMD.cmake
@@ -50,15 +50,17 @@ find_library ( AMD_LIBRARY
 
 if ( MSVC )
     set ( STATIC_SUFFIX .lib )
+    set ( STATIC_NAME amd_static )
 else ( )
     set ( STATIC_SUFFIX .a )
+    set ( STATIC_NAME amd )
 endif ( )
 
 # static AMD library
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( AMD_STATIC
-    NAMES amd
+    NAMES ${STATIC_NAME}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/AMD
     HINTS ${CMAKE_SOURCE_DIR}/../AMD

--- a/BTF/cmake_modules/FindBTF.cmake
+++ b/BTF/cmake_modules/FindBTF.cmake
@@ -50,15 +50,17 @@ find_library ( BTF_LIBRARY
 
 if ( MSVC )
     set ( STATIC_SUFFIX .lib )
+    set ( STATIC_NAME btf_static )
 else ( )
     set ( STATIC_SUFFIX .a )
+    set ( STATIC_NAME btf )
 endif ( )
 
 # static BTF library
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( BTF_STATIC
-    NAMES btf
+    NAMES ${STATIC_NAME}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/BTF
     HINTS ${CMAKE_SOURCE_DIR}/../BTF

--- a/CAMD/cmake_modules/FindCAMD.cmake
+++ b/CAMD/cmake_modules/FindCAMD.cmake
@@ -50,15 +50,17 @@ find_library ( CAMD_LIBRARY
 
 if ( MSVC )
     set ( STATIC_SUFFIX .lib )
+    set ( STATIC_NAME camd_static )
 else ( )
     set ( STATIC_SUFFIX .a )
+    set ( STATIC_NAME camd )
 endif ( )
 
 # static CAMD library
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( CAMD_STATIC
-    NAMES camd
+    NAMES ${STATIC_NAME}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/CAMD
     HINTS ${CMAKE_SOURCE_DIR}/../CAMD

--- a/CCOLAMD/cmake_modules/FindCCOLAMD.cmake
+++ b/CCOLAMD/cmake_modules/FindCCOLAMD.cmake
@@ -50,15 +50,17 @@ find_library ( CCOLAMD_LIBRARY
 
 if ( MSVC )
     set ( STATIC_SUFFIX .lib )
+    set ( STATIC_NAME ccolamd_static )
 else ( )
     set ( STATIC_SUFFIX .a )
+    set ( STATIC_NAME ccolamd )
 endif ( )
 
 # static CCOLAMD library
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( CCOLAMD_STATIC
-    NAMES ccolamd
+    NAMES ${STATIC_NAME}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/CCOLAMD
     HINTS ${CMAKE_SOURCE_DIR}/../CCOLAMD

--- a/CHOLMOD/cmake_modules/FindCHOLMOD.cmake
+++ b/CHOLMOD/cmake_modules/FindCHOLMOD.cmake
@@ -49,15 +49,17 @@ find_library ( CHOLMOD_LIBRARY
 
 if ( MSVC )
     set ( STATIC_SUFFIX .lib )
+    set ( STATIC_NAME cholmod_static )
 else ( )
     set ( STATIC_SUFFIX .a )
+    set ( STATIC_NAME cholmod )
 endif ( )
 
 # static CHOLMOD library
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( CHOLMOD_STATIC
-    NAMES cholmod
+    NAMES ${STATIC_NAME}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/CHOLMOD
     HINTS ${CMAKE_SOURCE_DIR}/../CHOLMOD

--- a/CHOLMOD/cmake_modules/FindCHOLMOD_CUDA.cmake
+++ b/CHOLMOD/cmake_modules/FindCHOLMOD_CUDA.cmake
@@ -58,7 +58,7 @@ endif ( )
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( CHOLMOD_CUDA_STATIC
-    NAMES cholmod_cuda
+    NAMES cholmod_cuda_static
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse
     HINTS ${CMAKE_SOURCE_DIR}/../CHOLMOD/

--- a/COLAMD/cmake_modules/FindCOLAMD.cmake
+++ b/COLAMD/cmake_modules/FindCOLAMD.cmake
@@ -50,15 +50,17 @@ find_library ( COLAMD_LIBRARY
 
 if ( MSVC )
     set ( STATIC_SUFFIX .lib )
+    set ( STATIC_NAME colamd_static )
 else ( )
     set ( STATIC_SUFFIX .a )
+    set ( STATIC_NAME colamd )
 endif ( )
 
 # static COLAMD library
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( COLAMD_STATIC
-    NAMES colamd
+    NAMES ${STATIC_NAME}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/COLAMD
     HINTS ${CMAKE_SOURCE_DIR}/../COLAMD

--- a/CXSparse/cmake_modules/FindCXSparse.cmake
+++ b/CXSparse/cmake_modules/FindCXSparse.cmake
@@ -54,15 +54,17 @@ find_library ( CXSPARSE_LIBRARY
 
 if ( MSVC )
     set ( STATIC_SUFFIX .lib )
+    set ( STATIC_NAME cxsparse_static )
 else ( )
     set ( STATIC_SUFFIX .a )
+    set ( STATIC_NAME cxsparse )
 endif ( )
 
 # static CXSPARSE library
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( CXSPARSE_STATIC
-    NAMES cxsparse
+    NAMES ${STATIC_NAME}
     HINTS ${CXSPARSE_ROOT}
     HINTS ENV CXSPARSE_ROOT
     HINTS ${CMAKE_SOURCE_DIR}/..

--- a/GraphBLAS/cmake_modules/FindGraphBLAS.cmake
+++ b/GraphBLAS/cmake_modules/FindGraphBLAS.cmake
@@ -85,15 +85,17 @@ find_library ( GRAPHBLAS_LIBRARY
 
 if ( MSVC )
     set ( STATIC_SUFFIX .lib )
+    set ( STATIC_NAME graphblas_static )
 else ( )
     set ( STATIC_SUFFIX .a )
+    set ( STATIC_NAME graphblas )
 endif ( )
 
 # static SuiteSparse:GraphBLAS library
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( GRAPHBLAS_STATIC
-  NAMES graphblas
+  NAMES ${STATIC_NAME}
   HINTS ${GRAPHBLAS_ROOT}
   HINTS ENV GRAPHBLAS_ROOT
   HINTS ${CMAKE_SOURCE_DIR}/..

--- a/KLU/cmake_modules/FindKLU.cmake
+++ b/KLU/cmake_modules/FindKLU.cmake
@@ -50,15 +50,17 @@ find_library ( KLU_LIBRARY
 
 if ( MSVC )
     set ( STATIC_SUFFIX .lib )
+    set ( STATIC_NAME klu_static )
 else ( )
     set ( STATIC_SUFFIX .a )
+    set ( STATIC_NAME klu )
 endif ( )
 
 # static KLU library
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( KLU_STATIC
-    NAMES klu
+    NAMES ${STATIC_NAME}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/KLU
     HINTS ${CMAKE_SOURCE_DIR}/../KLU

--- a/KLU/cmake_modules/FindKLU_CHOLMOD.cmake
+++ b/KLU/cmake_modules/FindKLU_CHOLMOD.cmake
@@ -66,7 +66,7 @@ endif ( )
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( KLU_CHOLMOD_STATIC
-    NAMES klu_cholmod
+    NAMES klu_cholmod_static
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/KLU/User
     HINTS ${CMAKE_SOURCE_DIR}/../KLU/User

--- a/LDL/cmake_modules/FindLDL.cmake
+++ b/LDL/cmake_modules/FindLDL.cmake
@@ -50,15 +50,17 @@ find_library ( LDL_LIBRARY
 
 if ( MSVC )
     set ( STATIC_SUFFIX .lib )
+    set ( STATIC_NAME ldl_static )
 else ( )
     set ( STATIC_SUFFIX .a )
+    set ( STATIC_NAME ldl )
 endif ( )
 
 # static LDL library
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( LDL_STATIC
-    NAMES ldl
+    NAMES ${STATIC_NAME}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/LDL
     HINTS ${CMAKE_SOURCE_DIR}/../LDL

--- a/Mongoose/cmake_modules/FindMongoose.cmake
+++ b/Mongoose/cmake_modules/FindMongoose.cmake
@@ -54,15 +54,17 @@ find_library ( MONGOOSE_LIBRARY
 
 if ( MSVC )
     set ( STATIC_SUFFIX .lib )
+    set ( STATIC_NAME mongoose_static )
 else ( )
     set ( STATIC_SUFFIX .a )
+    set ( STATIC_NAME mongoose )
 endif ( )
 
 # static Mongoose library
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( MONGOOSE_STATIC
-    NAMES mongoose
+    NAMES ${STATIC_NAME}
     HINTS ${MONGOOSE_ROOT}
     HINTS ENV ${MONGOOSE_ROOT}
     HINTS ${CMAKE_SOURCE_DIR}/..

--- a/RBio/cmake_modules/FindRBio.cmake
+++ b/RBio/cmake_modules/FindRBio.cmake
@@ -54,15 +54,17 @@ find_library ( RBIO_LIBRARY
 
 if ( MSVC )
     set ( STATIC_SUFFIX .lib )
+    set ( STATIC_NAME rbio_static )
 else ( )
     set ( STATIC_SUFFIX .a )
+    set ( STATIC_NAME rbio )
 endif ( )
 
 # static RBio library
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( RBIO_STATIC
-    NAMES rbio
+    NAMES ${STATIC_NAME}
     HINTS ${RBIO_ROOT}
     HINTS ENV RBIO_ROOT
     HINTS ${CMAKE_SOURCE_DIR}/..

--- a/SPEX/cmake_modules/FindSPEX.cmake
+++ b/SPEX/cmake_modules/FindSPEX.cmake
@@ -50,15 +50,17 @@ find_library ( SPEX_LIBRARY
 
 if ( MSVC )
     set ( STATIC_SUFFIX .lib )
+    set ( STATIC_NAME spex_static )
 else ( )
     set ( STATIC_SUFFIX .a )
+    set ( STATIC_NAME spex )
 endif ( )
 
 # static SPEX library
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( SPEX_STATIC
-    NAMES spex
+    NAMES ${STATIC_NAME}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/SPEX
     HINTS ${CMAKE_SOURCE_DIR}/../SPEX

--- a/SPQR/cmake_modules/FindSPQR.cmake
+++ b/SPQR/cmake_modules/FindSPQR.cmake
@@ -58,7 +58,7 @@ endif ( )
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( SPQR_STATIC
-    NAMES spqr
+    NAMES spqr_static spqr
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/SPQR
     HINTS ${CMAKE_SOURCE_DIR}/../SPQR

--- a/SPQR/cmake_modules/FindSPQR_CUDA.cmake
+++ b/SPQR/cmake_modules/FindSPQR_CUDA.cmake
@@ -48,8 +48,8 @@ endif ( )
 # static SPQR_CUDA library
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
-find_library ( SPQR_CUDA_LIBRARY
-    NAMES spqr_cuda
+find_library ( SPQR_CUDA_STATIC
+    NAMES spqr_cuda_static
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse
     HINTS ${CMAKE_SOURCE_DIR}/../SPQR/

--- a/SuiteSparse_config/cmake_modules/FindSuiteSparse_config.cmake
+++ b/SuiteSparse_config/cmake_modules/FindSuiteSparse_config.cmake
@@ -54,15 +54,17 @@ find_library ( SUITESPARSE_CONFIG_LIBRARY
 
 if ( MSVC )
     set ( STATIC_SUFFIX .lib )
+    set ( STATIC_NAME suitesparseconfig_static )
 else ( )
     set ( STATIC_SUFFIX .a )
+    set ( STATIC_NAME suitesparseconfig )
 endif ( )
 
 # static libraries for SuiteSparse_config
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( SUITESPARSE_CONFIG_STATIC
-    NAMES suitesparseconfig
+    NAMES ${STATIC_NAME}
     HINTS ${SUITESPARSE_CONFIG_ROOT}
     HINTS ENV SUITESPARSE_CONFIG_ROOT
     HINTS ${CMAKE_SOURCE_DIR}/..

--- a/UMFPACK/cmake_modules/FindUMFPACK.cmake
+++ b/UMFPACK/cmake_modules/FindUMFPACK.cmake
@@ -51,15 +51,17 @@ find_library ( UMFPACK_LIBRARY
 
 if ( MSVC )
     set ( STATIC_SUFFIX .lib )
+    set ( STATIC_NAME umfpack_static )
 else ( )
     set ( STATIC_SUFFIX .a )
+    set ( STATIC_NAME umfpack )
 endif ( )
 
 # static UMFPACK library
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( UMFPACK_STATIC
-    NAMES umfpack
+    NAMES ${STATIC_NAME}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/UMFPACK
     HINTS ${CMAKE_SOURCE_DIR}/../UMFPACK


### PR DESCRIPTION
Static libraries need to use a different name than shared libraries for MSVC (see #248).
At first, I consider to just prefer static libraries with the specific name. But that could have lead to a falls detection of an import library as a static library with MSVC.

This PR changes the rules to *only* look for the names specific to the respective compiler.
