### PR TITLE
Run CI on push to the main branches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,8 +3,6 @@ on:
   push:
     branches-ignore:
       - '**/dev2'
-      - '**/dev'
-      - '**/stable'
   pull_request:
 
 concurrency: ci-${{ github.ref }}


### PR DESCRIPTION
When I initially made that change, I was incorrectly assuming that caches could be restored from any branch (including PR branches). That is apparently not the case.

Enable the CI on the main branches again so that the caches can be populated on a branch from which they can be restored. Otherwise, the CI will be slow on PRs.
