### PR TITLE
CXSparse: Avoid including C header in C++ code

### DIFF
--- a/CXSparse/Config/cs.h.in
+++ b/CXSparse/Config/cs.h.in
@@ -27,12 +27,12 @@
 #define _CXS_H
 
 #if @CXSPARSE_USE_COMPLEX@
-#include <complex.h>
-#define cs_complex_t double _Complex
-#endif
-
-#ifdef __cplusplus
-extern "C" {
+#  ifdef __cplusplus
+#    include <complex>
+#  else
+#    include <complex.h>
+#  endif
+#  define cs_complex_t double _Complex
 #endif
 
 #define CS_VER @CXSPARSE_VERSION_MAJOR@  /* CXSparse Version */
@@ -46,6 +46,10 @@ extern "C" {
 #define cs_long_t       int64_t
 #define cs_long_t_id    "%" PRId64
 #define cs_long_t_max   INT64_MAX
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* -------------------------------------------------------------------------- */
 /* double/int32_t version of CXSparse */

--- a/CXSparse/Include/cs.h
+++ b/CXSparse/Include/cs.h
@@ -27,12 +27,12 @@
 #define _CXS_H
 
 #if 1
-#include <complex.h>
-#define cs_complex_t double _Complex
-#endif
-
-#ifdef __cplusplus
-extern "C" {
+#  ifdef __cplusplus
+#    include <complex>
+#  else
+#    include <complex.h>
+#  endif
+#  define cs_complex_t double _Complex
 #endif
 
 #define CS_VER 4  /* CXSparse Version */
@@ -46,6 +46,10 @@ extern "C" {
 #define cs_long_t       int64_t
 #define cs_long_t_id    "%" PRId64
 #define cs_long_t_max   INT64_MAX
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* -------------------------------------------------------------------------- */
 /* double/int32_t version of CXSparse */


### PR DESCRIPTION
According to [1]: "Source files that are not intended to also be valid ISO C should not use any of the C headers."

It is still correct to define `cs_complex_t` as `double _Complex` in C and C++ code. But the C standard header `complex.h` shouldn't be included in a header that can be used in C++ code. That is not a requirement. But it is a recommendation.
I wasn't aware of that recommendation for PR #312.

Additionally, avoid inclusion of headers inside an `extern "C"` block.

[1]: https://en.cppreference.com/w/cpp/standard_library
