### PR TITLE
CXSparse: Use correct type in declaration of functions in C++ code.

### DIFF
--- a/CXSparse/Config/cs.h.in
+++ b/CXSparse/Config/cs.h.in
@@ -27,16 +27,11 @@
 #define _CXS_H
 
 #ifdef __cplusplus
-#if @CXSPARSE_USE_COMPLEX@
-#include <complex>
-typedef std::complex<double> cs_complex_t ;
-#endif
 extern "C" {
-#else
+#endif
 #if @CXSPARSE_USE_COMPLEX@
 #include <complex.h>
 #define cs_complex_t double complex
-#endif
 #endif
 
 #define CS_VER @CXSPARSE_VERSION_MAJOR@  /* CXSparse Version */

--- a/CXSparse/Include/cs.h
+++ b/CXSparse/Include/cs.h
@@ -27,16 +27,11 @@
 #define _CXS_H
 
 #ifdef __cplusplus
-#if 1
-#include <complex>
-typedef std::complex<double> cs_complex_t ;
-#endif
 extern "C" {
-#else
+#endif
 #if 1
 #include <complex.h>
 #define cs_complex_t double complex
-#endif
 #endif
 
 #define CS_VER 4  /* CXSparse Version */


### PR DESCRIPTION
Use the same type in function declarations that was used in the function definition on compile time.

See also the following comment for why this is the "right thing" here:
https://github.com/DrTimothyAldenDavis/SuiteSparse/pull/294#issuecomment-1518140344