### PR TITLE
SPEX: Fall back to shared MPFR library if there is no static one.

### DIFF
--- a/SPEX/cmake_modules/FindMPFR.cmake
+++ b/SPEX/cmake_modules/FindMPFR.cmake
@@ -53,6 +53,10 @@ find_library ( MPFR_STATIC
     PATH_SUFFIXES lib build
 )
 
+if ( NOT MPFR_STATIC )
+    set ( MPFR_STATIC ${MPFR_LIBRARY} )
+endif ( )
+
 if ( NOT MSVC )
     # restore the CMAKE_FIND_LIBRARY_SUFFIXES variable
     set ( CMAKE_FIND_LIBRARY_SUFFIXES ${save} )


### PR DESCRIPTION
MSYS2 stopped packaging a static MPFR library for MinGW.
It is not uncommon to link a static library to a shared library. So, fall back to a shared MPFR library in case there is no static one.
