### PR TITLE
Use pkg-config to find MPFR and GMP if possible.

### DIFF
--- a/Example/cmake_modules/FindGMP.cmake
+++ b/Example/cmake_modules/FindGMP.cmake
@@ -30,71 +30,107 @@ if ( DEFINED ENV{CMAKE_PREFIX_PATH} )
     list ( PREPEND CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH} )
 endif ( )
 
-# include files for gmp
-find_path ( GMP_INCLUDE_DIR
-    NAMES gmp.h
-    PATH_SUFFIXES include Include
-)
-
-# dynamic gmp library (or possibly static if no GMP dynamic library exists)
-find_library ( GMP_LIBRARY
-    NAMES gmp
-    PATH_SUFFIXES lib build
-)
-
-# static gmp library
-if ( NOT MSVC )
-    set ( save_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} )
-    set ( CMAKE_FIND_LIBRARY_SUFFIXES
-        ${CMAKE_STATIC_LIBRARY_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
-endif ( )
-
-find_library ( GMP_STATIC
-    NAMES gmp
-    PATH_SUFFIXES lib build
-)
-
-if ( NOT MSVC )
-    # restore the CMAKE_FIND_LIBRARY_SUFFIXES variable
-    set ( CMAKE_FIND_LIBRARY_SUFFIXES ${save_CMAKE_FIND_LIBRARY_SUFFIXES} )
-endif ( )
-
-# get version of the library from the filename
-get_filename_component ( GMP_LIBRARY ${GMP_LIBRARY} REALPATH )
-
-# look in the middle for 6.2.1 (/spackstuff/gmp-6.2.1-morestuff/libgmp.10.4.1)
-string ( REGEX MATCH "gmp-[0-9]+.[0-9]+.[0-9]+" GMP_VERSION1 ${GMP_LIBRARY} )
-
-if ( GMP_VERSION1 STREQUAL "" )
-    # gmp has been found, but not as a spack library.  Hunt for the version
-    # number in gmp.h.  The gmp.h file includes the following lines:
-    #   #define __GNU_MP_VERSION            6
-    #   #define __GNU_MP_VERSION_MINOR      2
-    #   #define __GNU_MP_VERSION_PATCHLEVEL 0
-    file ( STRINGS ${GMP_INCLUDE_DIR}/gmp.h GMP_VER_MAJOR_STRING
-        REGEX "define __GNU_MP_VERSION " )
-    file ( STRINGS ${GMP_INCLUDE_DIR}/gmp.h GMP_VER_MINOR_STRING
-        REGEX "define __GNU_MP_VERSION_MINOR " )
-    file ( STRINGS ${GMP_INCLUDE_DIR}/gmp.h GMP_VER_PATCH_STRING
-        REGEX "define __GNU_MP_VERSION_PATCHLEVEL " )
-    message ( STATUS "major: ${GMP_VER_MAJOR_STRING}" )
-    message ( STATUS "minor: ${GMP_VER_MINOR_STRING}" )
-    message ( STATUS "patch: ${GMP_VER_PATCH_STRING}" )
-    if ( GMP_VER_MAJOR_STRING STREQUAL "")
-        # look at the end of the filename for the version number
-        string (
-            REGEX MATCH "[0-9]+.[0-9]+.[0-9]+"
-            GMP_VERSION ${GMP_LIBRARY} )
+# Try to get information from pkg-config file first.
+find_package ( PkgConfig )
+if ( PKG_CONFIG_FOUND )
+    set ( GMP_PC_OPTIONS "" )
+    if ( GMP_FIND_VERSION )
+        set ( GMP_PC_OPTIONS "gmp>=${GMP_FIND_VERSION}" )
     else ( )
-        # get the version number from inside the gmp.h file itself
-        string ( REGEX MATCH "[0-9]+" GMP_VER_MAJOR ${GMP_VER_MAJOR_STRING} )
-        string ( REGEX MATCH "[0-9]+" GMP_VER_MINOR ${GMP_VER_MINOR_STRING} )
-        string ( REGEX MATCH "[0-9]+" GMP_VER_PATCH ${GMP_VER_PATCH_STRING} )
-        set ( GMP_VERSION "${GMP_VER_MAJOR}.${GMP_VER_MINOR}.${GMP_VER_PATCH}")
+        set ( GMP_PC_OPTIONS "gmp" )
     endif ( )
-else ( )
-    # look at gmp-6.2.1 for the version number (spack library)
-    string ( REGEX MATCH "[0-9]+.[0-9]+.[0-9]" GMP_VERSION ${GMP_VERSION1} )
+    if ( GMP_FIND_REQUIRED )
+        # FIXME: Are there installations without pkg-config file?
+        # list ( APPEND GMP_PC_OPTIONS REQUIRED )
+    endif ( )
+    pkg_check_modules ( GMP ${GMP_PC_OPTIONS} )
+
+    if ( GMP_FOUND )
+        # assume first is the actual library
+        # FIXME: Would it be possible to return all libraries in that variable?
+        list ( GET GMP_LINK_LIBRARIES 0 GMP_LIBRARY )
+        set ( GMP_INCLUDE_DIR ${GMP_INCLUDEDIR} )
+    endif ( )
+    if (GMP_STATIC_FOUND)
+        # assume first is the actual library
+        list ( GET GMP_STATIC_LINK_LIBRARIES 0 GMP_STATIC )
+        set ( GMP_INCLUDE_DIR ${GMP_INCLUDEDIR} )
+    endif ( )
+endif ( )
+
+if ( NOT GMP_FOUND )
+    # Manual search if pkg-config couldn't be used.
+
+    # include files for gmp
+    find_path ( GMP_INCLUDE_DIR
+        NAMES gmp.h
+        PATH_SUFFIXES include Include
+    )
+
+    # dynamic gmp library (or possibly static if no GMP dynamic library exists)
+    find_library ( GMP_LIBRARY
+        NAMES gmp
+        PATH_SUFFIXES lib build
+    )
+
+    # static gmp library
+    if ( NOT MSVC )
+        set ( save_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} )
+        set ( CMAKE_FIND_LIBRARY_SUFFIXES
+            ${CMAKE_STATIC_LIBRARY_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
+    endif ( )
+
+    find_library ( GMP_STATIC
+        NAMES gmp
+        PATH_SUFFIXES lib build
+    )
+
+    if ( NOT MSVC )
+        # restore the CMAKE_FIND_LIBRARY_SUFFIXES variable
+        set ( CMAKE_FIND_LIBRARY_SUFFIXES ${save_CMAKE_FIND_LIBRARY_SUFFIXES} )
+    endif ( )
+
+    # get version of the library from the filename
+    get_filename_component ( GMP_LIBRARY ${GMP_LIBRARY} REALPATH )
+
+    # look in the middle for 6.2.1 (/spackstuff/gmp-6.2.1-morestuff/libgmp.10.4.1)
+    string ( REGEX MATCH "gmp-[0-9]+.[0-9]+.[0-9]+" GMP_VERSION1 ${GMP_LIBRARY} )
+
+    if ( GMP_VERSION1 STREQUAL "" )
+        # gmp has been found, but not as a spack library.  Hunt for the version
+        # number in gmp.h.  The gmp.h file includes the following lines:
+        #   #define __GNU_MP_VERSION            6
+        #   #define __GNU_MP_VERSION_MINOR      2
+        #   #define __GNU_MP_VERSION_PATCHLEVEL 0
+        file ( STRINGS ${GMP_INCLUDE_DIR}/gmp.h GMP_VER_MAJOR_STRING
+            REGEX "define __GNU_MP_VERSION " )
+        file ( STRINGS ${GMP_INCLUDE_DIR}/gmp.h GMP_VER_MINOR_STRING
+            REGEX "define __GNU_MP_VERSION_MINOR " )
+        file ( STRINGS ${GMP_INCLUDE_DIR}/gmp.h GMP_VER_PATCH_STRING
+            REGEX "define __GNU_MP_VERSION_PATCHLEVEL " )
+        message ( STATUS "major: ${GMP_VER_MAJOR_STRING}" )
+        message ( STATUS "minor: ${GMP_VER_MINOR_STRING}" )
+        message ( STATUS "patch: ${GMP_VER_PATCH_STRING}" )
+        if ( GMP_VER_MAJOR_STRING STREQUAL "")
+            # look at the end of the filename for the version number
+            string (
+                REGEX MATCH "[0-9]+.[0-9]+.[0-9]+"
+                GMP_VERSION ${GMP_LIBRARY} )
+        else ( )
+            # get the version number from inside the gmp.h file itself
+            string ( REGEX MATCH "[0-9]+" GMP_VER_MAJOR ${GMP_VER_MAJOR_STRING} )
+            string ( REGEX MATCH "[0-9]+" GMP_VER_MINOR ${GMP_VER_MINOR_STRING} )
+            string ( REGEX MATCH "[0-9]+" GMP_VER_PATCH ${GMP_VER_PATCH_STRING} )
+            set ( GMP_VERSION "${GMP_VER_MAJOR}.${GMP_VER_MINOR}.${GMP_VER_PATCH}")
+        endif ( )
+    else ( )
+        # look at gmp-6.2.1 for the version number (spack library)
+        string ( REGEX MATCH "[0-9]+.[0-9]+.[0-9]" GMP_VERSION ${GMP_VERSION1} )
+    endif ( )
+endif ( )
+
+if ( NOT GMP_STATIC )
+    set ( GMP_STATIC ${GMP_LIBRARY} )
 endif ( )
 
 set ( GMP_LIBRARIES ${GMP_LIBRARY} )

--- a/Example/cmake_modules/FindMPFR.cmake
+++ b/Example/cmake_modules/FindMPFR.cmake
@@ -30,64 +30,94 @@ if ( DEFINED ENV{CMAKE_PREFIX_PATH} )
     list ( PREPEND CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH} )
 endif ( )
 
-# include files for mpfr
-find_path ( MPFR_INCLUDE_DIR
-    NAMES mpfr.h
-    PATH_SUFFIXES include Include
-)
+# Try to get information from pkg-config file first.
+find_package ( PkgConfig )
+if ( PKG_CONFIG_FOUND )
+    set ( MPFR_PC_OPTIONS "" )
+    if ( MPFR_FIND_VERSION )
+        set ( MPFR_PC_OPTIONS "mpfr>=${MPFR_FIND_VERSION}" )
+    else ( )
+        set ( MPFR_PC_OPTIONS "mpfr" )
+    endif ( )
+    if ( MPFR_FIND_REQUIRED )
+        # FIXME: Are there installations without pkg-config file?
+        # list ( APPEND MPFR_PC_OPTIONS REQUIRED )
+    endif ( )
+    pkg_check_modules ( MPFR ${MPFR_PC_OPTIONS} )
 
-# dynamic mpfr library (or possibly static if no mpfr dynamic library exists)
-find_library ( MPFR_LIBRARY
-    NAMES mpfr
-    PATH_SUFFIXES lib build
-)
-
-# static mpfr library
-if ( NOT MSVC )
-    set ( save_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} )
-    set ( CMAKE_FIND_LIBRARY_SUFFIXES
-        ${CMAKE_STATIC_LIBRARY_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
+    if ( MPFR_FOUND )
+        # assume first is the actual library
+        list ( GET MPFR_LINK_LIBRARIES 0 MPFR_LIBRARY )
+        set ( MPFR_INCLUDE_DIR ${MPFR_INCLUDEDIR} )
+    endif ( )
+    if (MPFR_STATIC_FOUND)
+        # assume first is the actual library
+        list ( GET MPFR_STATIC_LINK_LIBRARIES 0 MPFR_STATIC )
+        set ( MPFR_INCLUDE_DIR ${MPFR_INCLUDEDIR} )
+    endif ( )
 endif ( )
 
-find_library ( MPFR_STATIC
-    NAMES mpfr
-    PATH_SUFFIXES lib build
-)
+if ( NOT MPFR_FOUND )
+    # Manual search if pkg-config couldn't be used.
+    # include files for mpfr
+    find_path ( MPFR_INCLUDE_DIR
+        NAMES mpfr.h
+        PATH_SUFFIXES include Include
+    )
+
+    # dynamic mpfr library (or possibly static if no mpfr dynamic library exists)
+    find_library ( MPFR_LIBRARY
+        NAMES mpfr
+        PATH_SUFFIXES lib build
+    )
+
+    # static mpfr library
+    if ( NOT MSVC )
+        set ( save_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} )
+        set ( CMAKE_FIND_LIBRARY_SUFFIXES
+            ${CMAKE_STATIC_LIBRARY_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
+    endif ( )
+
+    find_library ( MPFR_STATIC
+        NAMES mpfr
+        PATH_SUFFIXES lib build
+    )
+
+    if ( NOT MSVC )
+        # restore the CMAKE_FIND_LIBRARY_SUFFIXES variable
+        set ( CMAKE_FIND_LIBRARY_SUFFIXES ${save_CMAKE_FIND_LIBRARY_SUFFIXES} )
+    endif ( )
+
+    # get version of the library from the filename
+    get_filename_component ( MPFR_LIBRARY ${MPFR_LIBRARY} REALPATH )
+
+    # look in the middle for 4.1.0 (/spackstuff/mpfr-4.1.0-morestuff/libmpfr.10.4.1)
+    string ( REGEX MATCH "mpfr-[0-9]+.[0-9]+.[0-9]+" MPFR_VERSION1 ${MPFR_LIBRARY} )
+
+    if ( MPFR_VERSION1 STREQUAL "" )
+        # mpfr has been found, but not a spack library.  Hunt for the version
+        # number in mpfr.h.  The mpfr.h file includes the following line:
+        #       #define MPFR_VERSION_STRING "4.0.2"
+        file ( STRINGS ${MPFR_INCLUDE_DIR}/mpfr.h MPFR_VER_STRING
+            REGEX "MPFR_VERSION_STRING" )
+        message ( STATUS "major/minor/patch: ${MPFR_VER_STRING}" )
+        if ( MPFR_VER_STRING STREQUAL "")
+            # look at the end of the filename for the version number
+            string (
+                REGEX MATCH "[0-9]+.[0-9]+.[0-9]+"
+                MPFR_VERSION ${MPFR_LIBRARY} )
+        else ( )
+            # get the version number from inside the mpfr.h file itself
+            string ( REGEX MATCH "[0-9]+.[0-9]+.[0-9]+" MPFR_VERSION ${MPFR_VER_STRING} )
+        endif ( )
+    else ( )
+        # look at mpfr-4.1.0 for the version number (spack library)
+        string ( REGEX MATCH "[0-9]+.[0-9]+.[0-9]+" MPFR_VERSION ${MPFR_VERSION1} )
+    endif ( )
+endif ( )
 
 if ( NOT MPFR_STATIC )
     set ( MPFR_STATIC ${MPFR_LIBRARY} )
-endif ( )
-
-if ( NOT MSVC )
-    # restore the CMAKE_FIND_LIBRARY_SUFFIXES variable
-    set ( CMAKE_FIND_LIBRARY_SUFFIXES ${save_CMAKE_FIND_LIBRARY_SUFFIXES} )
-endif ( )
-
-# get version of the library from the filename
-get_filename_component ( MPFR_LIBRARY ${MPFR_LIBRARY} REALPATH )
-
-# look in the middle for 4.1.0 (/spackstuff/mpfr-4.1.0-morestuff/libmpfr.10.4.1)
-string ( REGEX MATCH "mpfr-[0-9]+.[0-9]+.[0-9]+" MPFR_VERSION1 ${MPFR_LIBRARY} )
-
-if ( MPFR_VERSION1 STREQUAL "" )
-    # mpfr has been found, but not a spack library.  Hunt for the version
-    # number in mpfr.h.  The mpfr.h file includes the following line:
-    #       #define MPFR_VERSION_STRING "4.0.2"
-    file ( STRINGS ${MPFR_INCLUDE_DIR}/mpfr.h MPFR_VER_STRING
-        REGEX "MPFR_VERSION_STRING" )
-    message ( STATUS "major/minor/patch: ${MPFR_VER_STRING}" )
-    if ( MPFR_VER_STRING STREQUAL "")
-        # look at the end of the filename for the version number
-        string (
-            REGEX MATCH "[0-9]+.[0-9]+.[0-9]+"
-            MPFR_VERSION ${MPFR_LIBRARY} )
-    else ( )
-        # get the version number from inside the mpfr.h file itself
-        string ( REGEX MATCH "[0-9]+.[0-9]+.[0-9]+" MPFR_VERSION ${MPFR_VER_STRING} )
-    endif ( )
-else ( )
-    # look at mpfr-4.1.0 for the version number (spack library)
-    string ( REGEX MATCH "[0-9]+.[0-9]+.[0-9]+" MPFR_VERSION ${MPFR_VERSION1} )
 endif ( )
 
 set ( MPFR_LIBRARIES ${MPFR_LIBRARY} )

--- a/SPEX/cmake_modules/FindGMP.cmake
+++ b/SPEX/cmake_modules/FindGMP.cmake
@@ -30,71 +30,107 @@ if ( DEFINED ENV{CMAKE_PREFIX_PATH} )
     list ( PREPEND CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH} )
 endif ( )
 
-# include files for gmp
-find_path ( GMP_INCLUDE_DIR
-    NAMES gmp.h
-    PATH_SUFFIXES include Include
-)
-
-# dynamic gmp library (or possibly static if no GMP dynamic library exists)
-find_library ( GMP_LIBRARY
-    NAMES gmp
-    PATH_SUFFIXES lib build
-)
-
-# static gmp library
-if ( NOT MSVC )
-    set ( save_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} )
-    set ( CMAKE_FIND_LIBRARY_SUFFIXES
-        ${CMAKE_STATIC_LIBRARY_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
-endif ( )
-
-find_library ( GMP_STATIC
-    NAMES gmp
-    PATH_SUFFIXES lib build
-)
-
-if ( NOT MSVC )
-    # restore the CMAKE_FIND_LIBRARY_SUFFIXES variable
-    set ( CMAKE_FIND_LIBRARY_SUFFIXES ${save_CMAKE_FIND_LIBRARY_SUFFIXES} )
-endif ( )
-
-# get version of the library from the filename
-get_filename_component ( GMP_LIBRARY ${GMP_LIBRARY} REALPATH )
-
-# look in the middle for 6.2.1 (/spackstuff/gmp-6.2.1-morestuff/libgmp.10.4.1)
-string ( REGEX MATCH "gmp-[0-9]+.[0-9]+.[0-9]+" GMP_VERSION1 ${GMP_LIBRARY} )
-
-if ( GMP_VERSION1 STREQUAL "" )
-    # gmp has been found, but not as a spack library.  Hunt for the version
-    # number in gmp.h.  The gmp.h file includes the following lines:
-    #   #define __GNU_MP_VERSION            6
-    #   #define __GNU_MP_VERSION_MINOR      2
-    #   #define __GNU_MP_VERSION_PATCHLEVEL 0
-    file ( STRINGS ${GMP_INCLUDE_DIR}/gmp.h GMP_VER_MAJOR_STRING
-        REGEX "define __GNU_MP_VERSION " )
-    file ( STRINGS ${GMP_INCLUDE_DIR}/gmp.h GMP_VER_MINOR_STRING
-        REGEX "define __GNU_MP_VERSION_MINOR " )
-    file ( STRINGS ${GMP_INCLUDE_DIR}/gmp.h GMP_VER_PATCH_STRING
-        REGEX "define __GNU_MP_VERSION_PATCHLEVEL " )
-    message ( STATUS "major: ${GMP_VER_MAJOR_STRING}" )
-    message ( STATUS "minor: ${GMP_VER_MINOR_STRING}" )
-    message ( STATUS "patch: ${GMP_VER_PATCH_STRING}" )
-    if ( GMP_VER_MAJOR_STRING STREQUAL "")
-        # look at the end of the filename for the version number
-        string (
-            REGEX MATCH "[0-9]+.[0-9]+.[0-9]+"
-            GMP_VERSION ${GMP_LIBRARY} )
+# Try to get information from pkg-config file first.
+find_package ( PkgConfig )
+if ( PKG_CONFIG_FOUND )
+    set ( GMP_PC_OPTIONS "" )
+    if ( GMP_FIND_VERSION )
+        set ( GMP_PC_OPTIONS "gmp>=${GMP_FIND_VERSION}" )
     else ( )
-        # get the version number from inside the gmp.h file itself
-        string ( REGEX MATCH "[0-9]+" GMP_VER_MAJOR ${GMP_VER_MAJOR_STRING} )
-        string ( REGEX MATCH "[0-9]+" GMP_VER_MINOR ${GMP_VER_MINOR_STRING} )
-        string ( REGEX MATCH "[0-9]+" GMP_VER_PATCH ${GMP_VER_PATCH_STRING} )
-        set ( GMP_VERSION "${GMP_VER_MAJOR}.${GMP_VER_MINOR}.${GMP_VER_PATCH}")
+        set ( GMP_PC_OPTIONS "gmp" )
     endif ( )
-else ( )
-    # look at gmp-6.2.1 for the version number (spack library)
-    string ( REGEX MATCH "[0-9]+.[0-9]+.[0-9]" GMP_VERSION ${GMP_VERSION1} )
+    if ( GMP_FIND_REQUIRED )
+        # FIXME: Are there installations without pkg-config file?
+        # list ( APPEND GMP_PC_OPTIONS REQUIRED )
+    endif ( )
+    pkg_check_modules ( GMP ${GMP_PC_OPTIONS} )
+
+    if ( GMP_FOUND )
+        # assume first is the actual library
+        # FIXME: Would it be possible to return all libraries in that variable?
+        list ( GET GMP_LINK_LIBRARIES 0 GMP_LIBRARY )
+        set ( GMP_INCLUDE_DIR ${GMP_INCLUDEDIR} )
+    endif ( )
+    if (GMP_STATIC_FOUND)
+        # assume first is the actual library
+        list ( GET GMP_STATIC_LINK_LIBRARIES 0 GMP_STATIC )
+        set ( GMP_INCLUDE_DIR ${GMP_INCLUDEDIR} )
+    endif ( )
+endif ( )
+
+if ( NOT GMP_FOUND )
+    # Manual search if pkg-config couldn't be used.
+
+    # include files for gmp
+    find_path ( GMP_INCLUDE_DIR
+        NAMES gmp.h
+        PATH_SUFFIXES include Include
+    )
+
+    # dynamic gmp library (or possibly static if no GMP dynamic library exists)
+    find_library ( GMP_LIBRARY
+        NAMES gmp
+        PATH_SUFFIXES lib build
+    )
+
+    # static gmp library
+    if ( NOT MSVC )
+        set ( save_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} )
+        set ( CMAKE_FIND_LIBRARY_SUFFIXES
+            ${CMAKE_STATIC_LIBRARY_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
+    endif ( )
+
+    find_library ( GMP_STATIC
+        NAMES gmp
+        PATH_SUFFIXES lib build
+    )
+
+    if ( NOT MSVC )
+        # restore the CMAKE_FIND_LIBRARY_SUFFIXES variable
+        set ( CMAKE_FIND_LIBRARY_SUFFIXES ${save_CMAKE_FIND_LIBRARY_SUFFIXES} )
+    endif ( )
+
+    # get version of the library from the filename
+    get_filename_component ( GMP_LIBRARY ${GMP_LIBRARY} REALPATH )
+
+    # look in the middle for 6.2.1 (/spackstuff/gmp-6.2.1-morestuff/libgmp.10.4.1)
+    string ( REGEX MATCH "gmp-[0-9]+.[0-9]+.[0-9]+" GMP_VERSION1 ${GMP_LIBRARY} )
+
+    if ( GMP_VERSION1 STREQUAL "" )
+        # gmp has been found, but not as a spack library.  Hunt for the version
+        # number in gmp.h.  The gmp.h file includes the following lines:
+        #   #define __GNU_MP_VERSION            6
+        #   #define __GNU_MP_VERSION_MINOR      2
+        #   #define __GNU_MP_VERSION_PATCHLEVEL 0
+        file ( STRINGS ${GMP_INCLUDE_DIR}/gmp.h GMP_VER_MAJOR_STRING
+            REGEX "define __GNU_MP_VERSION " )
+        file ( STRINGS ${GMP_INCLUDE_DIR}/gmp.h GMP_VER_MINOR_STRING
+            REGEX "define __GNU_MP_VERSION_MINOR " )
+        file ( STRINGS ${GMP_INCLUDE_DIR}/gmp.h GMP_VER_PATCH_STRING
+            REGEX "define __GNU_MP_VERSION_PATCHLEVEL " )
+        message ( STATUS "major: ${GMP_VER_MAJOR_STRING}" )
+        message ( STATUS "minor: ${GMP_VER_MINOR_STRING}" )
+        message ( STATUS "patch: ${GMP_VER_PATCH_STRING}" )
+        if ( GMP_VER_MAJOR_STRING STREQUAL "")
+            # look at the end of the filename for the version number
+            string (
+                REGEX MATCH "[0-9]+.[0-9]+.[0-9]+"
+                GMP_VERSION ${GMP_LIBRARY} )
+        else ( )
+            # get the version number from inside the gmp.h file itself
+            string ( REGEX MATCH "[0-9]+" GMP_VER_MAJOR ${GMP_VER_MAJOR_STRING} )
+            string ( REGEX MATCH "[0-9]+" GMP_VER_MINOR ${GMP_VER_MINOR_STRING} )
+            string ( REGEX MATCH "[0-9]+" GMP_VER_PATCH ${GMP_VER_PATCH_STRING} )
+            set ( GMP_VERSION "${GMP_VER_MAJOR}.${GMP_VER_MINOR}.${GMP_VER_PATCH}")
+        endif ( )
+    else ( )
+        # look at gmp-6.2.1 for the version number (spack library)
+        string ( REGEX MATCH "[0-9]+.[0-9]+.[0-9]" GMP_VERSION ${GMP_VERSION1} )
+    endif ( )
+endif ( )
+
+if ( NOT GMP_STATIC )
+    set ( GMP_STATIC ${GMP_LIBRARY} )
 endif ( )
 
 set ( GMP_LIBRARIES ${GMP_LIBRARY} )

--- a/SPEX/cmake_modules/FindMPFR.cmake
+++ b/SPEX/cmake_modules/FindMPFR.cmake
@@ -30,64 +30,94 @@ if ( DEFINED ENV{CMAKE_PREFIX_PATH} )
     list ( PREPEND CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH} )
 endif ( )
 
-# include files for mpfr
-find_path ( MPFR_INCLUDE_DIR
-    NAMES mpfr.h
-    PATH_SUFFIXES include Include
-)
+# Try to get information from pkg-config file first.
+find_package ( PkgConfig )
+if ( PKG_CONFIG_FOUND )
+    set ( MPFR_PC_OPTIONS "" )
+    if ( MPFR_FIND_VERSION )
+        set ( MPFR_PC_OPTIONS "mpfr>=${MPFR_FIND_VERSION}" )
+    else ( )
+        set ( MPFR_PC_OPTIONS "mpfr" )
+    endif ( )
+    if ( MPFR_FIND_REQUIRED )
+        # FIXME: Are there installations without pkg-config file?
+        # list ( APPEND MPFR_PC_OPTIONS REQUIRED )
+    endif ( )
+    pkg_check_modules ( MPFR ${MPFR_PC_OPTIONS} )
 
-# dynamic mpfr library (or possibly static if no mpfr dynamic library exists)
-find_library ( MPFR_LIBRARY
-    NAMES mpfr
-    PATH_SUFFIXES lib build
-)
-
-# static mpfr library
-if ( NOT MSVC )
-    set ( save_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} )
-    set ( CMAKE_FIND_LIBRARY_SUFFIXES
-        ${CMAKE_STATIC_LIBRARY_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
+    if ( MPFR_FOUND )
+        # assume first is the actual library
+        list ( GET MPFR_LINK_LIBRARIES 0 MPFR_LIBRARY )
+        set ( MPFR_INCLUDE_DIR ${MPFR_INCLUDEDIR} )
+    endif ( )
+    if (MPFR_STATIC_FOUND)
+        # assume first is the actual library
+        list ( GET MPFR_STATIC_LINK_LIBRARIES 0 MPFR_STATIC )
+        set ( MPFR_INCLUDE_DIR ${MPFR_INCLUDEDIR} )
+    endif ( )
 endif ( )
 
-find_library ( MPFR_STATIC
-    NAMES mpfr
-    PATH_SUFFIXES lib build
-)
+if ( NOT MPFR_FOUND )
+    # Manual search if pkg-config couldn't be used.
+    # include files for mpfr
+    find_path ( MPFR_INCLUDE_DIR
+        NAMES mpfr.h
+        PATH_SUFFIXES include Include
+    )
+
+    # dynamic mpfr library (or possibly static if no mpfr dynamic library exists)
+    find_library ( MPFR_LIBRARY
+        NAMES mpfr
+        PATH_SUFFIXES lib build
+    )
+
+    # static mpfr library
+    if ( NOT MSVC )
+        set ( save_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} )
+        set ( CMAKE_FIND_LIBRARY_SUFFIXES
+            ${CMAKE_STATIC_LIBRARY_SUFFIX} ${CMAKE_FIND_LIBRARY_SUFFIXES} )
+    endif ( )
+
+    find_library ( MPFR_STATIC
+        NAMES mpfr
+        PATH_SUFFIXES lib build
+    )
+
+    if ( NOT MSVC )
+        # restore the CMAKE_FIND_LIBRARY_SUFFIXES variable
+        set ( CMAKE_FIND_LIBRARY_SUFFIXES ${save_CMAKE_FIND_LIBRARY_SUFFIXES} )
+    endif ( )
+
+    # get version of the library from the filename
+    get_filename_component ( MPFR_LIBRARY ${MPFR_LIBRARY} REALPATH )
+
+    # look in the middle for 4.1.0 (/spackstuff/mpfr-4.1.0-morestuff/libmpfr.10.4.1)
+    string ( REGEX MATCH "mpfr-[0-9]+.[0-9]+.[0-9]+" MPFR_VERSION1 ${MPFR_LIBRARY} )
+
+    if ( MPFR_VERSION1 STREQUAL "" )
+        # mpfr has been found, but not a spack library.  Hunt for the version
+        # number in mpfr.h.  The mpfr.h file includes the following line:
+        #       #define MPFR_VERSION_STRING "4.0.2"
+        file ( STRINGS ${MPFR_INCLUDE_DIR}/mpfr.h MPFR_VER_STRING
+            REGEX "MPFR_VERSION_STRING" )
+        message ( STATUS "major/minor/patch: ${MPFR_VER_STRING}" )
+        if ( MPFR_VER_STRING STREQUAL "")
+            # look at the end of the filename for the version number
+            string (
+                REGEX MATCH "[0-9]+.[0-9]+.[0-9]+"
+                MPFR_VERSION ${MPFR_LIBRARY} )
+        else ( )
+            # get the version number from inside the mpfr.h file itself
+            string ( REGEX MATCH "[0-9]+.[0-9]+.[0-9]+" MPFR_VERSION ${MPFR_VER_STRING} )
+        endif ( )
+    else ( )
+        # look at mpfr-4.1.0 for the version number (spack library)
+        string ( REGEX MATCH "[0-9]+.[0-9]+.[0-9]+" MPFR_VERSION ${MPFR_VERSION1} )
+    endif ( )
+endif ( )
 
 if ( NOT MPFR_STATIC )
     set ( MPFR_STATIC ${MPFR_LIBRARY} )
-endif ( )
-
-if ( NOT MSVC )
-    # restore the CMAKE_FIND_LIBRARY_SUFFIXES variable
-    set ( CMAKE_FIND_LIBRARY_SUFFIXES ${save_CMAKE_FIND_LIBRARY_SUFFIXES} )
-endif ( )
-
-# get version of the library from the filename
-get_filename_component ( MPFR_LIBRARY ${MPFR_LIBRARY} REALPATH )
-
-# look in the middle for 4.1.0 (/spackstuff/mpfr-4.1.0-morestuff/libmpfr.10.4.1)
-string ( REGEX MATCH "mpfr-[0-9]+.[0-9]+.[0-9]+" MPFR_VERSION1 ${MPFR_LIBRARY} )
-
-if ( MPFR_VERSION1 STREQUAL "" )
-    # mpfr has been found, but not a spack library.  Hunt for the version
-    # number in mpfr.h.  The mpfr.h file includes the following line:
-    #       #define MPFR_VERSION_STRING "4.0.2"
-    file ( STRINGS ${MPFR_INCLUDE_DIR}/mpfr.h MPFR_VER_STRING
-        REGEX "MPFR_VERSION_STRING" )
-    message ( STATUS "major/minor/patch: ${MPFR_VER_STRING}" )
-    if ( MPFR_VER_STRING STREQUAL "")
-        # look at the end of the filename for the version number
-        string (
-            REGEX MATCH "[0-9]+.[0-9]+.[0-9]+"
-            MPFR_VERSION ${MPFR_LIBRARY} )
-    else ( )
-        # get the version number from inside the mpfr.h file itself
-        string ( REGEX MATCH "[0-9]+.[0-9]+.[0-9]+" MPFR_VERSION ${MPFR_VER_STRING} )
-    endif ( )
-else ( )
-    # look at mpfr-4.1.0 for the version number (spack library)
-    string ( REGEX MATCH "[0-9]+.[0-9]+.[0-9]+" MPFR_VERSION ${MPFR_VERSION1} )
 endif ( )
 
 set ( MPFR_LIBRARIES ${MPFR_LIBRARY} )


### PR DESCRIPTION
Prompted by the issue described in #320, use pkg-config to locate the MPFR and GMP libraries and headers. Only fall back to a manual search if using pkg-config fails.

This likely fixes #320 where the user set `PKG_CONFIG_PATH` but that didn't make a difference.
