### PR TITLE
CI: Build example in subfolder `build`.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -141,15 +141,17 @@ jobs:
 
       - name: build example
         run: |
-          cd ${GITHUB_WORKSPACE}/Example
+          cd ${GITHUB_WORKSPACE}/Example/build
           printf "::group::\033[0;32m==>\033[0m Configuring example\n"
-          cmake .
+          cmake \
+            -DBLA_VENDOR="OpenBLAS" \
+            ..
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Building example\n"
           cmake --build .
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Executing example\n"
-          LD_LIBRARY_PATH=../lib ./my_demo
+          LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_demo
           echo "::endgroup::"
 
 
@@ -257,11 +259,11 @@ jobs:
 
       - name: build example
         run: |
-          cd ${GITHUB_WORKSPACE}/Example
+          cd ${GITHUB_WORKSPACE}/Example/build
           printf "::group::\033[0;32m==>\033[0m Configuring example\n"
           cmake \
             -DCMAKE_PREFIX_PATH="/usr/local/opt/lapack;/usr/local/opt/openblas;/usr/local/opt/libomp" \
-            .
+            ..
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Building example\n"
           cmake --build .
@@ -413,9 +415,11 @@ jobs:
 
       - name: build example
         run: |
-          cd ${GITHUB_WORKSPACE}/Example
+          cd ${GITHUB_WORKSPACE}/Example/build
           printf "::group::\033[0;32m==>\033[0m Configuring example\n"
-          cmake -DCMAKE_MODULE_PATH="${MINGW_PREFIX}/lib/cmake/SuiteSparse" .
+          cmake \
+            -DCMAKE_MODULE_PATH="${MINGW_PREFIX}/lib/cmake/SuiteSparse" \
+            ..
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Building example\n"
           cmake --build .
@@ -591,12 +595,12 @@ jobs:
 
       - name: build example
         run: |
-          cd ${GITHUB_WORKSPACE}/Example
+          cd ${GITHUB_WORKSPACE}/Example/build
           printf "::group::\033[0;32m==>\033[0m Configuring example\n"
           cmake \
             -DCMAKE_PREFIX_PATH="C:/Miniconda/envs/test/Library;${GITHUB_WORKSPACE}/dependencies" \
             -DBLA_VENDOR="All" \
-            .
+            ..
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Building example\n"
           cmake --build . --config Release


### PR DESCRIPTION
It was probably intended that the example would be built in the subfolder `build` (instead of in the source tree).
This PR changes the CI rules to use the (otherwise (almost) empty) `build` folder when building the example on all platforms.
