### PR TITLE
Correctly save and restore CMAKE_FIND_LIBRARY_SUFFIXES for GMP and MPFR modules

### DIFF
--- a/Example/cmake_modules/FindGMP.cmake
+++ b/Example/cmake_modules/FindGMP.cmake
@@ -44,6 +44,7 @@ find_library ( GMP_LIBRARY
 
 # static gmp library
 if ( NOT MSVC )
+    set ( save_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} )
     set ( CMAKE_FIND_LIBRARY_SUFFIXES
         ${CMAKE_STATIC_LIBRARY_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 endif ( )
@@ -55,7 +56,7 @@ find_library ( GMP_STATIC
 
 if ( NOT MSVC )
     # restore the CMAKE_FIND_LIBRARY_SUFFIXES variable
-    set ( CMAKE_FIND_LIBRARY_SUFFIXES ${save} )
+    set ( CMAKE_FIND_LIBRARY_SUFFIXES ${save_CMAKE_FIND_LIBRARY_SUFFIXES} )
 endif ( )
 
 # get version of the library from the filename

--- a/Example/cmake_modules/FindMPFR.cmake
+++ b/Example/cmake_modules/FindMPFR.cmake
@@ -44,6 +44,7 @@ find_library ( MPFR_LIBRARY
 
 # static mpfr library
 if ( NOT MSVC )
+    set ( save_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} )
     set ( CMAKE_FIND_LIBRARY_SUFFIXES
         ${CMAKE_STATIC_LIBRARY_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 endif ( )
@@ -59,7 +60,7 @@ endif ( )
 
 if ( NOT MSVC )
     # restore the CMAKE_FIND_LIBRARY_SUFFIXES variable
-    set ( CMAKE_FIND_LIBRARY_SUFFIXES ${save} )
+    set ( CMAKE_FIND_LIBRARY_SUFFIXES ${save_CMAKE_FIND_LIBRARY_SUFFIXES} )
 endif ( )
 
 # get version of the library from the filename

--- a/SPEX/cmake_modules/FindGMP.cmake
+++ b/SPEX/cmake_modules/FindGMP.cmake
@@ -44,6 +44,7 @@ find_library ( GMP_LIBRARY
 
 # static gmp library
 if ( NOT MSVC )
+    set ( save_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} )
     set ( CMAKE_FIND_LIBRARY_SUFFIXES
         ${CMAKE_STATIC_LIBRARY_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 endif ( )
@@ -55,7 +56,7 @@ find_library ( GMP_STATIC
 
 if ( NOT MSVC )
     # restore the CMAKE_FIND_LIBRARY_SUFFIXES variable
-    set ( CMAKE_FIND_LIBRARY_SUFFIXES ${save} )
+    set ( CMAKE_FIND_LIBRARY_SUFFIXES ${save_CMAKE_FIND_LIBRARY_SUFFIXES} )
 endif ( )
 
 # get version of the library from the filename

--- a/SPEX/cmake_modules/FindMPFR.cmake
+++ b/SPEX/cmake_modules/FindMPFR.cmake
@@ -44,6 +44,7 @@ find_library ( MPFR_LIBRARY
 
 # static mpfr library
 if ( NOT MSVC )
+    set ( save_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} )
     set ( CMAKE_FIND_LIBRARY_SUFFIXES
         ${CMAKE_STATIC_LIBRARY_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
 endif ( )
@@ -59,7 +60,7 @@ endif ( )
 
 if ( NOT MSVC )
     # restore the CMAKE_FIND_LIBRARY_SUFFIXES variable
-    set ( CMAKE_FIND_LIBRARY_SUFFIXES ${save} )
+    set ( CMAKE_FIND_LIBRARY_SUFFIXES ${save_CMAKE_FIND_LIBRARY_SUFFIXES} )
 endif ( )
 
 # get version of the library from the filename


### PR DESCRIPTION
Currently, `CMAKE_FIND_LIBRARY_SUFFIXES` is (re-)set to the value of `save` in the modules `FindGMP.cmake` and `FindMPFR.cmake`. But that variable might not have been set depending on where those functions are being called. This means that `CMAKE_FIND_LIBRARY_SUFFIXES` is effectively set to the empty string `""`.
This can cause issues for subsequent calls to `find_library`.

The intention was probably to change `CMAKE_FIND_LIBRARY_SUFFIXES` for the duration of the call to `find_library` in those modules and reset it to its original value afterwards.

This PR does that and also changes the name of the variable `save` to something that is less likely to collide with a variable from the context of the caller.

This would probably fix the failing CI in #267.
