### PR TITLE
xxhash: workaround for broken MS Visual Studio cl compiler

### DIFF
--- a/GraphBLAS/xxHash/README.txt
+++ b/GraphBLAS/xxHash/README.txt
@@ -5,7 +5,7 @@ SPDX-License-Identifier: BSD-2-clause
 
 Notes by Tim Davis, on inclusion of xxHash into SuiteSparse:GraphBLAS:
 
-This directory contains a minimal copy of xxHash (Jan 30, 2023), from
+This directory contains a minimal copy of xxHash (June 16, 2023), from
 https://github.com/Cyan4973/xxHash.git by Yann Collet.
 See ./LICENSE and ./README_xxhash.md for more details.
 
@@ -14,7 +14,7 @@ Files in this folder:
     LICENSE         BSD 2-clause, Copyright (c) Copyright (c) 2012-present,
                     Yann Collet
     xxhash.h        unmodified from the xxHash library, dev branch as of
-                    Jan 30, 2023
+                    June 16, 2023
     README_xxhash.md  xxhash/README.md
     README.txt      this file
 

--- a/GraphBLAS/xxHash/README_xxhash.md
+++ b/GraphBLAS/xxHash/README_xxhash.md
@@ -153,6 +153,7 @@ The following macros can be set at compilation time to modify libxxhash's behavi
 
 When compiling the Command Line Interface `xxhsum` using `make`, the following environment variables can also be set :
 - `DISPATCH=1` : use `xxh_x86dispatch.c`, to automatically select between `scalar`, `sse2`, `avx2` or `avx512` instruction set at runtime, depending on local host. This option is only valid for `x86`/`x64` systems.
+- `XXH_1ST_SPEED_TARGET` : select an initial speed target, expressed in MB/s, for the first speed test in benchmark mode. Benchmark will adjust the target at subsequent iterations, but the first test is made "blindly" by targeting this speed. Currently conservatively set to 10 MB/s, to support very slow (emulated) platforms.
 
 ### Building xxHash - Using vcpkg
 

--- a/GraphBLAS/xxHash/xxhash.h
+++ b/GraphBLAS/xxHash/xxhash.h
@@ -1180,6 +1180,15 @@ struct XXH64_state_s {
 
 #ifndef XXH_NO_XXH3
 
+//--------------------------------------------------------------------------
+#if defined ( _MSC_VER ) /* GraphBLAS modification */
+    // MS Visual Studio is badly broken.  It states that it complies with
+    // ANSI C11, but it does not provide the required stdalign.h.
+    #define XXH_ALIGN(n)      __declspec(align(n))
+#else
+// unmodified rules from the original xxhash.h:
+//--------------------------------------------------------------------------
+
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) /* >= C11 */
 #  include <stdalign.h>
 #  define XXH_ALIGN(n)      alignas(n)
@@ -1193,6 +1202,10 @@ struct XXH64_state_s {
 #else
 #  define XXH_ALIGN(n)   /* disabled */
 #endif
+
+//--------------------------------------------------------------------------
+#endif  /* GraphBLAS modification */
+//--------------------------------------------------------------------------
 
 /* Old GCC versions only accept the attribute after the type in structures. */
 #if !(defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L))   /* C11+ */ \


### PR DESCRIPTION
Upgrade to latest version of xxhash (June 16, 2023, on the dev branch of xxhash).
Workaround for broken MS Visual Studio cl compiler.
