### PR TITLE
Combine output in groups instead of using top-level Makefile in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,13 @@ on:
 
 concurrency: ci-${{ github.ref }}
 
+env:
+  # string with name of libraries to be built
+  BUILD_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:RBio:SuiteSparse_GPURuntime:GPUQREngine:SPQR:GraphBLAS:SPEX"
+  # string with name of libraries to be checked
+  CHECK_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:RBio:SPQR:GraphBLAS:SPEX"
+
+
 jobs:
 
   ubuntu:
@@ -83,15 +90,32 @@ jobs:
 
       - name: build
         run: |
-          make CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release \
-                              -DCMAKE_C_COMPILER_LAUNCHER='ccache' \
-                              -DCMAKE_CXX_COMPILER_LAUNCHER='ccache' \
-                              -DCMAKE_Fortran_COMPILER_LAUNCHER='ccache' \
-                              -DBLA_VENDOR=OpenBLAS"
+          IFS=':' read -r -a libs <<< "${BUILD_LIBS}"
+          for lib in "${libs[@]}"; do
+            printf "   \033[0;32m==>\033[0m Building library \033[0;32m${lib}\033[0m\n"
+            echo "::group::Configure $lib"
+            cd ${GITHUB_WORKSPACE}/${lib}/build
+            cmake -DCMAKE_BUILD_TYPE="Release" \
+                  -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
+                  -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
+                  -DCMAKE_Fortran_COMPILER_LAUNCHER="ccache" \
+                  -DBLA_VENDOR="OpenBLAS" \
+                  ..
+            echo "::endgroup::"
+            echo "::group::Build $lib"
+            cmake --build . --config Release
+            echo "::endgroup::"
+          done
 
       - name: check
         run: |
-          make demos
+          IFS=':' read -r -a libs <<< "${CHECK_LIBS}"
+          for lib in "${libs[@]}"; do
+            printf "::group::   \033[0;32m==>\033[0m Checking library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/${lib}
+            make demos
+            echo "::endgroup::"
+          done
 
       - name: ccache status
         continue-on-error: true
@@ -102,10 +126,6 @@ jobs:
     # For available GitHub-hosted runners, see:
     # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
     runs-on: macos-latest
-
-    strategy:
-      # Allow other runners in the matrix to continue if some fail
-      fail-fast: false
 
     steps:
       - name: checkout repository
@@ -152,16 +172,33 @@ jobs:
 
       - name: build
         run: |
-          make CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=Release \
-                              -DCMAKE_C_COMPILER_LAUNCHER='ccache' \
-                              -DCMAKE_CXX_COMPILER_LAUNCHER='ccache' \
-                              -DCMAKE_Fortran_COMPILER_LAUNCHER='ccache' \
-                              -DBLA_VENDOR=OpenBLAS \
-                              -DCMAKE_PREFIX_PATH='/usr/local/opt/lapack;/usr/local/opt/openblas;/usr/local/opt/libomp'"
+          IFS=':' read -r -a libs <<< "${BUILD_LIBS}"
+          for lib in "${libs[@]}"; do
+            printf "   \033[0;32m==>\033[0m Building library \033[0;32m${lib}\033[0m\n"
+            echo "::group::Configure $lib"
+            cd ${GITHUB_WORKSPACE}/${lib}/build
+            cmake -DCMAKE_BUILD_TYPE="Release" \
+                  -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
+                  -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
+                  -DCMAKE_Fortran_COMPILER_LAUNCHER="ccache" \
+                  -DBLA_VENDOR="OpenBLAS" \
+                  -DCMAKE_PREFIX_PATH="/usr/local/opt/lapack;/usr/local/opt/openblas;/usr/local/opt/libomp" \
+                  ..
+            echo "::endgroup::"
+            echo "::group::Build $lib"
+            cmake --build . --config Release
+            echo "::endgroup::"
+          done
 
       - name: check
         run: |
-          make demos
+          IFS=':' read -r -a libs <<< "${CHECK_LIBS}"
+          for lib in "${libs[@]}"; do
+            printf "::group::   \033[0;32m==>\033[0m Checking library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/${lib}
+            make demos
+            echo "::endgroup::"
+          done
 
       - name: ccache status
         continue-on-error: true
@@ -263,18 +300,37 @@ jobs:
 
       - name: build
         run: |
-          make CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=\"${MINGW_PREFIX}\" \
-                              -DCMAKE_BUILD_TYPE=Release \
-                              -DCMAKE_C_COMPILER_LAUNCHER='ccache' \
-                              -DCMAKE_CXX_COMPILER_LAUNCHER='ccache' \
-                              -DCMAKE_Fortran_COMPILER_LAUNCHER='ccache' \
-                              -DBLA_VENDOR=OpenBLAS"
+          IFS=':' read -r -a libs <<< "${BUILD_LIBS}"
+          for lib in "${libs[@]}"; do
+            printf "   \033[0;32m==>\033[0m Building library \033[0;32m${lib}\033[0m\n"
+            echo "::group::Configure $lib"
+            cd ${GITHUB_WORKSPACE}/${lib}/build
+            cmake -DCMAKE_BUILD_TYPE="Release" \
+                  -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
+                  -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
+                  -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
+                  -DCMAKE_Fortran_COMPILER_LAUNCHER="ccache" \
+                  -DBLA_VENDOR="OpenBLAS" \
+                  ..
+            echo "::endgroup::"
+            echo "::group::Build $lib"
+            cmake --build . --config Release
+            echo "::endgroup::"
+          done
 
       - name: check
         # Need to install the libraries for the tests
         run: |
+          echo "::group::Install libraries"
           make install
-          make demos
+          echo "::endgroup::"
+          IFS=':' read -r -a libs <<< "${CHECK_LIBS}"
+          for lib in "${libs[@]}"; do
+            printf "::group::   \033[0;32m==>\033[0m Checking library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/${lib}
+            make demos
+            echo "::endgroup::"
+          done
 
       - name: ccache status
         continue-on-error: true


### PR DESCRIPTION
Instead of using the top-level Makefile, combine the output in groups for all platforms. That makes it easier to find the log for a given library.

For some reason, mingw (CLANG64) started to fail its tests. I'm not quite sure why.
~~Maybe because of this?~~
~~https://github.com/DrTimothyAldenDavis/SuiteSparse/commit/9f678372a8bf7d956cfe20df55af6bfadbd146e8#diff-6dbf8025b96177a872c950c1dc048aab951ff1d97fda27356fa6f723367b312dL39~~

~~Would that module still need to be included when configured to build the demos?~~