### PR TITLE
Use function pointers instead of void* for get and set functions.

### DIFF
--- a/CHOLMOD/Partition/cholmod_metis.c
+++ b/CHOLMOD/Partition/cholmod_metis.c
@@ -98,18 +98,18 @@
         save_calloc_func  = SuiteSparse_config_calloc_func_get ( ) ;        \
         save_realloc_func = SuiteSparse_config_realloc_func_get ( ) ;       \
         save_free_func    = SuiteSparse_config_free_func_get ( ) ;          \
-        SuiteSparse_config_malloc_func_set ((void *) malloc) ;              \
-        SuiteSparse_config_calloc_func_set ((void *) calloc) ;              \
-        SuiteSparse_config_realloc_func_set ((void *) realloc) ;            \
-        SuiteSparse_config_free_func_set ((void *) free) ;                  \
+        SuiteSparse_config_malloc_func_set (malloc) ;                       \
+        SuiteSparse_config_calloc_func_set (calloc) ;                       \
+        SuiteSparse_config_realloc_func_set (realloc) ;                     \
+        SuiteSparse_config_free_func_set (free) ;                           \
     }
 
     #define TEST_COVERAGE_RESUME                                            \
     {                                                                       \
-        SuiteSparse_config_malloc_func_set ((void *) save_malloc_func) ;    \
-        SuiteSparse_config_calloc_func_set ((void *) save_calloc_func) ;    \
-        SuiteSparse_config_realloc_func_set ((void *) save_realloc_func) ;  \
-        SuiteSparse_config_free_func_set ((void *) save_free_func) ;        \
+        SuiteSparse_config_malloc_func_set (save_malloc_func) ;             \
+        SuiteSparse_config_calloc_func_set (save_calloc_func) ;             \
+        SuiteSparse_config_realloc_func_set (save_realloc_func) ;           \
+        SuiteSparse_config_free_func_set (save_free_func) ;                 \
     }
 
 #else

--- a/CHOLMOD/Tcov/memory.c
+++ b/CHOLMOD/Tcov/memory.c
@@ -110,10 +110,10 @@ void my_free2 (void *p)
 
 void normal_memory_handler ( void )
 {
-    SuiteSparse_config_malloc_func_set ((void *) malloc) ;
-    SuiteSparse_config_calloc_func_set ((void *) calloc) ;
-    SuiteSparse_config_realloc_func_set ((void *) realloc) ;
-    SuiteSparse_config_free_func_set ((void *) free) ;
+    SuiteSparse_config_malloc_func_set (malloc) ;
+    SuiteSparse_config_calloc_func_set (calloc) ;
+    SuiteSparse_config_realloc_func_set (realloc) ;
+    SuiteSparse_config_free_func_set (free) ;
 
     cm->error_handler = my_handler ;
     CHOLMOD(free_work) (cm) ;
@@ -126,10 +126,10 @@ void normal_memory_handler ( void )
 
 void test_memory_handler ( void )
 {
-    SuiteSparse_config_malloc_func_set ((void *) my_malloc2) ;
-    SuiteSparse_config_calloc_func_set ((void *) my_calloc2) ;
-    SuiteSparse_config_realloc_func_set ((void *) my_realloc2) ;
-    SuiteSparse_config_free_func_set ((void *) my_free2) ;
+    SuiteSparse_config_malloc_func_set (my_malloc2) ;
+    SuiteSparse_config_calloc_func_set ((my_calloc2) ;
+    SuiteSparse_config_realloc_func_set (my_realloc2) ;
+    SuiteSparse_config_free_func_set (my_free2) ;
 
     cm->error_handler = NULL ;
     CHOLMOD(free_work) (cm) ;

--- a/KLU/Tcov/klutest.c
+++ b/KLU/Tcov/klutest.c
@@ -176,19 +176,19 @@ void my_free (void *p)
 
 static void normal_memory_handler ( void )
 {
-    SuiteSparse_config_malloc_func_set ((void *) malloc) ;
-    SuiteSparse_config_calloc_func_set ((void *) calloc) ;
-    SuiteSparse_config_realloc_func_set ((void *) realloc) ;
-    SuiteSparse_config_free_func_set ((void *) free) ;
+    SuiteSparse_config_malloc_func_set (malloc) ;
+    SuiteSparse_config_calloc_func_set (calloc) ;
+    SuiteSparse_config_realloc_func_set (realloc) ;
+    SuiteSparse_config_free_func_set (free) ;
     my_tries = -1 ;
 }
 
 static void test_memory_handler ( void )
 {
-    SuiteSparse_config_malloc_func_set ((void *) my_malloc) ;
-    SuiteSparse_config_calloc_func_set ((void *) my_calloc) ;
-    SuiteSparse_config_realloc_func_set ((void *) my_realloc) ;
-    SuiteSparse_config_free_func_set ((void *) my_free) ;
+    SuiteSparse_config_malloc_func_set (my_malloc) ;
+    SuiteSparse_config_calloc_func_set (my_calloc) ;
+    SuiteSparse_config_realloc_func_set (my_realloc) ;
+    SuiteSparse_config_free_func_set (my_free) ;
     my_tries = -1 ;
 }
 

--- a/Mongoose/Tests/Mongoose_Test_Memory.cpp
+++ b/Mongoose/Tests/Mongoose_Test_Memory.cpp
@@ -62,10 +62,10 @@ int runMemoryTest(const std::string &inputFile)
     }
 
     /* Override SuiteSparse memory management with custom testers. */
-    SuiteSparse_config_malloc_func_set ((void *) myMalloc) ;
-    SuiteSparse_config_calloc_func_set ((void *) myCalloc) ;
-    SuiteSparse_config_realloc_func_set ((void *) myRealloc) ;
-    SuiteSparse_config_free_func_set ((void *) myFree) ;
+    SuiteSparse_config_malloc_func_set (myMalloc) ;
+    SuiteSparse_config_calloc_func_set (myCalloc) ;
+    SuiteSparse_config_realloc_func_set (myRealloc) ;
+    SuiteSparse_config_free_func_set (myFree) ;
 
     int status = RunAllTests(inputFile, options);
 

--- a/Mongoose/Tests/Mongoose_UnitTest_Graph_exe.cpp
+++ b/Mongoose/Tests/Mongoose_UnitTest_Graph_exe.cpp
@@ -85,10 +85,10 @@ int main(int argn, char** argv)
 
     // Tests to increase coverage
     /* Override SuiteSparse memory management with custom testers. */
-    SuiteSparse_config_malloc_func_set ((void *) myMalloc) ;
-    SuiteSparse_config_calloc_func_set ((void *) myCalloc) ;
-    SuiteSparse_config_realloc_func_set ((void *) myRealloc) ;
-    SuiteSparse_config_free_func_set ((void *) myFree) ;
+    SuiteSparse_config_malloc_func_set (myMalloc) ;
+    SuiteSparse_config_calloc_func_set (myCalloc) ;
+    SuiteSparse_config_realloc_func_set (myRealloc) ;
+    SuiteSparse_config_free_func_set (myFree) ;
 
     // Simulate failure to allocate return arrays
     AllowedMallocs = 0;

--- a/SPEX/SPEX_Util/Source/SPEX_initialize_expert.c
+++ b/SPEX/SPEX_Util/Source/SPEX_initialize_expert.c
@@ -38,10 +38,10 @@ SPEX_info SPEX_initialize_expert
     // define the malloc/calloc/realloc/free functions 
     //--------------------------------------------------------------------------
 
-    SuiteSparse_config_malloc_func_set ((void *) user_malloc) ;
-    SuiteSparse_config_calloc_func_set ((void *) user_calloc) ;
-    SuiteSparse_config_realloc_func_set ((void *) user_realloc) ;
-    SuiteSparse_config_free_func_set ((void *) user_free) ;
+    SuiteSparse_config_malloc_func_set (user_malloc) ;
+    SuiteSparse_config_calloc_func_set (user_calloc) ;
+    SuiteSparse_config_realloc_func_set (user_realloc) ;
+    SuiteSparse_config_free_func_set (user_free) ;
 
     //--------------------------------------------------------------------------
     // Set GMP memory functions

--- a/SPQR/Tcov/qrtest.cpp
+++ b/SPQR/Tcov/qrtest.cpp
@@ -114,11 +114,11 @@ void my_handler (int status, const char *file, int line, const char *msg)
 
 void normal_memory_handler (cholmod_common *cc, bool free_work)
 {
-    SuiteSparse_config_printf_func_set ((void *) printf) ;
-    SuiteSparse_config_malloc_func_set ((void *) malloc) ;
-    SuiteSparse_config_calloc_func_set ((void *) calloc) ;
-    SuiteSparse_config_realloc_func_set ((void *) realloc) ;
-    SuiteSparse_config_free_func_set ((void *) free) ;
+    SuiteSparse_config_printf_func_set (printf) ;
+    SuiteSparse_config_malloc_func_set (malloc) ;
+    SuiteSparse_config_calloc_func_set (calloc) ;
+    SuiteSparse_config_realloc_func_set (realloc) ;
+    SuiteSparse_config_free_func_set (free) ;
 
     cc->error_handler = my_handler ;
     if (free_work) cholmod_l_free_work (cc) ;
@@ -128,11 +128,11 @@ void normal_memory_handler (cholmod_common *cc, bool free_work)
 
 void test_memory_handler (cholmod_common *cc, bool free_work)
 {
-    SuiteSparse_config_printf_func_set ((void *) NULL) ;
-    SuiteSparse_config_malloc_func_set ((void *) my_malloc) ;
-    SuiteSparse_config_calloc_func_set ((void *) my_calloc) ;
-    SuiteSparse_config_realloc_func_set ((void *) my_realloc) ;
-    SuiteSparse_config_free_func_set ((void *) my_free) ;
+    SuiteSparse_config_printf_func_set (NULL) ;
+    SuiteSparse_config_malloc_func_set (my_malloc) ;
+    SuiteSparse_config_calloc_func_set (my_calloc) ;
+    SuiteSparse_config_realloc_func_set (my_realloc) ;
+    SuiteSparse_config_free_func_set (my_free) ;
 
     cc->error_handler = NULL ;
     if (free_work) cholmod_l_free_work (cc) ;

--- a/SuiteSparse_config/Config/SuiteSparse_config.h.in
+++ b/SuiteSparse_config/Config/SuiteSparse_config.h.in
@@ -279,22 +279,22 @@ extern "C"
 // wrappers defined below to access them.
 
 // The SuiteSparse_config_*_get methods return the contents of the struct:
-void *SuiteSparse_config_malloc_func_get (void) ;
-void *SuiteSparse_config_calloc_func_get (void) ;
-void *SuiteSparse_config_realloc_func_get (void) ;
-void *SuiteSparse_config_free_func_get (void) ;
-void *SuiteSparse_config_printf_func_get (void) ;
-void *SuiteSparse_config_hypot_func_get (void) ;
-void *SuiteSparse_config_divcomplex_func_get (void) ;
+void *(*SuiteSparse_config_malloc_func_get (void)) (size_t);
+void *(*SuiteSparse_config_calloc_func_get (void)) (size_t, size_t);
+void *(*SuiteSparse_config_realloc_func_get (void)) (void *, size_t);
+void (*SuiteSparse_config_free_func_get (void)) (void *);
+int (*SuiteSparse_config_printf_func_get (void)) (const char *, ...);
+double (*SuiteSparse_config_hypot_func_get (void)) (double, double);
+int (*SuiteSparse_config_divcomplex_func_get (void)) (double, double, double, double, double *, double *);
 
 // The SuiteSparse_config_*_set methods modify the contents of the struct:
-void SuiteSparse_config_malloc_func_set (void *malloc_func) ;
-void SuiteSparse_config_calloc_func_set (void *calloc_func) ;
-void SuiteSparse_config_realloc_func_set (void *realloc_func) ;
-void SuiteSparse_config_free_func_set (void *free_func) ;
-void SuiteSparse_config_printf_func_set (void *printf_func) ;
-void SuiteSparse_config_hypot_func_set (void *hypot_func) ;
-void SuiteSparse_config_divcomplex_func_set (void *divcomplex_func) ;
+void SuiteSparse_config_malloc_func_set (void *(*malloc_func) (size_t));
+void SuiteSparse_config_calloc_func_set (void *(*calloc_func) (size_t, size_t));
+void SuiteSparse_config_realloc_func_set (void *(*realloc_func) (void *, size_t));
+void SuiteSparse_config_free_func_set (void (*free_func) (void *));
+void SuiteSparse_config_printf_func_set (int (*printf_func) (const char *, ...));
+void SuiteSparse_config_hypot_func_set (double (*hypot_func) (double, double));
+void SuiteSparse_config_divcomplex_func_set (int (*divcomplex_func) (double, double, double, double, double *, double *));
 
 // The SuiteSparse_config_*_func methods are wrappers that call the function
 // pointers in the struct.  Note that there is no wrapper for the printf_func.

--- a/SuiteSparse_config/SuiteSparse_config.c
+++ b/SuiteSparse_config/SuiteSparse_config.c
@@ -92,39 +92,39 @@ static struct SuiteSparse_config_struct SuiteSparse_config =
 
 // Methods that return the contents of the SuiteSparse_config struct.
 
-void *SuiteSparse_config_malloc_func_get (void)
+void *(*SuiteSparse_config_malloc_func_get (void)) (size_t)
 {
-    return ((void *) SuiteSparse_config.malloc_func) ;
+    return (SuiteSparse_config.malloc_func) ;
 }
 
-void *SuiteSparse_config_calloc_func_get (void)
+void *(*SuiteSparse_config_calloc_func_get (void)) (size_t, size_t)
 {
-    return ((void *) SuiteSparse_config.calloc_func) ;
+    return (SuiteSparse_config.calloc_func) ;
 }
 
-void *SuiteSparse_config_realloc_func_get (void)
+void *(*SuiteSparse_config_realloc_func_get (void)) (void *, size_t)
 {
-    return ((void *) SuiteSparse_config.realloc_func) ;
+    return (SuiteSparse_config.realloc_func) ;
 }
 
-void *SuiteSparse_config_free_func_get (void)
+void (*SuiteSparse_config_free_func_get (void)) (void *)
 {
-    return ((void *) SuiteSparse_config.free_func) ;
+    return (SuiteSparse_config.free_func) ;
 }
 
-void *SuiteSparse_config_printf_func_get (void)
+int (*SuiteSparse_config_printf_func_get (void)) (const char *, ...)
 {
-    return ((void *) SuiteSparse_config.printf_func) ;
+    return (SuiteSparse_config.printf_func) ;
 }
 
-void *SuiteSparse_config_hypot_func_get (void)
+double (*SuiteSparse_config_hypot_func_get (void)) (double, double)
 {
-    return ((void *) SuiteSparse_config.hypot_func) ;
+    return (SuiteSparse_config.hypot_func) ;
 }
 
-void *SuiteSparse_config_divcomplex_func_get (void)
+int (*SuiteSparse_config_divcomplex_func_get (void)) (double, double, double, double, double *, double *)
 {
-    return ((void *) SuiteSparse_config.divcomplex_func) ;
+    return (SuiteSparse_config.divcomplex_func) ;
 }
 
 //------------------------------------------------------------------------------
@@ -133,37 +133,37 @@ void *SuiteSparse_config_divcomplex_func_get (void)
 
 // Methods that set the contents of the SuiteSparse_config struct.
 
-void SuiteSparse_config_malloc_func_set (void *malloc_func)
+void SuiteSparse_config_malloc_func_set (void *(*malloc_func) (size_t))
 {
     SuiteSparse_config.malloc_func = malloc_func ;
 }
 
-void SuiteSparse_config_calloc_func_set (void *calloc_func)
+void SuiteSparse_config_calloc_func_set (void *(*calloc_func) (size_t, size_t))
 {
     SuiteSparse_config.calloc_func = calloc_func ;
 }
 
-void SuiteSparse_config_realloc_func_set (void *realloc_func)
+void SuiteSparse_config_realloc_func_set (void *(*realloc_func) (void *, size_t))
 {
     SuiteSparse_config.realloc_func = realloc_func ;
 }
 
-void SuiteSparse_config_free_func_set (void *free_func)
+void SuiteSparse_config_free_func_set (void (*free_func) (void *))
 {
     SuiteSparse_config.free_func = free_func ;
 }
 
-void SuiteSparse_config_printf_func_set (void *printf_func)
+void SuiteSparse_config_printf_func_set (int (*printf_func) (const char *, ...))
 {
     SuiteSparse_config.printf_func = printf_func ;
 }
 
-void SuiteSparse_config_hypot_func_set (void *hypot_func)
+void SuiteSparse_config_hypot_func_set (double (*hypot_func) (double, double))
 {
     SuiteSparse_config.hypot_func = hypot_func ;
 }
 
-void SuiteSparse_config_divcomplex_func_set (void *divcomplex_func)
+void SuiteSparse_config_divcomplex_func_set (int (*divcomplex_func) (double, double, double, double, double *, double *))
 {
     SuiteSparse_config.divcomplex_func = divcomplex_func ;
 }

--- a/SuiteSparse_config/SuiteSparse_config.h
+++ b/SuiteSparse_config/SuiteSparse_config.h
@@ -279,22 +279,22 @@ extern "C"
 // wrappers defined below to access them.
 
 // The SuiteSparse_config_*_get methods return the contents of the struct:
-void *SuiteSparse_config_malloc_func_get (void) ;
-void *SuiteSparse_config_calloc_func_get (void) ;
-void *SuiteSparse_config_realloc_func_get (void) ;
-void *SuiteSparse_config_free_func_get (void) ;
-void *SuiteSparse_config_printf_func_get (void) ;
-void *SuiteSparse_config_hypot_func_get (void) ;
-void *SuiteSparse_config_divcomplex_func_get (void) ;
+void *(*SuiteSparse_config_malloc_func_get (void)) (size_t);
+void *(*SuiteSparse_config_calloc_func_get (void)) (size_t, size_t);
+void *(*SuiteSparse_config_realloc_func_get (void)) (void *, size_t);
+void (*SuiteSparse_config_free_func_get (void)) (void *);
+int (*SuiteSparse_config_printf_func_get (void)) (const char *, ...);
+double (*SuiteSparse_config_hypot_func_get (void)) (double, double);
+int (*SuiteSparse_config_divcomplex_func_get (void)) (double, double, double, double, double *, double *);
 
 // The SuiteSparse_config_*_set methods modify the contents of the struct:
-void SuiteSparse_config_malloc_func_set (void *malloc_func) ;
-void SuiteSparse_config_calloc_func_set (void *calloc_func) ;
-void SuiteSparse_config_realloc_func_set (void *realloc_func) ;
-void SuiteSparse_config_free_func_set (void *free_func) ;
-void SuiteSparse_config_printf_func_set (void *printf_func) ;
-void SuiteSparse_config_hypot_func_set (void *hypot_func) ;
-void SuiteSparse_config_divcomplex_func_set (void *divcomplex_func) ;
+void SuiteSparse_config_malloc_func_set (void *(*malloc_func) (size_t));
+void SuiteSparse_config_calloc_func_set (void *(*calloc_func) (size_t, size_t));
+void SuiteSparse_config_realloc_func_set (void *(*realloc_func) (void *, size_t));
+void SuiteSparse_config_free_func_set (void (*free_func) (void *));
+void SuiteSparse_config_printf_func_set (int (*printf_func) (const char *, ...));
+void SuiteSparse_config_hypot_func_set (double (*hypot_func) (double, double));
+void SuiteSparse_config_divcomplex_func_set (int (*divcomplex_func) (double, double, double, double, double *, double *));
 
 // The SuiteSparse_config_*_func methods are wrappers that call the function
 // pointers in the struct.  Note that there is no wrapper for the printf_func.


### PR DESCRIPTION
I built and installed the libraries from the `7.0.0.beta1` tag. 
I tried to rebuild Octave with them installed. But (unsurprisingly) it needed some changes to account for the new API with get and set functions instead of the global structure.
Casting forth and back between function pointers and `void *` is pretty awkward in C++ if you try to avoid old-style casts. (`reinterpret_cast` fails on `nullptr` and `static_cast` fails on function pointers.)
Would it be possible to avoid the cast to `void *` in the API? That would also improve type safety. When a user inadvertently passes the pointer to a function with a non-matching signature, the compiler would already complain (instead of a crash on runtime).

The proposed changes use function pointers as the arguments and return values of the newly added get and set functions.
