### PR TITLE
CXSparse: Fix compilation in C++ mode.

### DIFF
--- a/CXSparse/Config/cs.h.in
+++ b/CXSparse/Config/cs.h.in
@@ -26,12 +26,13 @@
 #ifndef _CXS_H
 #define _CXS_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 #if @CXSPARSE_USE_COMPLEX@
 #include <complex.h>
-#define cs_complex_t double complex
+#define cs_complex_t double _Complex
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 #define CS_VER @CXSPARSE_VERSION_MAJOR@  /* CXSparse Version */

--- a/CXSparse/Include/cs.h
+++ b/CXSparse/Include/cs.h
@@ -26,12 +26,13 @@
 #ifndef _CXS_H
 #define _CXS_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 #if 1
 #include <complex.h>
-#define cs_complex_t double complex
+#define cs_complex_t double _Complex
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 #define CS_VER 4  /* CXSparse Version */


### PR DESCRIPTION
This fixes a regression from #312 when the header is included in C++ code.
Two changes:
- Don't include header from the standard library in `extern "C"` block (mostly style).
- Use the standard `_Complex` specifier instead of the C-specific `complex`.

Sorry for not noticing earlier. (The example from #294 helped to catch that.)

