### PR TITLE
CXSparse: Match API in public header to compiled library.

### DIFF
--- a/CXSparse/CMakeLists.txt
+++ b/CXSparse/CMakeLists.txt
@@ -46,8 +46,10 @@ endif ( )
 if ( NCOMPLEX )
     message ( STATUS "complex data type: disabled" )
     add_compile_definitions ( NCOMPLEX )
+    set ( CXSPARSE_USE_COMPLEX 0 )
 else ( )
     message ( STATUS "complex data type: enabled" )
+    set ( CXSPARSE_USE_COMPLEX 1 )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/CXSparse/Config/cs.h.in
+++ b/CXSparse/Config/cs.h.in
@@ -27,13 +27,13 @@
 #define _CXS_H
 
 #ifdef __cplusplus
-#ifndef NCOMPLEX
+#if @CXSPARSE_USE_COMPLEX@
 #include <complex>
 typedef std::complex<double> cs_complex_t ;
 #endif
 extern "C" {
 #else
-#ifndef NCOMPLEX
+#if @CXSPARSE_USE_COMPLEX@
 #include <complex.h>
 #define cs_complex_t double complex
 #endif
@@ -334,7 +334,7 @@ cs_dld *cs_dl_ddone (cs_dld *D, cs_dl *C, void *w, int64_t ok) ;
 /* complex/int32_t version of CXSparse */
 /* -------------------------------------------------------------------------- */
 
-#ifndef NCOMPLEX
+#if @CXSPARSE_USE_COMPLEX@
 
 /* --- primary CSparse routines and data structures ------------------------- */
 
@@ -759,7 +759,7 @@ cs_cld *cs_cl_ddone (cs_cld *D, cs_cl *C, void *w, int64_t ok) ;
 /* Conversion routines */
 /* -------------------------------------------------------------------------- */
 
-#ifndef NCOMPLEX
+#if @CXSPARSE_USE_COMPLEX@
 cs_di *cs_i_real (cs_ci *A, int32_t real) ;
 cs_ci *cs_i_complex (cs_di *A, int32_t real) ;
 cs_dl *cs_l_real (cs_cl *A, int64_t real) ;

--- a/CXSparse/Include/cs.h
+++ b/CXSparse/Include/cs.h
@@ -27,13 +27,13 @@
 #define _CXS_H
 
 #ifdef __cplusplus
-#ifndef NCOMPLEX
+#if 1
 #include <complex>
 typedef std::complex<double> cs_complex_t ;
 #endif
 extern "C" {
 #else
-#ifndef NCOMPLEX
+#if 1
 #include <complex.h>
 #define cs_complex_t double complex
 #endif
@@ -334,7 +334,7 @@ cs_dld *cs_dl_ddone (cs_dld *D, cs_dl *C, void *w, int64_t ok) ;
 /* complex/int32_t version of CXSparse */
 /* -------------------------------------------------------------------------- */
 
-#ifndef NCOMPLEX
+#if 1
 
 /* --- primary CSparse routines and data structures ------------------------- */
 
@@ -759,7 +759,7 @@ cs_cld *cs_cl_ddone (cs_cld *D, cs_cl *C, void *w, int64_t ok) ;
 /* Conversion routines */
 /* -------------------------------------------------------------------------- */
 
-#ifndef NCOMPLEX
+#if 1
 cs_di *cs_i_real (cs_ci *A, int32_t real) ;
 cs_ci *cs_i_complex (cs_di *A, int32_t real) ;
 cs_dl *cs_l_real (cs_cl *A, int64_t real) ;


### PR DESCRIPTION
Currently, a downstream user would need to know whether the CXSparse library was built with or without `NCOMPLEX`. The user would need to compile their dependent project with that preprocessor value defined (or undefined) accordingly. That might be difficult to determine in general, e.g., if the library was downloaded from a binary distribution repository (i.e., most Linux distributions).

The proposed changes hard-code the value that was used during compilation in the public header. So, a downstream user would no longer need to worry about the status of that flag during compilation.

Edit: By removing that preprocessor macro from the public header, the risk of a symbol collision in downstream projects would also be avoided.
