### PR TITLE
Add script to automatically build the library using Cmake VS generator.

### DIFF
--- a/Build_VS.ps1
+++ b/Build_VS.ps1
@@ -1,0 +1,26 @@
+$directories = @("SuiteSparse_config", "Mongoose", "AMD", "BTF", "CAMD", "CCOLAMD", "COLAMD", "CHOLMOD", "CSparse", "CXSparse", "KLU", "LDL", "UMFPACK", "SPQR")
+
+$blas_installation_path = "C:/OpenBLAS"
+$working_directory = (get-location).path
+$vs_generator = "Visual Studio 17 2022"
+$arch = "x64"
+$install_path = "./out/install"
+
+
+$cmake = Get-Command cmake -ErrorAction SilentlyContinue
+
+if ($null -eq $cmake) {
+    Write-Output "CMake is not installed. Exit."
+    exit
+} 
+
+
+foreach ($dir in $directories) {
+    Write-Host "Processing module: $dir"
+    
+    cmake -S "./$dir" -B "./$dir/out/build" -G $vs_generator -A $arch -DCMAKE_PREFIX_PATH="$blas_installation_path;$working_directory/out/install"
+    
+    cmake --build "./$dir/out/build" --target ALL_BUILD --config Release
+    
+    cmake --install "./$dir/out/build" --prefix "$install_path"
+}


### PR DESCRIPTION
Currently the instructions for building the library under Windows suggest to import each submodule as a Cmake project into Visual Studio. I tried that, but it is kind of tiresome and prone to errors because the order in which you build the submodules matters and you have point Cmake to each of the previous build / install directories. 

This is an attempt to streamline this process using a simple powershell script that calls cmake, build and install using the Visual Studio Generator in Cmake. The submodules are build each in their own build directory build they are collectively installed to a common install path.

If this idea is of interest. I could extend the script to match the functionality of the Makefile even further. 
