### PR TITLE
Build example as part of the CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
             cc: "gcc"
             cxx: "g++"
           - compiler: clang
-            compiler-pkgs: "clang"
+            compiler-pkgs: "clang libomp-dev"
             cc: "clang"
             cxx: "clang++"
           # Clang seems to generally require less cache size (smaller object files?).
@@ -60,17 +60,18 @@ jobs:
             libopenblas-dev
 
       - name: prepare ccache
-        # create human readable timestamp
-        id: ccache_cache_timestamp
+        # create key with human readable timestamp
+        # used in action/cache/restore and action/cache/save steps
+        id: ccache-prepare
         run: |
-          echo "timestamp=$(date +"%Y-%m-%d_%H-%M-%S")" >> $GITHUB_OUTPUT
+          echo "key=ccache:ubuntu:${{ matrix.compiler }}:${{ github.ref }}:$(date +"%Y-%m-%d_%H-%M-%S"):${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - name: restore ccache
         # setup the GitHub cache used to maintain the ccache from one job to the next
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: ~/.ccache
-          key: ccache:ubuntu:${{ matrix.compiler }}:${{ github.ref }}:${{ steps.ccache_cache_timestamp.outputs.timestamp }}:${{ github.sha }}
+          key: ${{ steps.ccache-prepare.outputs.key }}
           # Prefer caches from the same branch. Fall back to caches from the dev branch.
           restore-keys: |
             ccache:ubuntu:${{ matrix.compiler }}:${{ github.ref }}
@@ -94,6 +95,7 @@ jobs:
             echo "::group::Configure $lib"
             cd ${GITHUB_WORKSPACE}/${lib}/build
             cmake -DCMAKE_BUILD_TYPE="Release" \
+                  -DCMAKE_INSTALL_PREFIX=../.. \
                   -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
                   -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
                   -DCMAKE_Fortran_COMPILER_LAUNCHER="ccache" \
@@ -118,6 +120,37 @@ jobs:
       - name: ccache status
         continue-on-error: true
         run: ccache -s
+
+      - name: save ccache
+        # Save the cache after we are done (successfully) building
+        # This helps to retain the ccache even if the subsequent steps are failing.
+        uses: actions/cache/save@v3
+        with:
+          path: ~/.ccache
+          key: ${{ steps.ccache-prepare.outputs.key }}
+
+      - name: install
+        run: |
+          IFS=':' read -r -a libs <<< "${BUILD_LIBS}"
+          for lib in "${libs[@]}"; do
+            printf "::group::\033[0;32m==>\033[0m Installing library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/${lib}/build
+            cmake --install .
+            echo "::endgroup::"
+          done
+
+      - name: build example
+        run: |
+          cd ${GITHUB_WORKSPACE}/Example
+          printf "::group::\033[0;32m==>\033[0m Configuring example\n"
+          cmake .
+          echo "::endgroup::"
+          printf "::group::\033[0;32m==>\033[0m Building example\n"
+          cmake --build .
+          echo "::endgroup::"
+          printf "::group::\033[0;32m==>\033[0m Executing example\n"
+          LD_LIBRARY_PATH=../lib ./my_demo
+          echo "::endgroup::"
 
 
   macos:
@@ -145,17 +178,18 @@ jobs:
           brew install autoconf automake ccache cmake gmp lapack libomp mpfr openblas
 
       - name: prepare ccache
-        # create human readable timestamp
-        id: ccache_cache_timestamp
+        # create key with human readable timestamp
+        # used in action/cache/restore and action/cache/save steps
+        id: ccache-prepare
         run: |
-          echo "timestamp=$(date +"%Y-%m-%d_%H-%M-%S")" >> $GITHUB_OUTPUT
+          echo "key=ccache:macos-latest:${{ github.ref }}:$(date +"%Y-%m-%d_%H-%M-%S"):${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - name: restore ccache
         # setup the GitHub cache used to maintain the ccache from one job to the next
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: /Users/runner/Library/Caches/ccache
-          key: ccache:macos-latest:${{ github.ref }}:${{ steps.ccache_cache_timestamp.outputs.timestamp }}:${{ github.sha }}
+          key: ${{ steps.ccache-prepare.outputs.key }}
           # Prefer caches from the same branch. Fall back to caches from the dev branch.
           restore-keys: |
             ccache:macos-latest:${{ github.ref }}
@@ -176,6 +210,7 @@ jobs:
             echo "::group::Configure $lib"
             cd ${GITHUB_WORKSPACE}/${lib}/build
             cmake -DCMAKE_BUILD_TYPE="Release" \
+                  -DCMAKE_INSTALL_PREFIX=../.. \
                   -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
                   -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
                   -DCMAKE_Fortran_COMPILER_LAUNCHER="ccache" \
@@ -201,6 +236,39 @@ jobs:
       - name: ccache status
         continue-on-error: true
         run: ccache -s
+
+      - name: save ccache
+        # Save the cache after we are done (successfully) building
+        # This helps to retain the ccache even if the subsequent steps are failing.
+        uses: actions/cache/save@v3
+        with:
+          path: /Users/runner/Library/Caches/ccache
+          key: ${{ steps.ccache-prepare.outputs.key }}
+
+      - name: install
+        run: |
+          IFS=':' read -r -a libs <<< "${BUILD_LIBS}"
+          for lib in "${libs[@]}"; do
+            printf "::group::\033[0;32m==>\033[0m Installing library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/${lib}/build
+            cmake --install .
+            echo "::endgroup::"
+          done
+
+      - name: build example
+        run: |
+          cd ${GITHUB_WORKSPACE}/Example
+          printf "::group::\033[0;32m==>\033[0m Configuring example\n"
+          cmake \
+            -DCMAKE_PREFIX_PATH="/usr/local/opt/lapack;/usr/local/opt/openblas;/usr/local/opt/libomp" \
+            .
+          echo "::endgroup::"
+          printf "::group::\033[0;32m==>\033[0m Building example\n"
+          cmake --build .
+          echo "::endgroup::"
+          printf "::group::\033[0;32m==>\033[0m Executing example\n"
+          ./my_demo
+          echo "::endgroup::"
 
 
   mingw:
@@ -269,18 +337,19 @@ jobs:
         uses: actions/checkout@v3
 
       - name: prepare ccache
-        # Create human readable timestamp
-        id: ccache_cache_timestamp
+        # create key with human readable timestamp
+        # used in action/cache/restore and action/cache/save steps
+        id: ccache-prepare
         run: |
           echo "ccachedir=$(cygpath -m $(ccache -k cache_dir))" >> $GITHUB_OUTPUT
-          echo "timestamp=$(date +"%Y-%m-%d_%H-%M-%S")" >> $GITHUB_OUTPUT
+          echo "key=ccache:mingw:${{ matrix.msystem }}:${{ github.ref }}:$(date +"%Y-%m-%d_%H-%M-%S"):${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - name: restore ccache
         # Setup the GitHub cache used to maintain the ccache from one job to the next
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
-          path: ${{ steps.ccache_cache_timestamp.outputs.ccachedir }}
-          key: ccache:mingw:${{ matrix.msystem }}:${{ github.ref }}:${{ steps.ccache_cache_timestamp.outputs.timestamp }}:${{ github.sha }}
+          path: ${{ steps.ccache-prepare.outputs.ccachedir }}
+          key: ${{ steps.ccache-prepare.outputs.key }}
           # Prefer caches from the same branch. Fall back to caches from the dev branch.
           restore-keys: |
             ccache:mingw:${{ matrix.msystem }}:${{ github.ref }}
@@ -333,6 +402,27 @@ jobs:
       - name: ccache status
         continue-on-error: true
         run: ccache -s
+
+      - name: save ccache
+        # Save the cache after we are done (successfully) building
+        # This helps to retain the ccache even if the subsequent steps are failing.
+        uses: actions/cache/save@v3
+        with:
+          path: ${{ steps.ccache-prepare.outputs.ccachedir }}
+          key: ${{ steps.ccache-prepare.outputs.key }}
+
+      - name: build example
+        run: |
+          cd ${GITHUB_WORKSPACE}/Example
+          printf "::group::\033[0;32m==>\033[0m Configuring example\n"
+          cmake -DCMAKE_MODULE_PATH="${MINGW_PREFIX}/lib/cmake/SuiteSparse" .
+          echo "::endgroup::"
+          printf "::group::\033[0;32m==>\033[0m Building example\n"
+          cmake --build .
+          echo "::endgroup::"
+          printf "::group::\033[0;32m==>\033[0m Executing example\n"
+          ./my_demo
+          echo "::endgroup::"
 
 
   msvc:
@@ -420,19 +510,20 @@ jobs:
           echo "CCACHE=C:/Miniconda/envs/test/Library/bin/ccache.exe" >> ${GITHUB_ENV}
 
       - name: prepare ccache
-        # Check path to cache directory
-        id: ccache-cache
+        # create key with human readable timestamp
+        # used in action/cache/restore and action/cache/save steps
+        id: ccache-prepare
         shell: msys2 {0}
         run: |
           echo "ccachedir=$(cygpath -m $(${CCACHE} -k cache_dir))" >> $GITHUB_OUTPUT
-          echo "timestamp=$(date +"%Y-%m-%d_%H-%M-%S")" >> $GITHUB_OUTPUT
+          echo "key=ccache:msvc:${{ github.ref }}:$(date +"%Y-%m-%d_%H-%M-%S"):${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - name: restore ccache
         # Setup the GitHub cache used to maintain the ccache from one job to the next
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
-          path: ${{ steps.ccache-cache.outputs.ccachedir }}
-          key: ccache:msvc:${{ github.ref }}:${{ steps.ccache-cache.outputs.timestamp }}:${{ github.sha }}
+          path: ${{ steps.ccache-prepare.outputs.ccachedir }}
+          key: ${{ steps.ccache-prepare.outputs.key }}
           # Prefer caches from the same branch. Fall back to caches from the dev branch.
           restore-keys: |
             ccache:msvc:${{ github.ref }}
@@ -441,9 +532,9 @@ jobs:
       - name: configure ccache
         # Limit the maximum size and switch on compression to avoid exceeding the total disk or cache quota.
         run: |
-          test -d ${{ steps.ccache-cache.outputs.ccachedir }} || mkdir -p ${{ steps.ccache-cache.outputs.ccachedir }}
-          echo "max_size = 250M" > ${{ steps.ccache-cache.outputs.ccachedir }}/ccache.conf
-          echo "compression = true" >> ${{ steps.ccache-cache.outputs.ccachedir }}/ccache.conf
+          test -d ${{ steps.ccache-prepare.outputs.ccachedir }} || mkdir -p ${{ steps.ccache-prepare.outputs.ccachedir }}
+          echo "max_size = 250M" > ${{ steps.ccache-prepare.outputs.ccachedir }}/ccache.conf
+          echo "compression = true" >> ${{ steps.ccache-prepare.outputs.ccachedir }}/ccache.conf
           ${CCACHE} -p
           ${CCACHE} -s
 
@@ -459,6 +550,7 @@ jobs:
             echo "::group::Configure $lib"
             cd ${GITHUB_WORKSPACE}/${lib}/build
             cmake -G"Ninja Multi-Config" \
+                  -DCMAKE_INSTALL_PREFIX=../.. \
                   -DCMAKE_BUILD_TYPE="Release" \
                   -DCMAKE_PREFIX_PATH="C:/Miniconda/envs/test/Library;${GITHUB_WORKSPACE}/dependencies" \
                   -DCMAKE_C_COMPILER_LAUNCHER=${CCACHE} \
@@ -478,3 +570,38 @@ jobs:
       - name: ccache status
         continue-on-error: true
         run: ${CCACHE} -s
+
+      - name: save ccache
+        # Save the cache after we are done (successfully) building
+        # This helps to retain the ccache even if the subsequent steps are failing.
+        uses: actions/cache/save@v3
+        with:
+          path: ${{ steps.ccache-prepare.outputs.ccachedir }}
+          key: ${{ steps.ccache-prepare.outputs.key }}
+
+      - name: install
+        run: |
+          IFS=':' read -r -a libs <<< "${BUILD_LIBS}"
+          for lib in "${libs[@]}"; do
+            printf "::group::\033[0;32m==>\033[0m Installing library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/${lib}/build
+            cmake --install .
+            echo "::endgroup::"
+          done
+
+      - name: build example
+        run: |
+          cd ${GITHUB_WORKSPACE}/Example
+          printf "::group::\033[0;32m==>\033[0m Configuring example\n"
+          cmake \
+            -DCMAKE_PREFIX_PATH="C:/Miniconda/envs/test/Library;${GITHUB_WORKSPACE}/dependencies" \
+            -DCMAKE_C_FLAGS="-DNCOMPLEX" \
+            -DBLA_VENDOR="All" \
+            .
+          echo "::endgroup::"
+          printf "::group::\033[0;32m==>\033[0m Building example\n"
+          cmake --build . --config Release
+          echo "::endgroup::"
+          printf "::group::\033[0;32m==>\033[0m Executing example\n"
+          PATH="${GITHUB_WORKSPACE}/bin;${GITHUB_WORKSPACE}/dependencies/bin;${PATH}" ./Release/my_demo
+          echo "::endgroup::"

--- a/AMD/cmake_modules/FindAMD.cmake
+++ b/AMD/cmake_modules/FindAMD.cmake
@@ -49,7 +49,7 @@ find_library ( AMD_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME amd_static )
+    set ( STATIC_NAME amd_static amd )
 else ( )
     set ( STATIC_NAME amd )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/BTF/cmake_modules/FindBTF.cmake
+++ b/BTF/cmake_modules/FindBTF.cmake
@@ -49,7 +49,7 @@ find_library ( BTF_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME btf_static )
+    set ( STATIC_NAME btf_static btf )
 else ( )
     set ( STATIC_NAME btf )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/CAMD/cmake_modules/FindCAMD.cmake
+++ b/CAMD/cmake_modules/FindCAMD.cmake
@@ -49,7 +49,7 @@ find_library ( CAMD_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME camd_static )
+    set ( STATIC_NAME camd_static camd )
 else ( )
     set ( STATIC_NAME camd )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/CCOLAMD/cmake_modules/FindCCOLAMD.cmake
+++ b/CCOLAMD/cmake_modules/FindCCOLAMD.cmake
@@ -49,7 +49,7 @@ find_library ( CCOLAMD_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME ccolamd_static )
+    set ( STATIC_NAME ccolamd_static ccolamd )
 else ( )
     set ( STATIC_NAME ccolamd )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/CHOLMOD/cmake_modules/FindCHOLMOD.cmake
+++ b/CHOLMOD/cmake_modules/FindCHOLMOD.cmake
@@ -48,7 +48,7 @@ find_library ( CHOLMOD_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME cholmod_static )
+    set ( STATIC_NAME cholmod_static cholmod )
 else ( )
     set ( STATIC_NAME cholmod )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/CHOLMOD/cmake_modules/FindCHOLMOD_CUDA.cmake
+++ b/CHOLMOD/cmake_modules/FindCHOLMOD_CUDA.cmake
@@ -50,7 +50,7 @@ find_library ( CHOLMOD_CUDA_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME cholmod_cuda_static )
+    set ( STATIC_NAME cholmod_cuda_static cholmod_cuda )
 else ( )
     set ( STATIC_NAME cholmod_cuda )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/COLAMD/cmake_modules/FindCOLAMD.cmake
+++ b/COLAMD/cmake_modules/FindCOLAMD.cmake
@@ -49,7 +49,7 @@ find_library ( COLAMD_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME colamd_static )
+    set ( STATIC_NAME colamd_static colamd )
 else ( )
     set ( STATIC_NAME colamd )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/CXSparse/cmake_modules/FindCXSparse.cmake
+++ b/CXSparse/cmake_modules/FindCXSparse.cmake
@@ -54,7 +54,7 @@ find_library ( CXSPARSE_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME cxsparse_static )
+    set ( STATIC_NAME cxsparse_static cxsparse )
 else ( )
     set ( STATIC_NAME cxsparse )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/GPUQREngine/cmake_modules/FindGPUQREngine.cmake
+++ b/GPUQREngine/cmake_modules/FindGPUQREngine.cmake
@@ -51,7 +51,7 @@ find_library ( GPUQRENGINE_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME gpuqrengine_static )
+    set ( STATIC_NAME gpuqrengine_static gpuqrengine )
 else ( )
     set ( STATIC_NAME gpuqrengine )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/GraphBLAS/cmake_modules/FindGraphBLAS.cmake
+++ b/GraphBLAS/cmake_modules/FindGraphBLAS.cmake
@@ -86,7 +86,7 @@ find_library ( GRAPHBLAS_LIBRARY
   )
 
 if ( MSVC )
-    set ( STATIC_NAME graphblas_static )
+    set ( STATIC_NAME graphblas_static graphblas )
 else ( )
     set ( STATIC_NAME graphblas )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/KLU/cmake_modules/FindKLU.cmake
+++ b/KLU/cmake_modules/FindKLU.cmake
@@ -49,7 +49,7 @@ find_library ( KLU_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME klu_static )
+    set ( STATIC_NAME klu_static klu )
 else ( )
     set ( STATIC_NAME klu )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/KLU/cmake_modules/FindKLU_CHOLMOD.cmake
+++ b/KLU/cmake_modules/FindKLU_CHOLMOD.cmake
@@ -57,7 +57,7 @@ find_library ( KLU_CHOLMOD_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME klu_cholmod_static )
+    set ( STATIC_NAME klu_cholmod_static klu_cholmod )
 else ( )
     set ( STATIC_NAME klu_cholmod )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/LDL/cmake_modules/FindLDL.cmake
+++ b/LDL/cmake_modules/FindLDL.cmake
@@ -49,7 +49,7 @@ find_library ( LDL_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME ldl_static )
+    set ( STATIC_NAME ldl_static ldl )
 else ( )
     set ( STATIC_NAME ldl )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/Mongoose/cmake_modules/FindMongoose.cmake
+++ b/Mongoose/cmake_modules/FindMongoose.cmake
@@ -53,7 +53,7 @@ find_library ( MONGOOSE_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME mongoose_static )
+    set ( STATIC_NAME mongoose_static mongoose )
 else ( )
     set ( STATIC_NAME mongoose )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/RBio/cmake_modules/FindRBio.cmake
+++ b/RBio/cmake_modules/FindRBio.cmake
@@ -53,7 +53,7 @@ find_library ( RBIO_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME rbio_static )
+    set ( STATIC_NAME rbio_static rbio )
 else ( )
     set ( STATIC_NAME rbio )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/SPEX/cmake_modules/FindSPEX.cmake
+++ b/SPEX/cmake_modules/FindSPEX.cmake
@@ -49,7 +49,7 @@ find_library ( SPEX_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME spex_static )
+    set ( STATIC_NAME spex_static spex )
 else ( )
     set ( STATIC_NAME spex )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/SPQR/cmake_modules/FindSPQR.cmake
+++ b/SPQR/cmake_modules/FindSPQR.cmake
@@ -49,7 +49,7 @@ find_library ( SPQR_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME spqr_static )
+    set ( STATIC_NAME spqr_static spqr )
 else ( )
     set ( STATIC_NAME spqr )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/SPQR/cmake_modules/FindSPQR_CUDA.cmake
+++ b/SPQR/cmake_modules/FindSPQR_CUDA.cmake
@@ -40,7 +40,7 @@ find_library ( SPQR_CUDA_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME spqr_cuda_static )
+    set ( STATIC_NAME spqr_cuda_static spqr_cuda )
 else ( )
     set ( STATIC_NAME spqr_cuda )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/SuiteSparse_GPURuntime/cmake_modules/FindSuiteSparse_GPURuntime.cmake
+++ b/SuiteSparse_GPURuntime/cmake_modules/FindSuiteSparse_GPURuntime.cmake
@@ -51,7 +51,7 @@ find_library ( SUITESPARSE_GPURUNTIME_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME suitesparse_gpuruntime_static )
+    set ( STATIC_NAME suitesparse_gpuruntime_static suitesparse_gpuruntime )
 else ( )
     set ( STATIC_NAME suitesparse_gpuruntime )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/SuiteSparse_config/cmake_modules/FindSuiteSparse_config.cmake
+++ b/SuiteSparse_config/cmake_modules/FindSuiteSparse_config.cmake
@@ -53,7 +53,7 @@ find_library ( SUITESPARSE_CONFIG_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME suitesparseconfig_static )
+    set ( STATIC_NAME suitesparseconfig_static suitesparseconfig )
 else ( )
     set ( STATIC_NAME suitesparseconfig )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )

--- a/UMFPACK/cmake_modules/FindUMFPACK.cmake
+++ b/UMFPACK/cmake_modules/FindUMFPACK.cmake
@@ -50,7 +50,7 @@ find_library ( UMFPACK_LIBRARY
 )
 
 if ( MSVC )
-    set ( STATIC_NAME umfpack_static )
+    set ( STATIC_NAME umfpack_static umfpack )
 else ( )
     set ( STATIC_NAME umfpack )
     set ( save ${CMAKE_FIND_LIBRARY_SUFFIXES} )


### PR DESCRIPTION
This PR adds steps to build (and execute) the example as part of the CI.
This helps to check if the Find*.cmake modules are doing the "Right Thing™".

Adding this revealed a few (potential) issues:
- The `ubuntu (clang)` runner was building without OpenMP. This only affected the CI and should be fixed with the changes here.
- Using the Find*.cmake modules with MSVC didn't fall back to the shared library if the static library wasn't built. That is the default for the GraphBLAS library. This currently also affects downstream users with MSVC. This should be fixed by the second commit in this PR.
- It would be nice if some of the preprocessor flags would be public. E.g., downstream users of CXSparse would likely be interested in whether the library was built with `-DNCOMPLEX` in the preprocessor/compiler flags. (It might also be nice if that preprocessor flag would be renamed to something more specific like `CXSPARSE_NCOMPLEX` to avoid symbol collisions in downstream projects.) There are no changes related to this in this PR. It might be easier to tackle this once/if downstream could import targets (see #267).

Edit: For an alternative approach to avoid the issue described in the last point see #288.