### PR TITLE
SPEX: Don't override CMAKE_PREFIX_PATH defined as command line argument

### DIFF
--- a/SPEX/cmake_modules/FindGMP.cmake
+++ b/SPEX/cmake_modules/FindGMP.cmake
@@ -17,8 +17,6 @@
 # GMP_LIBRARIES   - libraries when using gmp
 # GMP_FOUND       - true if gmp found
 
-# For MS Visual Studio, GMP_LIBRARY and GMP_STATIC are the same.
-
 # set ``GMP_ROOT`` to a gmp installation root to
 # tell this module where to look.
 
@@ -29,7 +27,7 @@
 
 if ( DEFINED ENV{CMAKE_PREFIX_PATH} )
     # import CMAKE_PREFIX_PATH, typically created by spack
-    set ( CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH} )
+    list ( PREPEND CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH} )
 endif ( )
 
 # include files for gmp
@@ -44,12 +42,12 @@ find_library ( GMP_LIBRARY
     PATH_SUFFIXES lib build
 )
 
+# static gmp library
 if ( NOT MSVC )
     set ( CMAKE_FIND_LIBRARY_SUFFIXES
         ${CMAKE_STATIC_LIBRARY_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 endif ( )
 
-# static gmp library
 find_library ( GMP_STATIC
     NAMES gmp
     PATH_SUFFIXES lib build

--- a/SPEX/cmake_modules/FindMPFR.cmake
+++ b/SPEX/cmake_modules/FindMPFR.cmake
@@ -17,8 +17,6 @@
 # MPFR_LIBRARIES   - libraries when using mpfr
 # MPFR_FOUND       - true if mpfr found
 
-# For MS Visual Studio, MPFR_LIBRARY and MPFR_STATIC are the same.
-
 # set ``MPFR_ROOT`` to a mpfr installation root to
 # tell this module where to look.
 
@@ -29,7 +27,7 @@
 
 if ( DEFINED ENV{CMAKE_PREFIX_PATH} )
     # import CMAKE_PREFIX_PATH, typically created by spack
-    set ( CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH} )
+    list ( PREPEND CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH} )
 endif ( )
 
 # include files for mpfr
@@ -44,12 +42,12 @@ find_library ( MPFR_LIBRARY
     PATH_SUFFIXES lib build
 )
 
+# static mpfr library
 if ( NOT MSVC )
     set ( CMAKE_FIND_LIBRARY_SUFFIXES
         ${CMAKE_STATIC_LIBRARY_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 endif ( )
 
-# static mpfr library
 find_library ( MPFR_STATIC
     NAMES mpfr
     PATH_SUFFIXES lib build


### PR DESCRIPTION
After recent changes, linking was prefering static libraries even for shared libraries on Windows.

Change the `Find*.cmake` modules to prefer linking to import libraries on Windows. Fall back to linking to the shared library directly unless MSVC.
