### PR TITLE
Look for libraries in folders for MSVC configurations

### DIFF
--- a/AMD/cmake_modules/FindAMD.cmake
+++ b/AMD/cmake_modules/FindAMD.cmake
@@ -45,7 +45,7 @@ find_library ( AMD_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/AMD
     HINTS ${CMAKE_SOURCE_DIR}/../AMD
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -63,7 +63,7 @@ find_library ( AMD_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/AMD
     HINTS ${CMAKE_SOURCE_DIR}/../AMD
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/BTF/cmake_modules/FindBTF.cmake
+++ b/BTF/cmake_modules/FindBTF.cmake
@@ -45,7 +45,7 @@ find_library ( BTF_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/BTF
     HINTS ${CMAKE_SOURCE_DIR}/../BTF
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -63,7 +63,7 @@ find_library ( BTF_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/BTF
     HINTS ${CMAKE_SOURCE_DIR}/../BTF
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/CAMD/cmake_modules/FindCAMD.cmake
+++ b/CAMD/cmake_modules/FindCAMD.cmake
@@ -45,7 +45,7 @@ find_library ( CAMD_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/CAMD
     HINTS ${CMAKE_SOURCE_DIR}/../CAMD
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -63,7 +63,7 @@ find_library ( CAMD_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/CAMD
     HINTS ${CMAKE_SOURCE_DIR}/../CAMD
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/CCOLAMD/cmake_modules/FindCCOLAMD.cmake
+++ b/CCOLAMD/cmake_modules/FindCCOLAMD.cmake
@@ -45,7 +45,7 @@ find_library ( CCOLAMD_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/CCOLAMD
     HINTS ${CMAKE_SOURCE_DIR}/../CCOLAMD
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -63,7 +63,7 @@ find_library ( CCOLAMD_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/CCOLAMD
     HINTS ${CMAKE_SOURCE_DIR}/../CCOLAMD
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/CHOLMOD/cmake_modules/FindCHOLMOD.cmake
+++ b/CHOLMOD/cmake_modules/FindCHOLMOD.cmake
@@ -44,7 +44,7 @@ find_library ( CHOLMOD_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/CHOLMOD
     HINTS ${CMAKE_SOURCE_DIR}/../CHOLMOD
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -62,7 +62,7 @@ find_library ( CHOLMOD_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/CHOLMOD
     HINTS ${CMAKE_SOURCE_DIR}/../CHOLMOD
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/CHOLMOD/cmake_modules/FindCHOLMOD_CUDA.cmake
+++ b/CHOLMOD/cmake_modules/FindCHOLMOD_CUDA.cmake
@@ -46,7 +46,7 @@ find_library ( CHOLMOD_CUDA_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse
     HINTS ${CMAKE_SOURCE_DIR}/../CHOLMOD/
     HINTS ${CMAKE_SOURCE_DIR}/../CHOLMOD/build/GPU
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -65,7 +65,7 @@ find_library ( CHOLMOD_CUDA_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse
     HINTS ${CMAKE_SOURCE_DIR}/../CHOLMOD/
     HINTS ${CMAKE_SOURCE_DIR}/../CHOLMOD/build/GPU
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/COLAMD/cmake_modules/FindCOLAMD.cmake
+++ b/COLAMD/cmake_modules/FindCOLAMD.cmake
@@ -45,7 +45,7 @@ find_library ( COLAMD_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/COLAMD
     HINTS ${CMAKE_SOURCE_DIR}/../COLAMD
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -63,7 +63,7 @@ find_library ( COLAMD_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/COLAMD
     HINTS ${CMAKE_SOURCE_DIR}/../COLAMD
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/CXSparse/cmake_modules/FindCXSparse.cmake
+++ b/CXSparse/cmake_modules/FindCXSparse.cmake
@@ -50,7 +50,7 @@ find_library ( CXSPARSE_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/CXSparse
     HINTS ${CMAKE_SOURCE_DIR}/../CXSparse
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -70,7 +70,7 @@ find_library ( CXSPARSE_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/CXSparse
     HINTS ${CMAKE_SOURCE_DIR}/../CXSparse
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/GPUQREngine/cmake_modules/FindGPUQREngine.cmake
+++ b/GPUQREngine/cmake_modules/FindGPUQREngine.cmake
@@ -47,7 +47,7 @@ find_library ( GPUQRENGINE_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/GPUQREngine
     HINTS ${CMAKE_SOURCE_DIR}/../GPUQREngine
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -67,7 +67,7 @@ find_library ( GPUQRENGINE_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/GPUQREngine
     HINTS ${CMAKE_SOURCE_DIR}/../GPUQREngine
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/GraphBLAS/cmake_modules/FindGraphBLAS.cmake
+++ b/GraphBLAS/cmake_modules/FindGraphBLAS.cmake
@@ -82,7 +82,7 @@ find_library ( GRAPHBLAS_LIBRARY
   HINTS ${CMAKE_SOURCE_DIR}/..
   HINTS ${CMAKE_SOURCE_DIR}/../GraphBLAS
   HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/GraphBLAS
-  PATH_SUFFIXES lib build alternative
+  PATH_SUFFIXES lib build build/Release build/Debug alternative
   )
 
 if ( MSVC )
@@ -102,7 +102,7 @@ find_library ( GRAPHBLAS_STATIC
   HINTS ${CMAKE_SOURCE_DIR}/..
   HINTS ${CMAKE_SOURCE_DIR}/../GraphBLAS
   HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/GraphBLAS
-  PATH_SUFFIXES lib build alternative
+  PATH_SUFFIXES lib build build/Release build/Debug alternative
   )
 
 if ( NOT MSVC )

--- a/KLU/cmake_modules/FindKLU.cmake
+++ b/KLU/cmake_modules/FindKLU.cmake
@@ -45,7 +45,7 @@ find_library ( KLU_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/KLU
     HINTS ${CMAKE_SOURCE_DIR}/../KLU
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -63,7 +63,7 @@ find_library ( KLU_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/KLU
     HINTS ${CMAKE_SOURCE_DIR}/../KLU
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/KLU/cmake_modules/FindKLU_CHOLMOD.cmake
+++ b/KLU/cmake_modules/FindKLU_CHOLMOD.cmake
@@ -53,7 +53,7 @@ find_library ( KLU_CHOLMOD_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/KLU/User
     HINTS ${CMAKE_SOURCE_DIR}/../KLU/User
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -71,7 +71,7 @@ find_library ( KLU_CHOLMOD_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/KLU/User
     HINTS ${CMAKE_SOURCE_DIR}/../KLU/User
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/LDL/cmake_modules/FindLDL.cmake
+++ b/LDL/cmake_modules/FindLDL.cmake
@@ -45,7 +45,7 @@ find_library ( LDL_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/LDL
     HINTS ${CMAKE_SOURCE_DIR}/../LDL
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -63,7 +63,7 @@ find_library ( LDL_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/LDL
     HINTS ${CMAKE_SOURCE_DIR}/../LDL
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/Mongoose/cmake_modules/FindMongoose.cmake
+++ b/Mongoose/cmake_modules/FindMongoose.cmake
@@ -49,7 +49,7 @@ find_library ( MONGOOSE_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/Mongoose
     HINTS ${CMAKE_SOURCE_DIR}/../Mongoose
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -69,7 +69,7 @@ find_library ( MONGOOSE_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/Mongoose
     HINTS ${CMAKE_SOURCE_DIR}/../Mongoose
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/RBio/cmake_modules/FindRBio.cmake
+++ b/RBio/cmake_modules/FindRBio.cmake
@@ -49,7 +49,7 @@ find_library ( RBIO_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/RBio
     HINTS ${CMAKE_SOURCE_DIR}/../RBio
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -69,7 +69,7 @@ find_library ( RBIO_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/RBio
     HINTS ${CMAKE_SOURCE_DIR}/../RBio
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/SPEX/cmake_modules/FindSPEX.cmake
+++ b/SPEX/cmake_modules/FindSPEX.cmake
@@ -45,7 +45,7 @@ find_library ( SPEX_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/SPEX
     HINTS ${CMAKE_SOURCE_DIR}/../SPEX
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -63,7 +63,7 @@ find_library ( SPEX_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/SPEX
     HINTS ${CMAKE_SOURCE_DIR}/../SPEX
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/SPQR/cmake_modules/FindSPQR.cmake
+++ b/SPQR/cmake_modules/FindSPQR.cmake
@@ -45,7 +45,7 @@ find_library ( SPQR_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/SPQR
     HINTS ${CMAKE_SOURCE_DIR}/../SPQR
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -63,7 +63,7 @@ find_library ( SPQR_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/SPQR
     HINTS ${CMAKE_SOURCE_DIR}/../SPQR
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/SPQR/cmake_modules/FindSPQR_CUDA.cmake
+++ b/SPQR/cmake_modules/FindSPQR_CUDA.cmake
@@ -36,7 +36,7 @@ find_library ( SPQR_CUDA_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse
     HINTS ${CMAKE_SOURCE_DIR}/../SPQR/
     HINTS ${CMAKE_SOURCE_DIR}/../SPQR/build/SPQRGPU
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -55,7 +55,7 @@ find_library ( SPQR_CUDA_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse
     HINTS ${CMAKE_SOURCE_DIR}/../SPQR/
     HINTS ${CMAKE_SOURCE_DIR}/../SPQR/build/SPQRGPU
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/SuiteSparse_GPURuntime/cmake_modules/FindSuiteSparse_GPURuntime.cmake
+++ b/SuiteSparse_GPURuntime/cmake_modules/FindSuiteSparse_GPURuntime.cmake
@@ -47,7 +47,7 @@ find_library ( SUITESPARSE_GPURUNTIME_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/SuiteSparse_GPURuntime
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse_GPURuntime
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -67,7 +67,7 @@ find_library ( SUITESPARSE_GPURUNTIME_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/SuiteSparse_GPURuntime
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse_GPURuntime
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/SuiteSparse_config/cmake_modules/FindSuiteSparse_config.cmake
+++ b/SuiteSparse_config/cmake_modules/FindSuiteSparse_config.cmake
@@ -49,7 +49,7 @@ find_library ( SUITESPARSE_CONFIG_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/SuiteSparse_config
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -71,7 +71,7 @@ find_library ( SUITESPARSE_CONFIG_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/SuiteSparse_config
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )

--- a/UMFPACK/cmake_modules/FindUMFPACK.cmake
+++ b/UMFPACK/cmake_modules/FindUMFPACK.cmake
@@ -46,7 +46,7 @@ find_library ( UMFPACK_LIBRARY
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/UMFPACK
     HINTS ${CMAKE_SOURCE_DIR}/../UMFPACK
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( MSVC )
@@ -64,7 +64,7 @@ find_library ( UMFPACK_STATIC
     HINTS ${CMAKE_SOURCE_DIR}/..
     HINTS ${CMAKE_SOURCE_DIR}/../SuiteSparse/UMFPACK
     HINTS ${CMAKE_SOURCE_DIR}/../UMFPACK
-    PATH_SUFFIXES lib build
+    PATH_SUFFIXES lib build build/Release build/Debug
 )
 
 if ( NOT MSVC )


### PR DESCRIPTION
MSVC apparently has two different configurations for compilation: Release and Debug.
For each of these configurations, it creates the binaries in different subfolders of the build folder.

Adjust the `Find*.cmake` modules to detect the libraries in the corresponding subfolders.