### PR TITLE
remove unused METIS files

### DIFF
--- a/CHOLMOD/Partition/cholmod_metis_wrapper.c
+++ b/CHOLMOD/Partition/cholmod_metis_wrapper.c
@@ -2,7 +2,7 @@
 // CHOLMOD/Partition/cholmod_metis_wrapper: METIS functions embedded in CHOLMOD
 //------------------------------------------------------------------------------
 
-// CHOLMOD/Partition Module.  Copyright (C) 2005-2022, University of Florida.
+// CHOLMOD/Partition Module.  Copyright (C) 2005-2023, University of Florida.
 // All Rights Reserved.  Author: Timothy A. Davis.
 // SPDX-License-Identifier: LGPL-2.1+
 
@@ -19,26 +19,20 @@
 
 #include "cholmod_metis_wrapper.h"
 
-#include "SuiteSparse_metis/GKlib/b64.c"
 #include "SuiteSparse_metis/GKlib/blas.c"
-#include "SuiteSparse_metis/GKlib/csr.c"
 #include "SuiteSparse_metis/GKlib/error.c"
 #include "SuiteSparse_metis/GKlib/evaluate.c"
 #include "SuiteSparse_metis/GKlib/fkvkselect.c"
-#include "SuiteSparse_metis/GKlib/graph.c"
-#include "SuiteSparse_metis/GKlib/htable.c"
-#include "SuiteSparse_metis/GKlib/itemsets.c"
 #include "SuiteSparse_metis/GKlib/mcore.c"
 #include "SuiteSparse_metis/GKlib/memory.c"
 #include "SuiteSparse_metis/GKlib/omp.c"
-#include "SuiteSparse_metis/GKlib/pqueue.c"
 #include "SuiteSparse_metis/GKlib/random.c"
 #include "SuiteSparse_metis/GKlib/sort.c"
 #include "SuiteSparse_metis/GKlib/util.c"
 
 // unused by CHOLMOD:
 // #include "SuiteSparse_metis/GKlib/timers.c"
-// replace the timer functions from timers.c::
+// replace the timer functions from timers.c:
 double gk_WClockSeconds(void) { return (0) ; }
 double gk_CPUSeconds(void) { return (0) ; }
 // #include "SuiteSparse_metis/GKlib/fs.c"
@@ -50,6 +44,12 @@ double gk_CPUSeconds(void) { return (0) ; }
 // #include "SuiteSparse_metis/GKlib/seq.c"
 // #include "SuiteSparse_metis/GKlib/tokenizer.c"
 // #include "SuiteSparse_metis/GKlib/string.c"
+// #include "SuiteSparse_metis/GKlib/pqueue.c"
+// #include "SuiteSparse_metis/GKlib/csr.c"
+// #include "SuiteSparse_metis/GKlib/graph.c"
+// #include "SuiteSparse_metis/GKlib/itemsets.c"
+// #include "SuiteSparse_metis/GKlib/b64.c"
+// #include "SuiteSparse_metis/GKlib/htable.c"
 
 // for parmetis.c: replace abs with 64-bit version
 #define abs SuiteSparse_metis_abs64


### PR DESCRIPTION
Commented out more GKlib files in METIS that are not required for building the METIS library itself.
