### PR TITLE
klu_cholmod: Avoid name conflict of static library with MSVC

### DIFF
--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -149,13 +149,18 @@ if ( NOT NCHOLMOD )
         PUBLIC_HEADER "User/klu_cholmod.h" )
 
     if ( NOT NSTATIC )
-    add_library ( klu_cholmod_static STATIC ${KLU_CHOLMOD_SOURCES} )
+        add_library ( klu_cholmod_static STATIC ${KLU_CHOLMOD_SOURCES} )
 
-    set_target_properties ( klu_cholmod_static PROPERTIES
-        VERSION ${KLU_VERSION_MAJOR}.${KLU_VERSION_MINOR}.${KLU_VERSION_SUB}
-        C_STANDARD_REQUIRED 11
-        OUTPUT_NAME klu_cholmod
-        SOVERSION ${KLU_VERSION_MAJOR} )
+        set_target_properties ( klu_cholmod_static PROPERTIES
+            VERSION ${KLU_VERSION_MAJOR}.${KLU_VERSION_MINOR}.${KLU_VERSION_SUB}
+            C_STANDARD_REQUIRED 11
+            OUTPUT_NAME klu_cholmod
+            SOVERSION ${KLU_VERSION_MAJOR} )
+
+        if ( MSVC )
+            set_target_properties ( klu_cholmod_static PROPERTIES
+                OUTPUT_NAME klu_cholmod_static )
+        endif ( )
     endif ( )
 
 endif ( )

--- a/KLU/cmake_modules/FindKLU_CHOLMOD.cmake
+++ b/KLU/cmake_modules/FindKLU_CHOLMOD.cmake
@@ -58,15 +58,17 @@ find_library ( KLU_CHOLMOD_LIBRARY
 
 if ( MSVC )
     set ( STATIC_SUFFIX .lib )
+    set ( STATIC_NAME klu_cholmod_static )
 else ( )
     set ( STATIC_SUFFIX .a )
+    set ( STATIC_NAME klu_cholmod )
 endif ( )
 
 # static KLU_CHOLMOD library
 set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 set ( CMAKE_FIND_LIBRARY_SUFFIXES ${STATIC_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 find_library ( KLU_CHOLMOD_STATIC
-    NAMES klu_cholmod_static
+    NAMES ${STATIC_NAME}
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/KLU/User
     HINTS ${CMAKE_SOURCE_DIR}/../KLU/User


### PR DESCRIPTION
I missed a file name conflict for one additional library in #248 (and missed that `OUTPUT_NAME` was specified for it in #251).

Should be fixed with this change.