### PR TITLE
Add CI rules for MSVC

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -279,3 +279,169 @@ jobs:
       - name: ccache status
         continue-on-error: true
         run: ccache -s
+
+
+  msvc:
+    # For available GitHub-hosted runners, see:
+    # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        # Use bash as default shell
+        shell: bash -el {0}
+
+    env:
+      CHERE_INVOKING: 1
+
+    steps:
+      - name: get CPU name
+        shell: pwsh
+        run : |
+          Get-CIMInstance -Class Win32_Processor | Select-Object -Property Name
+
+      - name: checkout repository
+        uses: actions/checkout@v3
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+
+      - name: cache conda packages
+        id: conda-cache
+        uses: actions/cache/restore@v3
+        with:
+          path: C:/Miniconda/envs/test
+          key: conda:msvc
+
+      - name: install packages with conda
+        if: ${{ steps.conda-cache.outputs.cache-hit != 'true' }}
+        run: |
+          echo ${{ steps.conda-cache.outputs.cache-hit }}
+          conda info
+          conda list
+          conda install -y -c intel mkl-devel
+          conda install -y -c conda-forge --override-channels ccache
+
+      - name: save conda cache
+        if: ${{ steps.conda-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v3
+        with:
+          path: C:/Miniconda/envs/test
+          key: ${{ steps.conda-cache.outputs.cache-primary-key }}
+
+      - name: install libraries from MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+
+          # Use pre-installed version to save disc space on partition with source.
+          release: false
+
+          install: >-
+            mingw-w64-ucrt-x86_64-gmp
+            mingw-w64-ucrt-x86_64-mpfr
+
+          msystem: UCRT64
+
+      - name: setup build environment
+        # get packages from MSYS2
+        # Copy only relevant parts to avoid picking up headers and libraries
+        # that are thought for MinGW only.
+        run: |
+          mkdir -p ./dependencies/{bin,lib,include}
+          # GMP
+          cp C:/msys64/ucrt64/bin/libgmp*.dll ./dependencies/bin/
+          cp C:/msys64/ucrt64/include/gmp.h ./dependencies/include/
+          cp C:/msys64/ucrt64/lib/libgmp.dll.a ./dependencies/lib/gmp.lib
+          # MPFR
+          cp C:/msys64/ucrt64/bin/libmpfr*.dll ./dependencies/bin/
+          cp C:/msys64/ucrt64/include/mpf2mpfr.h ./dependencies/include/
+          cp C:/msys64/ucrt64/include/mpfr.h ./dependencies/include/
+          cp C:/msys64/ucrt64/lib/libmpfr.dll.a ./dependencies/lib/mpfr.lib
+          # run-time dependencies
+          cp C:/msys64/ucrt64/bin/libgcc_s_seh*.dll ./dependencies/bin/
+          cp C:/msys64/ucrt64/bin/libwinpthread*.dll ./dependencies/bin/
+          # create environment variable for easier access
+          echo "CCACHE=C:/Miniconda/envs/test/Library/bin/ccache.exe" >> ${GITHUB_ENV}
+
+      - name: prepare ccache
+        # Check path to cache directory
+        id: ccache-cache
+        shell: msys2 {0}
+        run: |
+          echo "ccachedir=$(cygpath -m $(${CCACHE} -k cache_dir))" >> $GITHUB_OUTPUT
+          echo "timestamp=$(date +"%Y-%m-%d_%H-%M-%S")" >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
+
+      - name: restore ccache
+        # Setup the GitHub cache used to maintain the ccache from one job to the next
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.ccache-cache.outputs.ccachedir }}
+          key: ccache:msvc:${{ github.ref }}:${{ steps.ccache-cache.outputs.timestamp }}:${{ github.sha }}
+          # Prefer caches from the same branch. Fall back to caches from the dev branch.
+          restore-keys: |
+            ccache:msvc:${{ github.ref }}
+            ccache:msvc
+
+      - name: configure ccache
+        # Limit the maximum size and switch on compression to avoid exceeding the total disk or cache quota.
+        run: |
+          test -d ${{ steps.ccache-cache.outputs.ccachedir }} || mkdir -p ${{ steps.ccache-cache.outputs.ccachedir }}
+          echo "max_size = 50M" > ${{ steps.ccache-cache.outputs.ccachedir }}/ccache.conf
+          echo "compression = true" >> ${{ steps.ccache-cache.outputs.ccachedir }}/ccache.conf
+          ${CCACHE} -p
+          ${CCACHE} -s
+
+      - name: setup MSVC toolchain
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: build
+        env:
+          CCACHE: C:/Miniconda/envs/test/Library/bin/ccache.exe
+        # The default generator doesn't use ccache. Use Ninja generator instead.
+        # Skip CXSparse for now because there are issues with "complex" in C code.
+        # Skip GraphBLAS for now because it doesn't link with Ninja.
+        run: |
+          libs=("SuiteSparse_config"
+                "Mongoose"
+                "AMD"
+                "BTF"
+                "CAMD"
+                "CCOLAMD"
+                "COLAMD"
+                "CHOLMOD"
+                "CSparse"
+                "LDL"
+                "KLU"
+                "UMFPACK"
+                "RBio"
+                "SuiteSparse_GPURuntime"
+                "GPUQREngine"
+                "SPQR"
+                "SPEX")
+          for lib in "${libs[@]}"; do
+            printf "   \033[0;32m==>\033[0m Building library \033[0;32m${lib}\033[0m\n"
+            echo "::group::Configure $lib"
+            cd ${GITHUB_WORKSPACE}/${lib}/build
+            cmake -G"Ninja Multi-Config" \
+                  -DCMAKE_BUILD_TYPE="Release" \
+                  -DCMAKE_PREFIX_PATH="C:/Miniconda/envs/test/Library;${GITHUB_WORKSPACE}/dependencies" \
+                  -DCMAKE_C_COMPILER_LAUNCHER=${CCACHE} \
+                  -DCMAKE_CXX_COMPILER_LAUNCHER=${CCACHE} \
+                  -DCMAKE_Fortran_COMPILER_LAUNCHER=${CCACHE} \
+                  -DNFORTRAN=ON \
+                  -DBLA_VENDOR="All" \
+                  ..
+            echo "::endgroup::"
+            echo "::group::Build $lib"
+            cmake --build . --config Release
+            echo "::endgroup::"
+          done
+
+      # FIXME: Run demos after building
+
+      - name: ccache status
+        continue-on-error: true
+        run: ${CCACHE} -s


### PR DESCRIPTION
Add rules to build (most of) the SuiteSparse libraries in CI with MSVC.

This is currently failing and depends on #259 (and possibly #258).

It currently only builds the libraries and doesn't run the demos to check if they actually work. But this is still a good enough first step imho.

Currently, CXSparse doesn't build because there are no `complex` floating point type with MSVC. Afaict, those types are optional as of C11. And MSVC was never C99-compatible. See also:
https://learn.microsoft.com/en-us/cpp/c-runtime-library/complex-math-support?view=msvc-170
https://devblogs.microsoft.com/cppblog/c11-and-c17-standard-support-arriving-in-msvc/#whats-not

Additionally, GraphBLAS doesn't build with the `Ninja*` generators. (See https://github.com/DrTimothyAldenDavis/GraphBLAS/issues/194.)
I does build with the `Visual Studio *` generators. But those don't support `ccache`. I figured having a working compiler cache is preferable for CI that might be running often.

PS: I added the manual loop over all libraries because MSVC can't use the top-level Makefile. (Or I didn't figure out how to do that.)
But come to think of it, I prefer having the option to insert action "directives" because it makes looking for the output of a given library so much easier. Should we change the other rules to also not use the top-level Makefile?