### PR TITLE
CI: No longer manually define NCOMPLEX when building the example with MSVC.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -595,7 +595,6 @@ jobs:
           printf "::group::\033[0;32m==>\033[0m Configuring example\n"
           cmake \
             -DCMAKE_PREFIX_PATH="C:/Miniconda/envs/test/Library;${GITHUB_WORKSPACE}/dependencies" \
-            -DCMAKE_C_FLAGS="-DNCOMPLEX" \
             -DBLA_VENDOR="All" \
             .
           echo "::endgroup::"


### PR DESCRIPTION
Defining `NCOMPLEX` manually in the CFLAGS when building the example is no longer needed now that #288 is merged.
