### PR TITLE
SPQR: Cleanup for templates.

### DIFF
--- a/SPQR/Include/SuiteSparseQR.hpp
+++ b/SPQR/Include/SuiteSparseQR.hpp
@@ -659,43 +659,31 @@ template <typename Entry, typename Int = int64_t> int SuiteSparseQR_numeric
     SuiteSparseQR_factorization <Entry, Int> *QR,
     cholmod_common *cc      // workspace and parameters
 ) ;
+
+// forward declare template instantiations
+
 extern template int SuiteSparseQR_numeric <double, int32_t>
 (
-    // inputs:
-    double tol,             // treat columns with 2-norm <= tol as zero
-    cholmod_sparse *A,      // sparse matrix to factorize
-    // input/output
-    SuiteSparseQR_factorization <double, int32_t> *QR,
-    cholmod_common *cc      // workspace and parameters
+    double tol, cholmod_sparse *A,
+    SuiteSparseQR_factorization <double, int32_t> *QR, cholmod_common *cc
 ) ;
 
 extern template int SuiteSparseQR_numeric <Complex, int32_t>
 (
-    // inputs:
-    double tol,             // treat columns with 2-norm <= tol as zero
-    cholmod_sparse *A,      // sparse matrix to factorize
-    // input/output
-    SuiteSparseQR_factorization <Complex, int32_t> *QR,
-    cholmod_common *cc      // workspace and parameters
+    double tol, cholmod_sparse *A,
+    SuiteSparseQR_factorization <Complex, int32_t> *QR, cholmod_common *cc
 ) ;
+
 extern template int SuiteSparseQR_numeric <double, int64_t>
 (
-    // inputs:
-    double tol,             // treat columns with 2-norm <= tol as zero
-    cholmod_sparse *A,      // sparse matrix to factorize
-    // input/output
-    SuiteSparseQR_factorization <double, int64_t> *QR,
-    cholmod_common *cc      // workspace and parameters
+    double tol, cholmod_sparse *A,
+    SuiteSparseQR_factorization <double, int64_t> *QR, cholmod_common *cc
 ) ;
 
 extern template int SuiteSparseQR_numeric <Complex, int64_t>
 (
-    // inputs:
-    double tol,             // treat columns with 2-norm <= tol as zero
-    cholmod_sparse *A,      // sparse matrix to factorize
-    // input/output
-    SuiteSparseQR_factorization <Complex, int64_t> *QR,
-    cholmod_common *cc      // workspace and parameters
+    double tol, cholmod_sparse *A,
+    SuiteSparseQR_factorization <Complex, int64_t> *QR, cholmod_common *cc
 ) ;
 #endif
 

--- a/SPQR/Include/spqr_cholmod_wrappers.hpp
+++ b/SPQR/Include/spqr_cholmod_wrappers.hpp
@@ -1,47 +1,23 @@
 #include "spqr.hpp"
 
+// wrappers for CHOLMOD functions
+
+// template declarations
+
 template <typename Int> void *spqr_malloc (size_t n, size_t size, cholmod_common *Common) ;
-template <> void *spqr_malloc <int32_t> (size_t n, size_t size, cholmod_common *Common) ;
-template <> void *spqr_malloc <int64_t> (size_t n, size_t size, cholmod_common *Common) ;
 
 template <typename Int> void *spqr_calloc (size_t n, size_t size, cholmod_common *Common) ;
-template <> void *spqr_calloc <int32_t> (size_t n, size_t size, cholmod_common *Common) ;
-template <> void *spqr_calloc <int64_t> (size_t n, size_t size, cholmod_common *Common) ;
 
 template <typename Int> void *spqr_free (size_t n, size_t size, void *p, cholmod_common *Common) ;
-template <> void *spqr_free <int32_t> (size_t n, size_t size, void *p, cholmod_common *Common) ;
-template <> void *spqr_free <int64_t> (size_t n, size_t size, void *p, cholmod_common *Common) ;
 
 template <typename Int> void *spqr_realloc	/* returns pointer to reallocated block */
 (
     /* ---- input ---- */
-    size_t nnew,	/* requested # of items in reallocated block */
-    size_t size,	/* size of each item */
+    size_t nnew,  /* requested # of items in reallocated block */
+    size_t size,  /* size of each item */
     /* ---- in/out --- */
-    void *p,		/* block of memory to realloc */
-    size_t *n,		/* current size on input, nnew on output if successful*/
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> void *spqr_realloc <int32_t>	/* returns pointer to reallocated block */
-(
-    /* ---- input ---- */
-    size_t nnew,	/* requested # of items in reallocated block */
-    size_t size,	/* size of each item */
-    /* ---- in/out --- */
-    void *p,		/* block of memory to realloc */
-    size_t *n,		/* current size on input, nnew on output if successful*/
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> void *spqr_realloc <int64_t>	/* returns pointer to reallocated block */
-(
-    /* ---- input ---- */
-    size_t nnew,	/* requested # of items in reallocated block */
-    size_t size,	/* size of each item */
-    /* ---- in/out --- */
-    void *p,		/* block of memory to realloc */
-    size_t *n,		/* current size on input, nnew on output if successful*/
+    void *p,      /* block of memory to realloc */
+    size_t *n,    /* current size on input, nnew on output if successful*/
     /* --------------- */
     cholmod_common *Common
 ) ;
@@ -49,39 +25,13 @@ template <> void *spqr_realloc <int64_t>	/* returns pointer to reallocated block
 template <typename Int> cholmod_sparse *spqr_allocate_sparse
 (
     /* ---- input ---- */
-    size_t nrow,	/* # of rows of A */
-    size_t ncol,	/* # of columns of A */
-    size_t nzmax,	/* max # of nonzeros of A */
-    int sorted,		/* TRUE if columns of A sorted, FALSE otherwise */
-    int packed,		/* TRUE if A will be packed, FALSE otherwise */
-    int stype,		/* stype of A */
-    int xtype,		/* CHOLMOD_PATTERN, _REAL, _COMPLEX, or _ZOMPLEX */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> cholmod_sparse *spqr_allocate_sparse <int32_t>
-(
-    /* ---- input ---- */
-    size_t nrow,	/* # of rows of A */
-    size_t ncol,	/* # of columns of A */
-    size_t nzmax,	/* max # of nonzeros of A */
-    int sorted,		/* TRUE if columns of A sorted, FALSE otherwise */
-    int packed,		/* TRUE if A will be packed, FALSE otherwise */
-    int stype,		/* stype of A */
-    int xtype,		/* CHOLMOD_PATTERN, _REAL, _COMPLEX, or _ZOMPLEX */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> cholmod_sparse *spqr_allocate_sparse <int64_t>
-(
-    /* ---- input ---- */
-    size_t nrow,	/* # of rows of A */
-    size_t ncol,	/* # of columns of A */
-    size_t nzmax,	/* max # of nonzeros of A */
-    int sorted,		/* TRUE if columns of A sorted, FALSE otherwise */
-    int packed,		/* TRUE if A will be packed, FALSE otherwise */
-    int stype,		/* stype of A */
-    int xtype,		/* CHOLMOD_PATTERN, _REAL, _COMPLEX, or _ZOMPLEX */
+    size_t nrow,  /* # of rows of A */
+    size_t ncol,  /* # of columns of A */
+    size_t nzmax, /* max # of nonzeros of A */
+    int sorted,   /* TRUE if columns of A sorted, FALSE otherwise */
+    int packed,   /* TRUE if A will be packed, FALSE otherwise */
+    int stype,    /* stype of A */
+    int xtype,    /* CHOLMOD_PATTERN, _REAL, _COMPLEX, or _ZOMPLEX */
     /* --------------- */
     cholmod_common *Common
 ) ;
@@ -93,45 +43,13 @@ template <typename Int> int spqr_free_sparse
     /* --------------- */
     cholmod_common *Common
 ) ;
-template <> int spqr_free_sparse <int32_t>
-(
-    /* ---- in/out --- */
-    cholmod_sparse **A,	/* matrix to deallocate, NULL on output */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> int spqr_free_sparse <int64_t>
-(
-    /* ---- in/out --- */
-    cholmod_sparse **A,	/* matrix to deallocate, NULL on output */
-    /* --------------- */
-    cholmod_common *Common
-) ;
 
 template <typename Int> int spqr_reallocate_sparse
 (
     /* ---- input ---- */
-    size_t nznew,	/* new # of entries in A */
+    size_t nznew,       /* new # of entries in A */
     /* ---- in/out --- */
-    cholmod_sparse *A,	/* matrix to reallocate */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> int spqr_reallocate_sparse <int32_t>
-(
-    /* ---- input ---- */
-    size_t nznew,	/* new # of entries in A */
-    /* ---- in/out --- */
-    cholmod_sparse *A,	/* matrix to reallocate */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> int spqr_reallocate_sparse <int64_t>
-(
-    /* ---- input ---- */
-    size_t nznew,	/* new # of entries in A */
-    /* ---- in/out --- */
-    cholmod_sparse *A,	/* matrix to reallocate */
+    cholmod_sparse *A,  /* matrix to reallocate */
     /* --------------- */
     cholmod_common *Common
 ) ;
@@ -139,31 +57,10 @@ template <> int spqr_reallocate_sparse <int64_t>
 template <typename Int> cholmod_dense *spqr_allocate_dense
 (
     /* ---- input ---- */
-    size_t nrow,	/* # of rows of matrix */
-    size_t ncol,	/* # of columns of matrix */
-    size_t d,		/* leading dimension */
-    int xtype,		/* CHOLMOD_REAL, _COMPLEX, or _ZOMPLEX */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> cholmod_dense *spqr_allocate_dense <int32_t>
-(
-    /* ---- input ---- */
-    size_t nrow,	/* # of rows of matrix */
-    size_t ncol,	/* # of columns of matrix */
-    size_t d,		/* leading dimension */
-    int xtype,		/* CHOLMOD_REAL, _COMPLEX, or _ZOMPLEX */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-
-template <> cholmod_dense *spqr_allocate_dense <int64_t>
-(
-    /* ---- input ---- */
-    size_t nrow,	/* # of rows of matrix */
-    size_t ncol,	/* # of columns of matrix */
-    size_t d,		/* leading dimension */
-    int xtype,		/* CHOLMOD_REAL, _COMPLEX, or _ZOMPLEX */
+    size_t nrow,  /* # of rows of matrix */
+    size_t ncol,  /* # of columns of matrix */
+    size_t d,     /* leading dimension */
+    int xtype,    /* CHOLMOD_REAL, _COMPLEX, or _ZOMPLEX */
     /* --------------- */
     cholmod_common *Common
 ) ;
@@ -171,21 +68,7 @@ template <> cholmod_dense *spqr_allocate_dense <int64_t>
 template <typename Int> int spqr_free_dense
 (
     /* ---- in/out --- */
-    cholmod_dense **X,	/* dense matrix to deallocate, NULL on output */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> int spqr_free_dense <int32_t>
-(
-    /* ---- in/out --- */
-    cholmod_dense **X,	/* dense matrix to deallocate, NULL on output */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> int spqr_free_dense <int64_t>
-(
-    /* ---- in/out --- */
-    cholmod_dense **X,	/* dense matrix to deallocate, NULL on output */
+    cholmod_dense **X,  /* dense matrix to deallocate, NULL on output */
     /* --------------- */
     cholmod_common *Common
 ) ;
@@ -193,21 +76,7 @@ template <> int spqr_free_dense <int64_t>
 template <typename Int> cholmod_factor *spqr_allocate_factor
 (
     /* ---- input ---- */
-    size_t n,		/* L is n-by-n */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> cholmod_factor *spqr_allocate_factor <int32_t>
-(
-    /* ---- input ---- */
-    size_t n,		/* L is n-by-n */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> cholmod_factor *spqr_allocate_factor <int64_t>
-(
-    /* ---- input ---- */
-    size_t n,		/* L is n-by-n */
+    size_t n,   /* L is n-by-n */
     /* --------------- */
     cholmod_common *Common
 ) ;
@@ -215,21 +84,7 @@ template <> cholmod_factor *spqr_allocate_factor <int64_t>
 template <typename Int> int spqr_free_factor
 (
     /* ---- in/out --- */
-    cholmod_factor **L,	/* factor to free, NULL on output */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> int spqr_free_factor <int32_t>
-(
-    /* ---- in/out --- */
-    cholmod_factor **L,	/* factor to free, NULL on output */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> int spqr_free_factor <int64_t>
-(
-    /* ---- in/out --- */
-    cholmod_factor **L,	/* factor to free, NULL on output */
+    cholmod_factor **L, /* factor to free, NULL on output */
     /* --------------- */
     cholmod_common *Common
 ) ;
@@ -237,27 +92,9 @@ template <> int spqr_free_factor <int64_t>
 template <typename Int> int spqr_allocate_work
 (
     /* ---- input ---- */
-    size_t nrow,	/* size: Common->Flag (nrow), Common->Head (nrow+1) */
-    size_t iworksize,	/* size of Common->Iwork */
-    size_t xworksize,	/* size of Common->Xwork */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> int spqr_allocate_work <int32_t>
-(
-    /* ---- input ---- */
-    size_t nrow,	/* size: Common->Flag (nrow), Common->Head (nrow+1) */
-    size_t iworksize,	/* size of Common->Iwork */
-    size_t xworksize,	/* size of Common->Xwork */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> int spqr_allocate_work <int64_t>
-(
-    /* ---- input ---- */
-    size_t nrow,	/* size: Common->Flag (nrow), Common->Head (nrow+1) */
-    size_t iworksize,	/* size of Common->Iwork */
-    size_t xworksize,	/* size of Common->Xwork */
+    size_t nrow,      /* size: Common->Flag (nrow), Common->Head (nrow+1) */
+    size_t iworksize, /* size of Common->Iwork */
+    size_t xworksize, /* size of Common->Xwork */
     /* --------------- */
     cholmod_common *Common
 ) ;
@@ -266,38 +103,13 @@ template <typename Int> int spqr_amd
 (
     cholmod_sparse *A, Int *fset, size_t fsize, Int *Perm, cholmod_common *Common
 ) ;
-template <> int spqr_amd <int64_t> 
-(
-    cholmod_sparse *A, int64_t *fset, size_t fsize, int64_t *Perm, cholmod_common *Common
-) ;
-template <> int spqr_amd <int32_t> 
-(
-    cholmod_sparse *A, int32_t *fset, size_t fsize, int32_t *Perm, cholmod_common *Common
-) ;
 
 template <typename Int> int spqr_metis 
 (
     cholmod_sparse *A, Int *fset, size_t fsize, int postorder, Int *Perm, cholmod_common *Common
 ) ;
-template <> int spqr_metis <int64_t> 
-(
-    cholmod_sparse *A, int64_t *fset, size_t fsize, int postorder, int64_t *Perm, cholmod_common *Common
-);
-
-template <> int spqr_metis <int32_t> 
-(
-    cholmod_sparse *A, int32_t *fset, size_t fsize, int postorder, int32_t *Perm, cholmod_common *Common
-);
 
 template <typename Int> cholmod_sparse *spqr_transpose 
-(
-    cholmod_sparse *A, int values, cholmod_common *Common
-) ;
-template <> cholmod_sparse *spqr_transpose <int64_t> 
-(
-    cholmod_sparse *A, int values, cholmod_common *Common
-) ;
-template <> cholmod_sparse *spqr_transpose <int32_t> 
 (
     cholmod_sparse *A, int values, cholmod_common *Common
 ) ;
@@ -309,38 +121,10 @@ cholmod_factor *spqr_analyze_p2
     int for_whom,       /* FOR_SPQR     (0): for SPQR but not GPU-accelerated
                            FOR_CHOLESKY (1): for Cholesky (GPU or not)
                            FOR_SPQRGPU  (2): for SPQR with GPU acceleration */
-    cholmod_sparse *A,	/* matrix to order and analyze */
-    Int *UserPerm,	/* user-provided permutation, size A->nrow */
-    Int *fset,	/* subset of 0:(A->ncol)-1 */
-    size_t fsize,	/* size of fset */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <>
-cholmod_factor *spqr_analyze_p2 <int32_t>
-(
-    /* ---- input ---- */
-    int for_whom,       /* FOR_SPQR     (0): for SPQR but not GPU-accelerated
-                           FOR_CHOLESKY (1): for Cholesky (GPU or not)
-                           FOR_SPQRGPU  (2): for SPQR with GPU acceleration */
-    cholmod_sparse *A,	/* matrix to order and analyze */
-    int32_t *UserPerm,	/* user-provided permutation, size A->nrow */
-    int32_t *fset,	/* subset of 0:(A->ncol)-1 */
-    size_t fsize,	/* size of fset */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <>
-cholmod_factor *spqr_analyze_p2 <int64_t>
-(
-    /* ---- input ---- */
-    int for_whom,       /* FOR_SPQR     (0): for SPQR but not GPU-accelerated
-                           FOR_CHOLESKY (1): for Cholesky (GPU or not)
-                           FOR_SPQRGPU  (2): for SPQR with GPU acceleration */
-    cholmod_sparse *A,	/* matrix to order and analyze */
-    int64_t *UserPerm,	/* user-provided permutation, size A->nrow */
-    int64_t *fset,	/* subset of 0:(A->ncol)-1 */
-    size_t fsize,	/* size of fset */
+    cholmod_sparse *A,  /* matrix to order and analyze */
+    Int *UserPerm,      /* user-provided permutation, size A->nrow */
+    Int *fset,          /* subset of 0:(A->ncol)-1 */
+    size_t fsize,       /* size of fset */
     /* --------------- */
     cholmod_common *Common
 ) ;
@@ -348,36 +132,12 @@ cholmod_factor *spqr_analyze_p2 <int64_t>
 template <typename Int> int spqr_colamd
 (
     /* ---- input ---- */
-    cholmod_sparse *A,	/* matrix to order */
-    Int *fset,	/* subset of 0:(A->ncol)-1 */
-    size_t fsize,	/* size of fset */
-    int postorder,	/* if TRUE, follow with a coletree postorder */
+    cholmod_sparse *A,  /* matrix to order */
+    Int *fset,          /* subset of 0:(A->ncol)-1 */
+    size_t fsize,       /* size of fset */
+    int postorder,      /* if TRUE, follow with a coletree postorder */
     /* ---- output --- */
-    Int *Perm,	/* size A->nrow, output permutation */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> int spqr_colamd <int32_t>
-(
-    /* ---- input ---- */
-    cholmod_sparse *A,	/* matrix to order */
-    int32_t *fset,	/* subset of 0:(A->ncol)-1 */
-    size_t fsize,	/* size of fset */
-    int postorder,	/* if TRUE, follow with a coletree postorder */
-    /* ---- output --- */
-    int32_t *Perm,	/* size A->nrow, output permutation */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> int spqr_colamd <int64_t>
-(
-    /* ---- input ---- */
-    cholmod_sparse *A,	/* matrix to order */
-    int64_t *fset,	/* subset of 0:(A->ncol)-1 */
-    size_t fsize,	/* size of fset */
-    int postorder,	/* if TRUE, follow with a coletree postorder */
-    /* ---- output --- */
-    int64_t *Perm,	/* size A->nrow, output permutation */
+    Int *Perm,          /* size A->nrow, output permutation */
     /* --------------- */
     cholmod_common *Common
 ) ;
@@ -385,33 +145,11 @@ template <> int spqr_colamd <int64_t>
 template <typename Int> Int spqr_postorder	/* return # of nodes postordered */
 (
     /* ---- input ---- */
-    Int *Parent,	/* size n. Parent [j] = p if p is the parent of j */
+    Int *Parent,    /* size n. Parent [j] = p if p is the parent of j */
     size_t n,
-    Int *Weight_p,	/* size n, optional. Weight [j] is weight of node j */
+    Int *Weight_p,  /* size n, optional. Weight [j] is weight of node j */
     /* ---- output --- */
-    Int *Post,	/* size n. Post [k] = j is kth in postordered tree */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> int32_t spqr_postorder <int32_t>	/* return # of nodes postordered */
-(
-    /* ---- input ---- */
-    int32_t *Parent,	/* size n. Parent [j] = p if p is the parent of j */
-    size_t n,
-    int32_t *Weight_p,	/* size n, optional. Weight [j] is weight of node j */
-    /* ---- output --- */
-    int32_t *Post,	/* size n. Post [k] = j is kth in postordered tree */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> int64_t spqr_postorder <int64_t>	/* return # of nodes postordered */
-(
-    /* ---- input ---- */
-    int64_t *Parent,	/* size n. Parent [j] = p if p is the parent of j */
-    size_t n,
-    int64_t *Weight_p,	/* size n, optional. Weight [j] is weight of node j */
-    /* ---- output --- */
-    int64_t *Post,	/* size n. Post [k] = j is kth in postordered tree */
+    Int *Post,      /* size n. Post [k] = j is kth in postordered tree */
     /* --------------- */
     cholmod_common *Common
 ) ;
@@ -421,38 +159,12 @@ template <typename Int> int64_t spqr_nnz
     cholmod_sparse *A,
     cholmod_common *Common
 ) ;
-template <> int64_t spqr_nnz <int64_t>
-(
-    cholmod_sparse *A,
-    cholmod_common *Common
-) ;
-template <> int64_t spqr_nnz <int32_t>
-(
-    cholmod_sparse *A,
-    cholmod_common *Common
-) ;
 
 template <typename Int> cholmod_sparse *spqr_dense_to_sparse
 (
     /* ---- input ---- */
-    cholmod_dense *X,	/* matrix to copy */
-    int values,		/* TRUE if values to be copied, FALSE otherwise */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> cholmod_sparse *spqr_dense_to_sparse <int32_t>
-(
-    /* ---- input ---- */
-    cholmod_dense *X,	/* matrix to copy */
-    int values,		/* TRUE if values to be copied, FALSE otherwise */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> cholmod_sparse *spqr_dense_to_sparse <int64_t>
-(
-    /* ---- input ---- */
-    cholmod_dense *X,	/* matrix to copy */
-    int values,		/* TRUE if values to be copied, FALSE otherwise */
+    cholmod_dense *X, /* matrix to copy */
+    int values,       /* TRUE if values to be copied, FALSE otherwise */
     /* --------------- */
     cholmod_common *Common
 ) ;
@@ -460,21 +172,7 @@ template <> cholmod_sparse *spqr_dense_to_sparse <int64_t>
 template <typename Int> cholmod_dense *spqr_sparse_to_dense
 (
     /* ---- input ---- */
-    cholmod_sparse *A,	/* matrix to copy */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> cholmod_dense *spqr_sparse_to_dense <int32_t>
-(
-    /* ---- input ---- */
-    cholmod_sparse *A,	/* matrix to copy */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> cholmod_dense *spqr_sparse_to_dense <int64_t>
-(
-    /* ---- input ---- */
-    cholmod_sparse *A,	/* matrix to copy */
+    cholmod_sparse *A,  /* matrix to copy */
     /* --------------- */
     cholmod_common *Common
 ) ;
@@ -482,27 +180,205 @@ template <> cholmod_dense *spqr_sparse_to_dense <int64_t>
 template <typename Int> cholmod_sparse *spqr_speye
 (
     /* ---- input ---- */
-    size_t nrow,	/* # of rows of A */
-    size_t ncol,	/* # of columns of A */
-    int xtype,		/* CHOLMOD_PATTERN, _REAL, _COMPLEX, or _ZOMPLEX */
+    size_t nrow,  /* # of rows of A */
+    size_t ncol,  /* # of columns of A */
+    int xtype,    /* CHOLMOD_PATTERN, _REAL, _COMPLEX, or _ZOMPLEX */
     /* --------------- */
     cholmod_common *Common
+) ;
+
+// forward declare template specializations for int32_t and int64_t
+
+template <> void *spqr_malloc <int32_t> (size_t n, size_t size, cholmod_common *Common) ;
+template <> void *spqr_malloc <int64_t> (size_t n, size_t size, cholmod_common *Common) ;
+
+template <> void *spqr_calloc <int32_t> (size_t n, size_t size, cholmod_common *Common) ;
+template <> void *spqr_calloc <int64_t> (size_t n, size_t size, cholmod_common *Common) ;
+
+template <> void *spqr_free <int32_t> (size_t n, size_t size, void *p, cholmod_common *Common) ;
+template <> void *spqr_free <int64_t> (size_t n, size_t size, void *p, cholmod_common *Common) ;
+
+template <> void *spqr_realloc <int32_t>
+(
+    size_t nnew, size_t size, void *p, size_t *n, cholmod_common *Common
+) ;
+template <> void *spqr_realloc <int64_t>
+(
+    size_t nnew, size_t size, void *p, size_t *n, cholmod_common *Common
+) ;
+
+template <> cholmod_sparse *spqr_allocate_sparse <int32_t>
+(
+    size_t nrow, size_t ncol, size_t nzmax, int sorted, int packed, int stype,
+    int xtype, cholmod_common *Common
+) ;
+template <> cholmod_sparse *spqr_allocate_sparse <int64_t>
+(
+    size_t nrow, size_t ncol, size_t nzmax, int sorted, int packed, int stype,
+    int xtype, cholmod_common *Common
+) ;
+
+template <> int spqr_free_sparse <int32_t>
+(
+    cholmod_sparse **A, cholmod_common *Common
+) ;
+template <> int spqr_free_sparse <int64_t>
+(
+    cholmod_sparse **A, cholmod_common *Common
+) ;
+
+template <> int spqr_reallocate_sparse <int32_t>
+(
+    size_t nznew, cholmod_sparse *A, cholmod_common *Common
+) ;
+template <> int spqr_reallocate_sparse <int64_t>
+(
+    size_t nznew, cholmod_sparse *A, cholmod_common *Common
+) ;
+
+template <> cholmod_dense *spqr_allocate_dense <int32_t>
+(
+    size_t nrow, size_t ncol, size_t d, int xtype, cholmod_common *Common
+) ;
+template <> cholmod_dense *spqr_allocate_dense <int64_t>
+(
+    size_t nrow, size_t ncol, size_t d, int xtype, cholmod_common *Common
+) ;
+
+template <> int spqr_free_dense <int32_t>
+(
+    cholmod_dense **X, cholmod_common *Common
+) ;
+template <> int spqr_free_dense <int64_t>
+(
+    cholmod_dense **X, cholmod_common *Common
+) ;
+
+template <> cholmod_factor *spqr_allocate_factor <int32_t>
+(
+    size_t n, cholmod_common *Common
+) ;
+template <> cholmod_factor *spqr_allocate_factor <int64_t>
+(
+    size_t n, cholmod_common *Common
+) ;
+
+template <> int spqr_free_factor <int32_t>
+(
+    cholmod_factor **L, cholmod_common *Common
+) ;
+template <> int spqr_free_factor <int64_t>
+(
+    cholmod_factor **L, cholmod_common *Common
+) ;
+
+template <> int spqr_allocate_work <int32_t>
+(
+    size_t nrow, size_t iworksize, size_t xworksize, cholmod_common *Common
+) ;
+template <> int spqr_allocate_work <int64_t>
+(
+    size_t nrow, size_t iworksize, size_t xworksize, cholmod_common *Common
+) ;
+
+template <> int spqr_amd <int32_t> 
+(
+    cholmod_sparse *A, int32_t *fset, size_t fsize, int32_t *Perm,
+    cholmod_common *Common
+) ;
+template <> int spqr_amd <int64_t> 
+(
+    cholmod_sparse *A, int64_t *fset, size_t fsize, int64_t *Perm,
+    cholmod_common *Common
+) ;
+
+template <> int spqr_metis <int32_t> 
+(
+    cholmod_sparse *A, int32_t *fset, size_t fsize, int postorder,
+    int32_t *Perm, cholmod_common *Common
+);
+template <> int spqr_metis <int64_t> 
+(
+    cholmod_sparse *A, int64_t *fset, size_t fsize, int postorder,
+    int64_t *Perm, cholmod_common *Common
+);
+
+template <> cholmod_sparse *spqr_transpose <int32_t> 
+(
+    cholmod_sparse *A, int values, cholmod_common *Common
+) ;
+template <> cholmod_sparse *spqr_transpose <int64_t> 
+(
+    cholmod_sparse *A, int values, cholmod_common *Common
+) ;
+
+template <>
+cholmod_factor *spqr_analyze_p2 <int32_t>
+(
+    int for_whom, cholmod_sparse *A, int32_t *UserPerm, int32_t *fset,
+    size_t fsize, cholmod_common *Common
+) ;
+template <>
+cholmod_factor *spqr_analyze_p2 <int64_t>
+(
+    int for_whom, cholmod_sparse *A, int64_t *UserPerm, int64_t *fset,
+    size_t fsize, cholmod_common *Common
+) ;
+
+template <> int spqr_colamd <int32_t>
+(
+    cholmod_sparse *A, int32_t *fset, size_t fsize, int postorder,
+    int32_t *Perm, cholmod_common *Common
+) ;
+template <> int spqr_colamd <int64_t>
+(
+    cholmod_sparse *A, int64_t *fset, size_t fsize, int postorder,
+    int64_t *Perm, cholmod_common *Common
+) ;
+
+template <> int32_t spqr_postorder <int32_t>
+(
+    int32_t *Parent, size_t n, int32_t *Weight_p, int32_t *Post,
+    cholmod_common *Common
+) ;
+template <> int64_t spqr_postorder <int64_t>
+(
+    int64_t *Parent, size_t n, int64_t *Weight_p, int64_t *Post,
+    cholmod_common *Common
+) ;
+
+template <> int64_t spqr_nnz <int32_t>
+(
+    cholmod_sparse *A, cholmod_common *Common
+) ;
+template <> int64_t spqr_nnz <int64_t>
+(
+    cholmod_sparse *A, cholmod_common *Common
+) ;
+
+template <> cholmod_sparse *spqr_dense_to_sparse <int32_t>
+(
+    cholmod_dense *X, int values, cholmod_common *Common
+) ;
+template <> cholmod_sparse *spqr_dense_to_sparse <int64_t>
+(
+    cholmod_dense *X, int values, cholmod_common *Common
+) ;
+
+template <> cholmod_dense *spqr_sparse_to_dense <int32_t>
+(
+    cholmod_sparse *A, cholmod_common *Common
+) ;
+template <> cholmod_dense *spqr_sparse_to_dense <int64_t>
+(
+    cholmod_sparse *A, cholmod_common *Common
+) ;
+
+template <> cholmod_sparse *spqr_speye <int32_t>
+(
+    size_t nrow, size_t ncol, int xtype, cholmod_common *Common
 ) ;
 template <> cholmod_sparse *spqr_speye <int64_t>
 (
-    /* ---- input ---- */
-    size_t nrow,	/* # of rows of A */
-    size_t ncol,	/* # of columns of A */
-    int xtype,		/* CHOLMOD_PATTERN, _REAL, _COMPLEX, or _ZOMPLEX */
-    /* --------------- */
-    cholmod_common *Common
-) ;
-template <> cholmod_sparse *spqr_speye <int32_t>
-(
-    /* ---- input ---- */
-    size_t nrow,	/* # of rows of A */
-    size_t ncol,	/* # of columns of A */
-    int xtype,		/* CHOLMOD_PATTERN, _REAL, _COMPLEX, or _ZOMPLEX */
-    /* --------------- */
-    cholmod_common *Common
+    size_t nrow, size_t ncol, int xtype, cholmod_common *Common
 ) ;

--- a/SPQR/SPQRGPU/spqrgpu_buildAssemblyMaps.cpp
+++ b/SPQR/SPQRGPU/spqrgpu_buildAssemblyMaps.cpp
@@ -199,53 +199,24 @@ void spqrgpu_buildAssemblyMaps
     }
 }
 
-template void spqrgpu_buildAssemblyMaps
+
+// explicit instantiations
+
+template void spqrgpu_buildAssemblyMaps <int32_t>
 (
-    int32_t numFronts,
-    int32_t n,
-    int32_t *Fmap,
-    int32_t *Post,
-    int32_t *Super,
-    int32_t *Rp,
-    int32_t *Rj,
-    int32_t *Sleft,
-    int32_t *Sp,
-    int32_t *Sj,
-    double *Sx,
-    int32_t *Fm,
-    int32_t *Cm,
-    int32_t *Childp,
-    int32_t *Child,
-    int32_t *CompleteStair,
-    int *CompleteRjmap,
-    int32_t *RjmapOffsets,
-    int *CompleteRimap,
-    int32_t *RimapOffsets,
-    SEntry *cpuS
+    int32_t numFronts, int32_t n, int32_t *Fmap, int32_t *Post, int32_t *Super,
+    int32_t *Rp, int32_t *Rj, int32_t *Sleft, int32_t *Sp, int32_t *Sj,
+    double *Sx, int32_t *Fm, int32_t *Cm, int32_t *Childp, int32_t *Child,
+    int32_t *CompleteStair, int *CompleteRjmap, int32_t *RjmapOffsets,
+    int *CompleteRimap, int32_t *RimapOffsets, SEntry *cpuS
 ) ;
 
-template void spqrgpu_buildAssemblyMaps
+template void spqrgpu_buildAssemblyMaps <int64_t>
 (
-    int64_t numFronts,
-    int64_t n,
-    int64_t *Fmap,
-    int64_t *Post,
-    int64_t *Super,
-    int64_t *Rp,
-    int64_t *Rj,
-    int64_t *Sleft,
-    int64_t *Sp,
-    int64_t *Sj,
-    double *Sx,
-    int64_t *Fm,
-    int64_t *Cm,
-    int64_t *Childp,
-    int64_t *Child,
-    int64_t *CompleteStair,
-    int *CompleteRjmap,
-    int64_t *RjmapOffsets,
-    int *CompleteRimap,
-    int64_t *RimapOffsets,
-    SEntry *cpuS
+    int64_t numFronts, int64_t n, int64_t *Fmap, int64_t *Post, int64_t *Super,
+    int64_t *Rp, int64_t *Rj, int64_t *Sleft, int64_t *Sp, int64_t *Sj,
+    double *Sx, int64_t *Fm, int64_t *Cm, int64_t *Childp, int64_t *Child,
+    int64_t *CompleteStair, int *CompleteRjmap, int64_t *RjmapOffsets,
+    int *CompleteRimap, int64_t *RimapOffsets, SEntry *cpuS
 ) ;
 #endif

--- a/SPQR/SPQRGPU/spqrgpu_computeFrontStaging.cpp
+++ b/SPQR/SPQRGPU/spqrgpu_computeFrontStaging.cpp
@@ -237,84 +237,27 @@ void spqrgpu_computeFrontStaging
     return;
 }
 
-template void spqrgpu_computeFrontStaging
+
+// explicit instantiations
+
+template void spqrgpu_computeFrontStaging <int32_t>
 (
-    // inputs, not modified on output
-    int64_t numFronts,     // total number of fronts (nf in caller)
-    int64_t *Parent,       // size nf+1, assembly tree (f=nf is placeholder)
-    int64_t *Childp,       // size nf+2, children of f are
-                        //      Child [Childp [f] ... Childp [f+1]-1]
-    int64_t *Child,        // size nf+1.
-
-    int64_t *Fm,           // size nf+1, front f has Fm [f] rows
-    int64_t *Cm,           // size nf+1, front f has Cm [f] rows in contrib
-    int64_t *Rp,           // size nf+1, Rj[Rp[f]...Rp[f+1]-1] are the cols in f
-    int64_t *Sp,           // size m+1, row pointers for sparse matrix S
-    int64_t *Sleft,        // size n+2, see spqr_stranspose for description
-    int64_t *Super,        // size nf+1, front f pivotal cols are
-                        //      Super[f]..Super[f+1]-1
-    int64_t *Post,         // size nf+1, front f is kth, if f = Post [k]
-
-    int64_t RimapSize,     // scalar, size of Rimap on the GPU (# of int's)
-    int64_t RjmapSize,     // scalar, size of Rimap on the GPU (# of int's)
-
-    // output, not defined on input:
-    bool *feasible,     // scalar, true if feasible, false if GPU memory too low
-    int64_t *numStages,    // scalar, number of stages
-    int64_t *Stagingp,     // size nf+2, fronts are in the list
-                        //      Post [Stagingp [stage]...Stagingp[stage+1]-1]
-    int64_t *StageMap,     // size nf, front f is in stage StageMap [f]
-
-    size_t *FSize,      // size nf+1, FSize[stage]: size in bytes of MongoF
-    size_t *RSize,      // size nf+1, Rsize[stage]: size in bytes of MongoR
-    size_t *SSize,      // size nf+1, Ssize[stage]: size in bytes of S
-    int64_t *FOffsets,     // size nf, front f in MondoF [FOffsets[f]...] on GPU
-    int64_t *ROffsets,     // size nf, R block in MondoR [Roffsets[f]...] on CPU
-    int64_t *SOffsets,     // size nf, S entries for front f are in
-                        //      wsS [SOffsets[f]...]
-
-    // input/output:
-    cholmod_common *cc
+    int32_t numFronts, int32_t *Parent, int32_t *Childp, int32_t *Child,
+    int32_t *Fm, int32_t *Cm, int32_t *Rp, int32_t *Sp, int32_t *Sleft,
+    int32_t *Super, int32_t *Post, int32_t RimapSize, int32_t RjmapSize,
+    bool *feasible, int32_t *numStages, int32_t *Stagingp, int32_t *StageMap,
+    size_t *FSize, size_t *RSize, size_t *SSize, int32_t *FOffsets,
+    int32_t *ROffsets, int32_t *SOffsets, cholmod_common *cc
 ) ;
 
-template void spqrgpu_computeFrontStaging
+template void spqrgpu_computeFrontStaging <int64_t>
 (
-    // inputs, not modified on output
-    int32_t numFronts,     // total number of fronts (nf in caller)
-    int32_t *Parent,       // size nf+1, assembly tree (f=nf is placeholder)
-    int32_t *Childp,       // size nf+2, children of f are
-                        //      Child [Childp [f] ... Childp [f+1]-1]
-    int32_t *Child,        // size nf+1.
-
-    int32_t *Fm,           // size nf+1, front f has Fm [f] rows
-    int32_t *Cm,           // size nf+1, front f has Cm [f] rows in contrib
-    int32_t *Rp,           // size nf+1, Rj[Rp[f]...Rp[f+1]-1] are the cols in f
-    int32_t *Sp,           // size m+1, row pointers for sparse matrix S
-    int32_t *Sleft,        // size n+2, see spqr_stranspose for description
-    int32_t *Super,        // size nf+1, front f pivotal cols are
-                        //      Super[f]..Super[f+1]-1
-    int32_t *Post,         // size nf+1, front f is kth, if f = Post [k]
-
-    int32_t RimapSize,     // scalar, size of Rimap on the GPU (# of int's)
-    int32_t RjmapSize,     // scalar, size of Rimap on the GPU (# of int's)
-
-    // output, not defined on input:
-    bool *feasible,     // scalar, true if feasible, false if GPU memory too low
-    int32_t *numStages,    // scalar, number of stages
-    int32_t *Stagingp,     // size nf+2, fronts are in the list
-                        //      Post [Stagingp [stage]...Stagingp[stage+1]-1]
-    int32_t *StageMap,     // size nf, front f is in stage StageMap [f]
-
-    size_t *FSize,      // size nf+1, FSize[stage]: size in bytes of MongoF
-    size_t *RSize,      // size nf+1, Rsize[stage]: size in bytes of MongoR
-    size_t *SSize,      // size nf+1, Ssize[stage]: size in bytes of S
-    int32_t *FOffsets,     // size nf, front f in MondoF [FOffsets[f]...] on GPU
-    int32_t *ROffsets,     // size nf, R block in MondoR [Roffsets[f]...] on CPU
-    int32_t *SOffsets,     // size nf, S entries for front f are in
-                        //      wsS [SOffsets[f]...]
-
-    // input/output:
-    cholmod_common *cc
+    int64_t numFronts, int64_t *Parent, int64_t *Childp, int64_t *Child,
+    int64_t *Fm, int64_t *Cm, int64_t *Rp, int64_t *Sp, int64_t *Sleft,
+    int64_t *Super, int64_t *Post, int64_t RimapSize, int64_t RjmapSize,
+    bool *feasible, int64_t *numStages, int64_t *Stagingp, int64_t *StageMap,
+    size_t *FSize, size_t *RSize, size_t *SSize, int64_t *FOffsets,
+    int64_t *ROffsets, int64_t *SOffsets, cholmod_common *cc
 ) ;
 
 #endif

--- a/SPQR/SPQRGPU/spqrgpu_kernel.cpp
+++ b/SPQR/SPQRGPU/spqrgpu_kernel.cpp
@@ -750,8 +750,13 @@ void spqrgpu_kernel
     return ;
 }
 
-template void spqrgpu_kernel (spqr_blob <Complex, int32_t> *Blob) ;
-template void spqrgpu_kernel (spqr_blob <Complex, int64_t> *Blob) ;
 
-template void spqrgpu_kernel (spqr_blob <double, int32_t> *Blob) ;
-template void spqrgpu_kernel (spqr_blob <double, int64_t> *Blob) ;
+// explicit instantiations
+
+template void spqrgpu_kernel <int32_t> (spqr_blob <double, int32_t> *Blob) ;
+
+template void spqrgpu_kernel <int32_t> (spqr_blob <Complex, int32_t> *Blob) ;
+
+template void spqrgpu_kernel <int64_t> (spqr_blob <double, int64_t> *Blob) ;
+
+template void spqrgpu_kernel <int64_t> (spqr_blob <Complex, int64_t> *Blob) ;

--- a/SPQR/Source/SuiteSparseQR.cpp
+++ b/SPQR/Source/SuiteSparseQR.cpp
@@ -59,223 +59,75 @@
         spqr_free <Int> (n+bncols, sizeof (Int), E, cc) ; \
         spqr_free <Int> (m, sizeof (Int), HP1inv, cc) ;
 
-extern template SuiteSparseQR_factorization <Complex, int32_t> *spqr_1factor <Complex, int32_t>
-(
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // only accept singletons above tol.  If tol <= -2,
-                            // then use the default tolerance
-    int32_t bncols,            // number of columns of B
-    int keepH,              // if TRUE, keep the Householder vectors
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    int32_t ldb,               // if dense, the leading dimension of B
-    int32_t *Bp,               // size bncols+1, column pointers of B
-    int32_t *Bi,               // size bnz = Bp [bncols], row indices of B
-    Complex *Bx,              // size bnz, numerical values of B
+// forward declare template instantiations
+// FIXME: Could those forward declarations be moved to a header?
 
-    // workspace and parameters
-    cholmod_common *cc
+extern template SuiteSparseQR_factorization <double, int32_t> *
+spqr_1factor <double, int32_t>
+(
+    int ordering, double tol, int32_t bncols, int keepH, cholmod_sparse *A,
+    int32_t ldb, int32_t *Bp, int32_t *Bi, double *Bx, cholmod_common *cc
 ) ;
 
-
-extern template SuiteSparseQR_factorization <double, int32_t> *spqr_1factor <double, int32_t>
+extern template SuiteSparseQR_factorization <Complex, int32_t> *
+spqr_1factor <Complex, int32_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // only accept singletons above tol.  If tol <= -2,
-                            // then use the default tolerance
-    int32_t bncols,            // number of columns of B
-    int keepH,              // if TRUE, keep the Householder vectors
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    int32_t ldb,               // if dense, the leading dimension of B
-    int32_t *Bp,               // size bncols+1, column pointers of B
-    int32_t *Bi,               // size bnz = Bp [bncols], row indices of B
-    double *Bx,              // size bnz, numerical values of B
-
-    // workspace and parameters
-    cholmod_common *cc
+    int ordering, double tol, int32_t bncols, int keepH, cholmod_sparse *A,
+    int32_t ldb, int32_t *Bp, int32_t *Bi, Complex *Bx, cholmod_common *cc
 ) ;
 
-extern template SuiteSparseQR_factorization <Complex, int64_t> *spqr_1factor <Complex, int64_t>
+extern template SuiteSparseQR_factorization <double, int64_t> *
+spqr_1factor <double, int64_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // only accept singletons above tol.  If tol <= -2,
-                            // then use the default tolerance
-    int64_t bncols,            // number of columns of B
-    int keepH,              // if TRUE, keep the Householder vectors
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    int64_t ldb,               // if dense, the leading dimension of B
-    int64_t *Bp,               // size bncols+1, column pointers of B
-    int64_t *Bi,               // size bnz = Bp [bncols], row indices of B
-    Complex *Bx,              // size bnz, numerical values of B
-
-    // workspace and parameters
-    cholmod_common *cc
+    int ordering, double tol, int64_t bncols, int keepH, cholmod_sparse *A,
+    int64_t ldb, int64_t *Bp, int64_t *Bi, double *Bx, cholmod_common *cc
 ) ;
 
-extern template int spqr_1fixed <Complex, int32_t>
+extern template SuiteSparseQR_factorization <Complex, int64_t> *
+spqr_1factor <Complex, int64_t>
 (
-    // inputs, not modified
-    double tol,             // only accept singletons above tol
-    int32_t bncols,            // number of columns of B
-    cholmod_sparse *A,      // m-by-n sparse matrix
-
-    // output arrays, neither allocated nor defined on input.
-
-    int32_t **p_R1p,           // size n1rows+1, R1p [k] = # of nonzeros in kth
-                            // row of R1.  NULL if n1cols == 0.
-    int32_t **p_P1inv,         // size m, singleton row inverse permutation.
-                            // If row i of A is the kth singleton row, then
-                            // P1inv [i] = k.  NULL if n1cols is zero.
-
-    cholmod_sparse **p_Y,   // on output, only the first n-n1cols+1 entries of
-                            // Y->p are defined (if Y is not NULL), where
-                            // Y = [A B] or Y = [A2 B2].  If B is empty and
-                            // there are no column singletons, Y is NULL
-
-    int32_t *p_n1cols,         // number of column singletons found
-    int32_t *p_n1rows,         // number of corresponding rows found
-
-    // workspace and parameters
-    cholmod_common *cc
-) ;
-extern template int spqr_1fixed <Complex, int64_t>
-(
-    // inputs, not modified
-    double tol,             // only accept singletons above tol
-    int64_t bncols,            // number of columns of B
-    cholmod_sparse *A,      // m-by-n sparse matrix
-
-    // output arrays, neither allocated nor defined on input.
-
-    int64_t **p_R1p,           // size n1rows+1, R1p [k] = # of nonzeros in kth
-                            // row of R1.  NULL if n1cols == 0.
-    int64_t **p_P1inv,         // size m, singleton row inverse permutation.
-                            // If row i of A is the kth singleton row, then
-                            // P1inv [i] = k.  NULL if n1cols is zero.
-
-    cholmod_sparse **p_Y,   // on output, only the first n-n1cols+1 entries of
-                            // Y->p are defined (if Y is not NULL), where
-                            // Y = [A B] or Y = [A2 B2].  If B is empty and
-                            // there are no column singletons, Y is NULL
-
-    int64_t *p_n1cols,         // number of column singletons found
-    int64_t *p_n1rows,         // number of corresponding rows found
-
-    // workspace and parameters
-    cholmod_common *cc
+    int ordering, double tol, int64_t bncols, int keepH, cholmod_sparse *A,
+    int64_t ldb, int64_t *Bp, int64_t *Bi, Complex *Bx, cholmod_common *cc
 ) ;
 
 extern template int spqr_1fixed <double, int32_t>
 (
-    // inputs, not modified
-    double tol,             // only accept singletons above tol
-    int32_t bncols,            // number of columns of B
-    cholmod_sparse *A,      // m-by-n sparse matrix
-
-    // output arrays, neither allocated nor defined on input.
-
-    int32_t **p_R1p,           // size n1rows+1, R1p [k] = # of nonzeros in kth
-                            // row of R1.  NULL if n1cols == 0.
-    int32_t **p_P1inv,         // size m, singleton row inverse permutation.
-                            // If row i of A is the kth singleton row, then
-                            // P1inv [i] = k.  NULL if n1cols is zero.
-
-    cholmod_sparse **p_Y,   // on output, only the first n-n1cols+1 entries of
-                            // Y->p are defined (if Y is not NULL), where
-                            // Y = [A B] or Y = [A2 B2].  If B is empty and
-                            // there are no column singletons, Y is NULL
-
-    int32_t *p_n1cols,         // number of column singletons found
-    int32_t *p_n1rows,         // number of corresponding rows found
-
-    // workspace and parameters
-    cholmod_common *cc
+    double tol, int32_t bncols, cholmod_sparse *A,
+    int32_t **p_R1p, int32_t **p_P1inv, cholmod_sparse **p_Y,
+    int32_t *p_n1cols, int32_t *p_n1rows, cholmod_common *cc
 ) ;
+
+extern template int spqr_1fixed <Complex, int32_t>
+(
+    double tol, int32_t bncols, cholmod_sparse *A,
+    int32_t **p_R1p, int32_t **p_P1inv, cholmod_sparse **p_Y,
+    int32_t *p_n1cols, int32_t *p_n1rows, cholmod_common *cc
+) ;
+
 extern template int spqr_1fixed <double, int64_t>
 (
-    // inputs, not modified
-    double tol,             // only accept singletons above tol
-    int64_t bncols,            // number of columns of B
-    cholmod_sparse *A,      // m-by-n sparse matrix
-
-    // output arrays, neither allocated nor defined on input.
-
-    int64_t **p_R1p,           // size n1rows+1, R1p [k] = # of nonzeros in kth
-                            // row of R1.  NULL if n1cols == 0.
-    int64_t **p_P1inv,         // size m, singleton row inverse permutation.
-                            // If row i of A is the kth singleton row, then
-                            // P1inv [i] = k.  NULL if n1cols is zero.
-
-    cholmod_sparse **p_Y,   // on output, only the first n-n1cols+1 entries of
-                            // Y->p are defined (if Y is not NULL), where
-                            // Y = [A B] or Y = [A2 B2].  If B is empty and
-                            // there are no column singletons, Y is NULL
-
-    int64_t *p_n1cols,         // number of column singletons found
-    int64_t *p_n1rows,         // number of corresponding rows found
-
-    // workspace and parameters
-    cholmod_common *cc
+    double tol, int64_t bncols, cholmod_sparse *A,
+    int64_t **p_R1p, int64_t **p_P1inv, cholmod_sparse **p_Y,
+    int64_t *p_n1cols, int64_t *p_n1rows, cholmod_common *cc
 ) ;
 
-extern template SuiteSparseQR_factorization <double, int64_t> *spqr_1factor <double, int64_t>
+extern template int spqr_1fixed <Complex, int64_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // only accept singletons above tol.  If tol <= -2,
-                            // then use the default tolerance
-    int64_t bncols,            // number of columns of B
-    int keepH,              // if TRUE, keep the Householder vectors
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    int64_t ldb,               // if dense, the leading dimension of B
-    int64_t *Bp,               // size bncols+1, column pointers of B
-    int64_t *Bi,               // size bnz = Bp [bncols], row indices of B
-    double *Bx,              // size bnz, numerical values of B
-
-    // workspace and parameters
-    cholmod_common *cc
+    double tol, int64_t bncols, cholmod_sparse *A,
+    int64_t **p_R1p, int64_t **p_P1inv, cholmod_sparse **p_Y,
+    int64_t *p_n1cols, int64_t *p_n1rows,  cholmod_common *cc
 ) ;
 
 extern template spqr_symbolic <int32_t> *spqr_analyze <int32_t>
 (
-    // inputs, not modified
-    cholmod_sparse *A,
-    int ordering,           // all options available
-    int32_t *Quser,            // user provided ordering, if given (may be NULL)
-
-    int do_rank_detection,  // if TRUE, then rank deficient matrices may be
-                            // considered during numerical factorization,
-    // with tol >= 0 (tol < 0 is also allowed).  If FALSE, then the tol
-    // parameter is ignored by the numerical factorization, and no rank
-    // detection is performed.  Ignored when using GPU acceleration
-    // (no rank detection is performed in that case).
-
-    int keepH,              // if TRUE, keep the Householder vectors
-
-    // workspace and parameters
-    cholmod_common *cc
+    cholmod_sparse *A, int ordering, int32_t *Quser, int do_rank_detection,
+    int keepH, cholmod_common *cc
 ) ;
 
 extern template spqr_symbolic <int64_t> *spqr_analyze <int64_t>
 (
-    // inputs, not modified
-    cholmod_sparse *A,
-    int ordering,           // all options available
-    int64_t *Quser,            // user provided ordering, if given (may be NULL)
-
-    int do_rank_detection,  // if TRUE, then rank deficient matrices may be
-                            // considered during numerical factorization,
-    // with tol >= 0 (tol < 0 is also allowed).  If FALSE, then the tol
-    // parameter is ignored by the numerical factorization, and no rank
-    // detection is performed.  Ignored when using GPU acceleration
-    // (no rank detection is performed in that case).
-
-    int keepH,              // if TRUE, keep the Householder vectors
-
-    // workspace and parameters
-    cholmod_common *cc
+    cholmod_sparse *A, int ordering, int64_t *Quser, int do_rank_detection,
+    int keepH, cholmod_common *cc
 ) ;
 
 // =============================================================================
@@ -288,7 +140,7 @@ template <typename Entry, typename Int> Int SuiteSparseQR
     // inputs, not modified
     int ordering,           // all, except 3:given treated as 0:fixed
     double tol,             // columns with 2-norm <= tol are treated as zero
-    Int econ,              // number of rows of C and R to return; a value
+    Int econ,               // number of rows of C and R to return; a value
                             // less than the rank r of A is treated as r, and
                             // a value greater than m is treated as m.
                             // That is, e = max(min(m,econ),rank(A)) gives the
@@ -316,9 +168,9 @@ template <typename Entry, typename Int> Int SuiteSparseQR
     cholmod_dense  **p_Zdense,
 
     cholmod_sparse **p_R,   // the R factor
-    Int **p_E,             // size n; fill-reducing ordering of A.
+    Int **p_E,              // size n; fill-reducing ordering of A.
     cholmod_sparse **p_H,   // the Householder vectors (m-by-nh)
-    Int **p_HPinv,         // size m; row permutation for H
+    Int **p_HPinv,          // size m; row permutation for H
     cholmod_dense **p_HTau, // size 1-by-nh, Householder coefficients
 
     // workspace and parameters
@@ -1213,133 +1065,45 @@ template <typename Entry, typename Int> Int SuiteSparseQR
     return (rank) ;
 }
 
+
+// explicit instantiations
+
 template int32_t SuiteSparseQR <double, int32_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int32_t econ,              // number of rows of C and R to return; a value
-                            // less than the rank r of A is treated as r, and
-                            // a value greater than m is treated as m.
-
-    int getCTX,             // if 0: return Z = C of size econ-by-bncols
-                            // if 1: return Z = C' of size bncols-by-econ
-                            // if 2: return Z = X of size econ-by-bncols
-
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_sparse *Bsparse,
-    cholmod_dense *Bdense,
-
-    // output arrays, neither allocated nor defined on input.
-
-    // Z is the matrix C, C', or X
-    cholmod_sparse **p_Zsparse,
-    cholmod_dense  **p_Zdense,
-    cholmod_sparse **p_R,   // the R factor
-    int32_t **p_E,             // size n; fill-reducing ordering of A.
-    cholmod_sparse **p_H,   // the Householder vectors (m-by-nh)
-    int32_t **p_HPinv,         // size m; row permutation for H
-    cholmod_dense **p_HTau, // size 1-by-nh, Householder coefficients
-
-    // workspace and parameters
-    cholmod_common *cc
-) ;
-
-template int64_t SuiteSparseQR <double, int64_t>
-(
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int64_t econ,              // number of rows of C and R to return; a value
-                            // less than the rank r of A is treated as r, and
-                            // a value greater than m is treated as m.
-
-    int getCTX,             // if 0: return Z = C of size econ-by-bncols
-                            // if 1: return Z = C' of size bncols-by-econ
-                            // if 2: return Z = X of size econ-by-bncols
-
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_sparse *Bsparse,
-    cholmod_dense *Bdense,
-
-    // output arrays, neither allocated nor defined on input.
-
-    // Z is the matrix C, C', or X
-    cholmod_sparse **p_Zsparse,
-    cholmod_dense  **p_Zdense,
-    cholmod_sparse **p_R,   // the R factor
-    int64_t **p_E,             // size n; fill-reducing ordering of A.
-    cholmod_sparse **p_H,   // the Householder vectors (m-by-nh)
-    int64_t **p_HPinv,         // size m; row permutation for H
-    cholmod_dense **p_HTau, // size 1-by-nh, Householder coefficients
-
-    // workspace and parameters
-    cholmod_common *cc
+    int ordering, double tol, int32_t econ, int getCTX,
+    cholmod_sparse *A, cholmod_sparse *Bsparse, cholmod_dense *Bdense,
+    cholmod_sparse **p_Zsparse, cholmod_dense  **p_Zdense,
+    cholmod_sparse **p_R, int32_t **p_E, cholmod_sparse **p_H,
+    int32_t **p_HPinv, cholmod_dense **p_HTau, cholmod_common *cc
 ) ;
 
 template int32_t SuiteSparseQR <Complex, int32_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int32_t econ,              // number of rows of C and R to return; a value
-                            // less than the rank r of A is treated as r, and
-                            // a value greater than m is treated as m.
+    int ordering, double tol, int32_t econ, int getCTX,
+    cholmod_sparse *A, cholmod_sparse *Bsparse, cholmod_dense *Bdense,
+    cholmod_sparse **p_Zsparse, cholmod_dense  **p_Zdense,
+    cholmod_sparse **p_R, int32_t **p_E, cholmod_sparse **p_H,
+    int32_t **p_HPinv, cholmod_dense **p_HTau, cholmod_common *cc
+) ;
 
-    int getCTX,             // if 0: return Z = C of size econ-by-bncols
-                            // if 1: return Z = C' of size bncols-by-econ
-                            // if 2: return Z = X of size econ-by-bncols
-
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_sparse *Bsparse,
-    cholmod_dense *Bdense,
-
-    // output arrays, neither allocated nor defined on input.
-
-    // Z is the matrix C, C', or X
-    cholmod_sparse **p_Zsparse,
-    cholmod_dense  **p_Zdense,
-    cholmod_sparse **p_R,   // the R factor
-    int32_t **p_E,             // size n; fill-reducing ordering of A.
-    cholmod_sparse **p_H,   // the Householder vectors (m-by-nh)
-    int32_t **p_HPinv,         // size m; row permutation for H
-    cholmod_dense **p_HTau, // size 1-by-nh, Householder coefficients
-
-    // workspace and parameters
-    cholmod_common *cc
+template int64_t SuiteSparseQR <double, int64_t>
+(
+    int ordering, double tol, int64_t econ, int getCTX,
+    cholmod_sparse *A, cholmod_sparse *Bsparse, cholmod_dense *Bdense,
+    cholmod_sparse **p_Zsparse, cholmod_dense  **p_Zdense,
+    cholmod_sparse **p_R, int64_t **p_E, cholmod_sparse **p_H,
+    int64_t **p_HPinv, cholmod_dense **p_HTau, cholmod_common *cc
 ) ;
 
 template int64_t SuiteSparseQR <Complex, int64_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int64_t econ,              // number of rows of C and R to return; a value
-                            // less than the rank r of A is treated as r, and
-                            // a value greater than m is treated as m.
-
-    int getCTX,             // if 0: return Z = C of size econ-by-bncols
-                            // if 1: return Z = C' of size bncols-by-econ
-                            // if 2: return Z = X of size econ-by-bncols
-
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_sparse *Bsparse,
-    cholmod_dense *Bdense,
-
-    // output arrays, neither allocated nor defined on input.
-
-    // Z is the matrix C, C', or X
-    cholmod_sparse **p_Zsparse,
-    cholmod_dense  **p_Zdense,
-    cholmod_sparse **p_R,   // the R factor
-    int64_t **p_E,             // size n; fill-reducing ordering of A.
-    cholmod_sparse **p_H,   // the Householder vectors (m-by-nh)
-    int64_t **p_HPinv,         // size m; row permutation for H
-    cholmod_dense **p_HTau, // size 1-by-nh, Householder coefficients
-
-    // workspace and parameters
-    cholmod_common *cc
+    int ordering, double tol, int64_t econ, int getCTX,
+    cholmod_sparse *A, cholmod_sparse *Bsparse, cholmod_dense *Bdense,
+    cholmod_sparse **p_Zsparse, cholmod_dense  **p_Zdense,
+    cholmod_sparse **p_R, int64_t **p_E, cholmod_sparse **p_H,
+    int64_t **p_HPinv, cholmod_dense **p_HTau, cholmod_common *cc
 ) ;
+
 
 // -----------------------------------------------------------------------------
 // X=A\B where X and B are dense
@@ -1359,39 +1123,33 @@ template <typename Entry, typename Int> cholmod_dense *SuiteSparseQR
     return (X) ;
 }
 
+
+// explicit instantiations
+
 template cholmod_dense *SuiteSparseQR <double, int32_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_dense  *B,      // m-by-nrhs
-    cholmod_common *cc      // workspace and parameters
-) ;
-template cholmod_dense *SuiteSparseQR <double, int64_t>
-(
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_dense  *B,      // m-by-nrhs
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, cholmod_sparse *A, cholmod_dense  *B,
+    cholmod_common *cc
 ) ;
 
 template cholmod_dense *SuiteSparseQR <Complex, int32_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_dense  *B,      // m-by-nrhs
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, cholmod_sparse *A, cholmod_dense  *B,
+    cholmod_common *cc
 ) ;
+
+template cholmod_dense *SuiteSparseQR <double, int64_t>
+(
+    int ordering, double tol, cholmod_sparse *A, cholmod_dense  *B,
+    cholmod_common *cc
+) ;
+
 template cholmod_dense *SuiteSparseQR <Complex, int64_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_dense  *B,      // m-by-nrhs
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, cholmod_sparse *A, cholmod_dense  *B,
+    cholmod_common *cc
 ) ;
+
 
 // -----------------------------------------------------------------------------
 // X=A\B where X and B are dense, default ordering and tol
@@ -1409,31 +1167,29 @@ template <typename Entry, typename Int> cholmod_dense *SuiteSparseQR
     return (X) ;
 }
 
+
+// explicit instantiations
+
 template cholmod_dense *SuiteSparseQR <double, int32_t>
 (
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_dense  *B,      // m-by-nrhs
-    cholmod_common *cc      // workspace and parameters
-) ;
-template cholmod_dense *SuiteSparseQR <double, int64_t>
-(
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_dense  *B,      // m-by-nrhs
-    cholmod_common *cc      // workspace and parameters
+    cholmod_sparse *A, cholmod_dense  *B, cholmod_common *cc
 ) ;
 
 template cholmod_dense *SuiteSparseQR <Complex, int32_t>
 (
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_dense  *B,      // m-by-nrhs
-    cholmod_common *cc      // workspace and parameters
+    cholmod_sparse *A, cholmod_dense  *B, cholmod_common *cc
 ) ;
+
+template cholmod_dense *SuiteSparseQR <double, int64_t>
+(
+    cholmod_sparse *A, cholmod_dense  *B, cholmod_common *cc
+) ;
+
 template cholmod_dense *SuiteSparseQR <Complex, int64_t>
 (
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_dense  *B,      // m-by-nrhs
-    cholmod_common *cc      // workspace and parameters
+    cholmod_sparse *A, cholmod_dense  *B, cholmod_common *cc
 ) ;
+
 
 // -----------------------------------------------------------------------------
 // X=A\B where X and B are sparse 
@@ -1455,41 +1211,33 @@ template <typename Entry, typename Int> cholmod_sparse *SuiteSparseQR
     return (X) ;
 }
 
+
+// explicit instantiations
+
 template cholmod_sparse *SuiteSparseQR <double, int32_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_sparse *B,      // m-by-nrhs
-    cholmod_common *cc      // workspace and parameters
-) ;
-
-template cholmod_sparse *SuiteSparseQR <double, int64_t>
-(
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_sparse *B,      // m-by-nrhs
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, cholmod_sparse *A, cholmod_sparse *B,
+    cholmod_common *cc
 ) ;
 
 template cholmod_sparse *SuiteSparseQR <Complex, int32_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_sparse *B,      // m-by-nrhs
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, cholmod_sparse *A, cholmod_sparse *B,
+    cholmod_common *cc
+) ;
+
+template cholmod_sparse *SuiteSparseQR <double, int64_t>
+(
+    int ordering, double tol, cholmod_sparse *A, cholmod_sparse *B,
+    cholmod_common *cc
 ) ;
 
 template cholmod_sparse *SuiteSparseQR <Complex, int64_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_sparse *B,      // m-by-nrhs
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, cholmod_sparse *A, cholmod_sparse *B,
+    cholmod_common *cc
 ) ;
+
 
 // -----------------------------------------------------------------------------
 // [Q,R,E] = qr(A), returning Q as a sparse matrix
@@ -1499,12 +1247,12 @@ template <typename Entry, typename Int> Int SuiteSparseQR     // returns rank(A)
 (
     int ordering,           // all, except 3:given treated as 0:fixed
     double tol,             // columns with 2-norm <= tol are treated as zero
-    Int econ,              // e = max(min(m,econ),rank(A))
+    Int econ,               // e = max(min(m,econ),rank(A))
     cholmod_sparse *A,      // m-by-n sparse matrix
     // outputs
     cholmod_sparse **Q,     // m-by-e sparse matrix
     cholmod_sparse **R,     // e-by-n sparse matrix
-    Int **E,               // permutation of 0:n-1, NULL if identity
+    Int **E,                // permutation of 0:n-1, NULL if identity
     cholmod_common *cc      // workspace and parameters
 )
 {
@@ -1519,55 +1267,34 @@ template <typename Entry, typename Int> Int SuiteSparseQR     // returns rank(A)
     spqr_free_sparse <Int> (&I, cc) ;
     return (rank) ;
 }
-template int32_t SuiteSparseQR <Complex, int32_t>     // returns rank(A) estimate
+
+
+// explicit instantiations
+
+template int32_t SuiteSparseQR <double, int32_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int32_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    // outputs
-    cholmod_sparse **Q,     // m-by-e sparse matrix
-    cholmod_sparse **R,     // e-by-n sparse matrix
-    int32_t **E,               // permutation of 0:n-1
-    cholmod_common *cc      // workspace and parameters
-) ;
-template int64_t SuiteSparseQR <Complex, int64_t>     // returns rank(A) estimate
-(
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int64_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    // outputs
-    cholmod_sparse **Q,     // m-by-e sparse matrix
-    cholmod_sparse **R,     // e-by-n sparse matrix
-    int64_t **E,               // permutation of 0:n-1
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, int32_t econ, cholmod_sparse *A,
+    cholmod_sparse **Q, cholmod_sparse **R, int32_t **E, cholmod_common *cc
 ) ;
 
-template int32_t SuiteSparseQR <double, int32_t>     // returns rank(A) estimate
+template int32_t SuiteSparseQR <Complex, int32_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int32_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    // outputs
-    cholmod_sparse **Q,     // m-by-e sparse matrix where e=max(econ,rank(A))
-    cholmod_sparse **R,     // e-by-n sparse matrix
-    int32_t **E,               // permutation of 0:n-1
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, int32_t econ, cholmod_sparse *A,
+    cholmod_sparse **Q, cholmod_sparse **R, int32_t **E, cholmod_common *cc
 ) ;
-template int64_t SuiteSparseQR <double, int64_t>     // returns rank(A) estimate
+
+template int64_t SuiteSparseQR <double, int64_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int64_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    // outputs
-    cholmod_sparse **Q,     // m-by-e sparse matrix where e=max(econ,rank(A))
-    cholmod_sparse **R,     // e-by-n sparse matrix
-    int64_t **E,               // permutation of 0:n-1
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, int64_t econ, cholmod_sparse *A,
+    cholmod_sparse **Q, cholmod_sparse **R, int64_t **E, cholmod_common *cc
 ) ;
+
+template int64_t SuiteSparseQR <Complex, int64_t>
+(
+    int ordering, double tol, int64_t econ, cholmod_sparse *A,
+    cholmod_sparse **Q, cholmod_sparse **R, int64_t **E, cholmod_common *cc
+) ;
+
 
 // -----------------------------------------------------------------------------
 // [Q,R,E] = qr(A), discarding Q
@@ -1577,62 +1304,45 @@ template <typename Entry, typename Int> Int SuiteSparseQR // returns rank(A) est
 (
     int ordering,           // all, except 3:given treated as 0:fixed
     double tol,             // columns with 2-norm <= tol are treated as zero
-    Int econ,              // e = max(min(m,econ),rank(A))
+    Int econ,               // e = max(min(m,econ),rank(A))
     cholmod_sparse *A,      // m-by-n sparse matrix
     // outputs
     cholmod_sparse **R,     // e-by-n sparse matrix
-    Int **E,               // permutation of 0:n-1, NULL if identity
+    Int **E,                // permutation of 0:n-1, NULL if identity
     cholmod_common *cc      // workspace and parameters
 )
 {
     return (SuiteSparseQR <Entry, Int> (ordering, tol, econ, 1, A,   
         NULL, NULL, NULL, NULL, R, E, NULL, NULL, NULL, cc)) ;
 }
-template int32_t SuiteSparseQR <Complex, int32_t>     // returns rank(A) estimate
+
+
+// explicit instantiations
+
+template int32_t SuiteSparseQR <double, int32_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int32_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    // outputs
-    cholmod_sparse **R,     // e-by-n sparse matrix
-    int32_t **E,               // permutation of 0:n-1, NULL if identity
-    cholmod_common *cc      // workspace and parameters
-) ;
-template int64_t SuiteSparseQR <Complex, int64_t>     // returns rank(A) estimate
-(
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int64_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    // outputs
-    cholmod_sparse **R,     // e-by-n sparse matrix
-    int64_t **E,               // permutation of 0:n-1, NULL if identity
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, int32_t econ, cholmod_sparse *A,
+    cholmod_sparse **R, int32_t **E, cholmod_common *cc
 ) ;
 
-template int32_t SuiteSparseQR <double, int32_t>     // returns rank(A) estimate
+template int32_t SuiteSparseQR <Complex, int32_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int32_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    // outputs
-    cholmod_sparse **R,     // e-by-n sparse matrix
-    int32_t **E,               // permutation of 0:n-1, NULL if identity
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, int32_t econ, cholmod_sparse *A,
+    cholmod_sparse **R, int32_t **E, cholmod_common *cc
 ) ;
-template int64_t SuiteSparseQR <double, int64_t>     // returns rank(A) estimate
+
+template int64_t SuiteSparseQR <double, int64_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int64_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    // outputs
-    cholmod_sparse **R,     // e-by-n sparse matrix
-    int64_t **E,               // permutation of 0:n-1, NULL if identity
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, int64_t econ, cholmod_sparse *A,
+    cholmod_sparse **R, int64_t **E, cholmod_common *cc
 ) ;
+
+template int64_t SuiteSparseQR <Complex, int64_t>
+(
+    int ordering, double tol, int64_t econ, cholmod_sparse *A,
+    cholmod_sparse **R, int64_t **E, cholmod_common *cc
+) ;
+
 
 // -----------------------------------------------------------------------------
 // [C,R,E] = qr(A,B) where C and B are both dense
@@ -1644,13 +1354,13 @@ template <typename Entry, typename Int> Int SuiteSparseQR
     // inputs, not modified
     int ordering,           // all, except 3:given treated as 0:fixed
     double tol,             // columns with 2-norm <= tol are treated as zero
-    Int econ,              // e = max(min(m,econ),rank(A))
+    Int econ,               // e = max(min(m,econ),rank(A))
     cholmod_sparse *A,      // m-by-n sparse matrix
     cholmod_dense  *B,      // m-by-nrhs dense matrix
     // outputs
     cholmod_dense  **C,     // C = Q'*B, an e-by-nrhs dense matrix
     cholmod_sparse **R,     // e-by-n sparse matrix where e=max(econ,rank(A))
-    Int **E,               // permutation of 0:n-1, NULL if identity
+    Int **E,                // permutation of 0:n-1, NULL if identity
     cholmod_common *cc      // workspace and parameters
 )
 {
@@ -1658,63 +1368,33 @@ template <typename Entry, typename Int> Int SuiteSparseQR
         NULL, C, R, E, NULL, NULL, NULL, cc)) ;
 }
 
+
+// explicit instantiations
+
 template int32_t SuiteSparseQR <double, int32_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int32_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_dense  *B,      // m-by-nrhs dense matrix
-    // outputs
-    cholmod_dense  **C,     // C = Q'*B, an e-by-nrhs dense matrix
-    cholmod_sparse **R,     // e-by-n sparse matrix where e=max(econ,rank(A))
-    int32_t **E,               // permutation of 0:n-1, NULL if identity
-    cholmod_common *cc      // workspace and parameters
-) ;
-template int64_t SuiteSparseQR <double, int64_t>
-(
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int64_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_dense  *B,      // m-by-nrhs dense matrix
-    // outputs
-    cholmod_dense  **C,     // C = Q'*B, an e-by-nrhs dense matrix
-    cholmod_sparse **R,     // e-by-n sparse matrix where e=max(econ,rank(A))
-    int64_t **E,               // permutation of 0:n-1, NULL if identity
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, int32_t econ, cholmod_sparse *A, cholmod_dense *B,
+    cholmod_dense **C, cholmod_sparse **R, int32_t **E, cholmod_common *cc
 ) ;
 
 template int32_t SuiteSparseQR <Complex, int32_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int32_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_dense  *B,      // m-by-nrhs dense matrix
-    // outputs
-    cholmod_dense  **C,     // C = Q'*B, an e-by-nrhs dense matrix
-    cholmod_sparse **R,     // e-by-n sparse matrix where e=max(econ,rank(A))
-    int32_t **E,               // permutation of 0:n-1, NULL if identity
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, int32_t econ, cholmod_sparse *A, cholmod_dense *B,
+    cholmod_dense **C, cholmod_sparse **R, int32_t **E, cholmod_common *cc
 ) ;
+
+template int64_t SuiteSparseQR <double, int64_t>
+(
+    int ordering, double tol, int64_t econ, cholmod_sparse *A, cholmod_dense *B,
+    cholmod_dense **C, cholmod_sparse **R, int64_t **E, cholmod_common *cc
+) ;
+
 template int64_t SuiteSparseQR <Complex, int64_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int64_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_dense  *B,      // m-by-nrhs dense matrix
-    // outputs
-    cholmod_dense  **C,     // C = Q'*B, an e-by-nrhs dense matrix
-    cholmod_sparse **R,     // e-by-n sparse matrix where e=max(econ,rank(A))
-    int64_t **E,               // permutation of 0:n-1, NULL if identity
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, int64_t econ, cholmod_sparse *A, cholmod_dense *B,
+    cholmod_dense **C, cholmod_sparse **R, int64_t **E, cholmod_common *cc
 ) ;
+
 
 // -----------------------------------------------------------------------------
 // [C,R,E] = qr(A,B) where C and B are both sparse
@@ -1740,64 +1420,37 @@ template <typename Entry, typename Int> Int SuiteSparseQR
         C, NULL, R, E, NULL, NULL, NULL, cc)) ;
 }
 
+
+// explicit instantiations
+
 template int32_t SuiteSparseQR <double, int32_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int32_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_sparse *B,      // m-by-nrhs sparse matrix
-    // outputs
-    cholmod_sparse **C,     // C = Q'*B, an e-by-nrhs sparse matrix
-    cholmod_sparse **R,     // e-by-n sparse matrix where e=max(econ,rank(A))
-    int32_t **E,               // permutation of 0:n-1, NULL if identity
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, int32_t econ,
+    cholmod_sparse *A, cholmod_sparse *B,
+    cholmod_sparse **C, cholmod_sparse **R, int32_t **E, cholmod_common *cc
 ) ;
-template int64_t SuiteSparseQR <double, int64_t>
-(
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int64_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_sparse *B,      // m-by-nrhs sparse matrix
-    // outputs
-    cholmod_sparse **C,     // C = Q'*B, an e-by-nrhs sparse matrix
-    cholmod_sparse **R,     // e-by-n sparse matrix where e=max(econ,rank(A))
-    int64_t **E,               // permutation of 0:n-1, NULL if identity
-    cholmod_common *cc      // workspace and parameters
-) ;
-
 
 template int32_t SuiteSparseQR <Complex, int32_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int32_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_sparse *B,      // m-by-nrhs sparse matrix
-    // outputs
-    cholmod_sparse **C,     // C = Q'*B, an e-by-nrhs sparse matrix
-    cholmod_sparse **R,     // e-by-n sparse matrix where e=max(econ,rank(A))
-    int32_t **E,               // permutation of 0:n-1, NULL if identity
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, int32_t econ,
+    cholmod_sparse *A, cholmod_sparse *B,
+    cholmod_sparse **C, cholmod_sparse **R, int32_t **E, cholmod_common *cc
 ) ;
+
+template int64_t SuiteSparseQR <double, int64_t>
+(
+    int ordering, double tol, int64_t econ,
+    cholmod_sparse *A, cholmod_sparse *B,
+    cholmod_sparse **C, cholmod_sparse **R, int64_t **E, cholmod_common *cc
+) ;
+
 template int64_t SuiteSparseQR <Complex, int64_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int64_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    cholmod_sparse *B,      // m-by-nrhs sparse matrix
-    // outputs
-    cholmod_sparse **C,     // C = Q'*B, an e-by-nrhs sparse matrix
-    cholmod_sparse **R,     // e-by-n sparse matrix where e=max(econ,rank(A))
-    int64_t **E,               // permutation of 0:n-1, NULL if identity
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, int64_t econ,
+    cholmod_sparse *A, cholmod_sparse *B,
+    cholmod_sparse **C, cholmod_sparse **R, int64_t **E, cholmod_common *cc
 ) ;
+
 
 // -----------------------------------------------------------------------------
 // [Q,R,E] = qr(A) where Q is returned in Householder form
@@ -1809,13 +1462,13 @@ template <typename Entry, typename Int> Int SuiteSparseQR
     // inputs, not modified
     int ordering,           // all, except 3:given treated as 0:fixed
     double tol,             // columns with 2-norm <= tol are treated as zero
-    Int econ,              // e = max(min(m,econ),rank(A))
+    Int econ,               // e = max(min(m,econ),rank(A))
     cholmod_sparse *A,      // m-by-n sparse matrix
     // outputs
     cholmod_sparse **R,     // the R factor
-    Int **E,               // permutation of 0:n-1, NULL if identity
+    Int **E,                // permutation of 0:n-1, NULL if identity
     cholmod_sparse **H,     // the Householder vectors (m-by-nh)
-    Int **HPinv,           // size m; row permutation for H
+    Int **HPinv,            // size m; row permutation for H
     cholmod_dense **HTau,   // size 1-by-nh, Householder coefficients
     cholmod_common *cc      // workspace and parameters
 )
@@ -1824,69 +1477,37 @@ template <typename Entry, typename Int> Int SuiteSparseQR
         NULL, NULL, NULL, NULL, R, E, H, HPinv, HTau, cc)) ;
 }
 
+
+// explicit instantiations
+
 template int32_t SuiteSparseQR <double, int32_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int32_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    // outputs
-    cholmod_sparse **R,     // the R factor
-    int32_t **E,               // permutation of 0:n-1, NULL if identity
-    cholmod_sparse **H,     // the Householder vectors (m-by-nh)
-    int32_t **HPinv,           // size m; row permutation for H
-    cholmod_dense **HTau,   // size 1-by-nh, Householder coefficients
-    cholmod_common *cc      // workspace and parameters
-) ;
-
-template int64_t SuiteSparseQR <double, int64_t>
-(
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int64_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    // outputs
-    cholmod_sparse **R,     // the R factor
-    int64_t **E,               // permutation of 0:n-1, NULL if identity
-    cholmod_sparse **H,     // the Householder vectors (m-by-nh)
-    int64_t **HPinv,           // size m; row permutation for H
-    cholmod_dense **HTau,   // size 1-by-nh, Householder coefficients
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, int32_t econ, cholmod_sparse *A,
+    cholmod_sparse **R, int32_t **E, cholmod_sparse **H, int32_t **HPinv,
+    cholmod_dense **HTau, cholmod_common *cc
 ) ;
 
 template int32_t SuiteSparseQR <Complex, int32_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int32_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    // outputs
-    cholmod_sparse **R,     // the R factor
-    int32_t **E,               // permutation of 0:n-1, NULL if identity
-    cholmod_sparse **H,     // the Householder vectors (m-by-nh)
-    int32_t **HPinv,           // size m; row permutation for H
-    cholmod_dense **HTau,   // size 1-by-nh, Householder coefficients
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, int32_t econ, cholmod_sparse *A,
+    cholmod_sparse **R, int32_t **E, cholmod_sparse **H, int32_t **HPinv,
+    cholmod_dense **HTau, cholmod_common *cc
+) ;
+
+template int64_t SuiteSparseQR <double, int64_t>
+(
+    int ordering, double tol, int64_t econ, cholmod_sparse *A,
+    cholmod_sparse **R, int64_t **E, cholmod_sparse **H, int64_t **HPinv,
+    cholmod_dense **HTau, cholmod_common *cc
 ) ;
 
 template int64_t SuiteSparseQR <Complex, int64_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // columns with 2-norm <= tol are treated as zero
-    int64_t econ,              // e = max(min(m,econ),rank(A))
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    // outputs
-    cholmod_sparse **R,     // the R factor
-    int64_t **E,               // permutation of 0:n-1, NULL if identity
-    cholmod_sparse **H,     // the Householder vectors (m-by-nh)
-    int64_t **HPinv,           // size m; row permutation for H
-    cholmod_dense **HTau,   // size 1-by-nh, Householder coefficients
-    cholmod_common *cc      // workspace and parameters
+    int ordering, double tol, int64_t econ, cholmod_sparse *A,
+    cholmod_sparse **R, int64_t **E, cholmod_sparse **H, int64_t **HPinv,
+    cholmod_dense **HTau, cholmod_common *cc
 ) ;
+
 
 template struct spqr_numeric <double, int32_t>;
 template struct spqr_numeric <Complex, int32_t>;

--- a/SPQR/Source/SuiteSparseQR_expert.cpp
+++ b/SPQR/Source/SuiteSparseQR_expert.cpp
@@ -64,7 +64,7 @@ SuiteSparseQR_factorization <Entry, Int> *SuiteSparseQR_symbolic
 
     RETURN_IF_NULL_COMMON (NULL) ;
     RETURN_IF_NULL (A, NULL) ;
-    int64_t xtype = spqr_type <Entry> ( ) ;
+    int xtype = spqr_type <Entry> ( ) ;
     RETURN_IF_XTYPE_INVALID (A, NULL) ;
     cc->status = CHOLMOD_OK ;
 
@@ -155,48 +155,36 @@ SuiteSparseQR_factorization <Entry, Int> *SuiteSparseQR_symbolic
     return (QR) ;
 }
 
+
+// explicit instantiations
+
 template
-SuiteSparseQR_factorization <double, int32_t> *SuiteSparseQR_symbolic <double, int32_t>
+SuiteSparseQR_factorization <double, int32_t> *
+SuiteSparseQR_symbolic <double, int32_t>
 (
-    // inputs:
-    int ordering,           // all, except 3:given treated as 0:fixed
-    int allow_tol,          // if FALSE, tol is ignored by the numeric
-                            // factorization, and no rank detection is performed
-    cholmod_sparse *A,      // sparse matrix to factorize (A->x ignored)
-    cholmod_common *cc      // workspace and parameters
+    int ordering, int allow_tol, cholmod_sparse *A, cholmod_common *cc
 ) ;
 
 template
-SuiteSparseQR_factorization <Complex, int32_t> *SuiteSparseQR_symbolic <Complex, int32_t>
+SuiteSparseQR_factorization <Complex, int32_t> *
+SuiteSparseQR_symbolic <Complex, int32_t>
 (
-    // inputs:
-    int ordering,           // all, except 3:given treated as 0:fixed
-    int allow_tol,          // if FALSE, tol is ignored by the numeric
-                            // factorization, and no rank detection is performed
-    cholmod_sparse *A,      // sparse matrix to factorize (A->x ignored)
-    cholmod_common *cc      // workspace and parameters
+    int ordering, int allow_tol, cholmod_sparse *A, cholmod_common *cc
 ) ;
 template
-SuiteSparseQR_factorization <double, int64_t> *SuiteSparseQR_symbolic <double, int64_t>
+SuiteSparseQR_factorization <double, int64_t> *
+SuiteSparseQR_symbolic <double, int64_t>
 (
-    // inputs:
-    int ordering,           // all, except 3:given treated as 0:fixed
-    int allow_tol,          // if FALSE, tol is ignored by the numeric
-                            // factorization, and no rank detection is performed
-    cholmod_sparse *A,      // sparse matrix to factorize (A->x ignored)
-    cholmod_common *cc      // workspace and parameters
+    int ordering, int allow_tol, cholmod_sparse *A, cholmod_common *cc
 ) ;
 
 template
-SuiteSparseQR_factorization <Complex, int64_t> *SuiteSparseQR_symbolic <Complex, int64_t>
+SuiteSparseQR_factorization <Complex, int64_t> *
+SuiteSparseQR_symbolic <Complex, int64_t>
 (
-    // inputs:
-    int ordering,           // all, except 3:given treated as 0:fixed
-    int allow_tol,          // if FALSE, tol is ignored by the numeric
-                            // factorization, and no rank detection is performed
-    cholmod_sparse *A,      // sparse matrix to factorize (A->x ignored)
-    cholmod_common *cc      // workspace and parameters
+    int ordering, int allow_tol, cholmod_sparse *A, cholmod_common *cc
 ) ;
+
 
 // =============================================================================
 // === SuiteSparseQR_numeric ===================================================
@@ -303,44 +291,34 @@ template <typename Entry, typename Int> int SuiteSparseQR_numeric
     return (TRUE) ;
 }
 
+
+// explicit instantiations
+
 template int SuiteSparseQR_numeric <double, int32_t>
 (
-    // inputs:
-    double tol,             // treat columns with 2-norm <= tol as zero
-    cholmod_sparse *A,      // sparse matrix to factorize
-    // input/output
-    SuiteSparseQR_factorization <double, int32_t> *QR,
-    cholmod_common *cc      // workspace and parameters
+    double tol, cholmod_sparse *A,
+    SuiteSparseQR_factorization <double, int32_t> *QR, cholmod_common *cc
 ) ;
 
 template int SuiteSparseQR_numeric <Complex, int32_t>
 (
-    // inputs:
-    double tol,             // treat columns with 2-norm <= tol as zero
-    cholmod_sparse *A,      // sparse matrix to factorize
-    // input/output
-    SuiteSparseQR_factorization <Complex, int32_t> *QR,
-    cholmod_common *cc      // workspace and parameters
+    double tol, cholmod_sparse *A,
+    SuiteSparseQR_factorization <Complex, int32_t> *QR, cholmod_common *cc
 ) ;
+
 template int SuiteSparseQR_numeric <double, int64_t>
 (
-    // inputs:
-    double tol,             // treat columns with 2-norm <= tol as zero
-    cholmod_sparse *A,      // sparse matrix to factorize
-    // input/output
-    SuiteSparseQR_factorization <double, int64_t> *QR,
-    cholmod_common *cc      // workspace and parameters
+    double tol, cholmod_sparse *A,
+    SuiteSparseQR_factorization <double, int64_t> *QR, cholmod_common *cc
 ) ;
 
 template int SuiteSparseQR_numeric <Complex, int64_t>
 (
-    // inputs:
-    double tol,             // treat columns with 2-norm <= tol as zero
-    cholmod_sparse *A,      // sparse matrix to factorize
-    // input/output
-    SuiteSparseQR_factorization <Complex, int64_t> *QR,
-    cholmod_common *cc      // workspace and parameters
+    double tol, cholmod_sparse *A,
+    SuiteSparseQR_factorization <Complex, int64_t> *QR, cholmod_common *cc
 ) ;
+
+
 // =============================================================================
 // === SuiteSparseQR_factorize =================================================
 // =============================================================================
@@ -386,44 +364,33 @@ SuiteSparseQR_factorization <Entry, Int> *SuiteSparseQR_factorize
         0, NULL, NULL, NULL, cc)) ;
 }
 
-template SuiteSparseQR_factorization <double, int32_t> *SuiteSparseQR_factorize <double, int32_t>
+
+// explicit instantiations
+
+template SuiteSparseQR_factorization <double, int32_t> *
+SuiteSparseQR_factorize <double, int32_t>
 (
-    // inputs, not modified:
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // treat columns with 2-norm <= tol as zero
-    cholmod_sparse *A,      // sparse matrix to factorize
-    // workspace and parameters
-    cholmod_common *cc
+    int ordering, double tol, cholmod_sparse *A, cholmod_common *cc
 ) ;
 
-template SuiteSparseQR_factorization <Complex, int32_t> *SuiteSparseQR_factorize<Complex, int32_t>
+template SuiteSparseQR_factorization <Complex, int32_t> *
+SuiteSparseQR_factorize<Complex, int32_t>
 (
-    // inputs, not modified:
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // treat columns with 2-norm <= tol as zero
-    cholmod_sparse *A,      // sparse matrix to factorize
-    // workspace and parameters
-    cholmod_common *cc
-) ;
-template SuiteSparseQR_factorization <double, int64_t> *SuiteSparseQR_factorize <double, int64_t>
-(
-    // inputs, not modified:
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // treat columns with 2-norm <= tol as zero
-    cholmod_sparse *A,      // sparse matrix to factorize
-    // workspace and parameters
-    cholmod_common *cc
+    int ordering, double tol, cholmod_sparse *A, cholmod_common *cc
 ) ;
 
-template SuiteSparseQR_factorization <Complex, int64_t> *SuiteSparseQR_factorize<Complex, int64_t>
+template SuiteSparseQR_factorization <double, int64_t> *
+SuiteSparseQR_factorize <double, int64_t>
 (
-    // inputs, not modified:
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // treat columns with 2-norm <= tol as zero
-    cholmod_sparse *A,      // sparse matrix to factorize
-    // workspace and parameters
-    cholmod_common *cc
+    int ordering, double tol, cholmod_sparse *A, cholmod_common *cc
 ) ;
+
+template SuiteSparseQR_factorization <Complex, int64_t> *
+SuiteSparseQR_factorize<Complex, int64_t>
+(
+    int ordering, double tol, cholmod_sparse *A, cholmod_common *cc
+) ;
+
 
 // =============================================================================
 // === spqr_private_rtsolve ====================================================
@@ -842,44 +809,32 @@ template <typename Entry, typename Int> cholmod_dense *SuiteSparseQR_solve // re
 }
 
 
-template cholmod_dense *SuiteSparseQR_solve <Complex, int32_t>
+// explicit instantiations
+
+template cholmod_dense *SuiteSparseQR_solve <double, int32_t>
 (
-    // inputs, not modified:
-    int system,                 // which system to solve
-    SuiteSparseQR_factorization <Complex, int32_t> *QR,  // of an m-by-n sparse matrix A
-    cholmod_dense *B,           // right-hand-side, m-by-nrhs or n-by-nrhs
-    // workspace and parameters
-    cholmod_common *cc
+    int system, SuiteSparseQR_factorization <double, int32_t> *QR,
+    cholmod_dense *B, cholmod_common *cc
 ) ;
 
-template cholmod_dense *SuiteSparseQR_solve <Complex, int64_t>
+template cholmod_dense *SuiteSparseQR_solve <Complex, int32_t>
 (
-    // inputs, not modified:
-    int system,                 // which system to solve
-    SuiteSparseQR_factorization <Complex, int64_t> *QR,  // of an m-by-n sparse matrix A
-    cholmod_dense *B,           // right-hand-side, m-by-nrhs or n-by-nrhs
-    // workspace and parameters
-    cholmod_common *cc
+    int system, SuiteSparseQR_factorization <Complex, int32_t> *QR,
+    cholmod_dense *B, cholmod_common *cc
 ) ;
 
 template cholmod_dense *SuiteSparseQR_solve <double, int64_t>
 (
-    // inputs, not modified:
-    int system,                 // which system to solve
-    SuiteSparseQR_factorization <double, int64_t> *QR,   // of an m-by-n sparse matrix A
-    cholmod_dense *B,           // right-hand-side, m-by-nrhs or n-by-nrhs
-    // workspace and parameters
-    cholmod_common *cc
+    int system, SuiteSparseQR_factorization <double, int64_t> *QR,
+    cholmod_dense *B, cholmod_common *cc
 ) ;
-template cholmod_dense *SuiteSparseQR_solve <double, int32_t>
+
+template cholmod_dense *SuiteSparseQR_solve <Complex, int64_t>
 (
-    // inputs, not modified:
-    int system,                 // which system to solve
-    SuiteSparseQR_factorization <double, int32_t> *QR,   // of an m-by-n sparse matrix A
-    cholmod_dense *B,           // right-hand-side, m-by-nrhs or n-by-nrhs
-    // workspace and parameters
-    cholmod_common *cc
+    int system, SuiteSparseQR_factorization <Complex, int64_t> *QR,
+    cholmod_dense *B, cholmod_common *cc
 ) ;
+
 
 // =============================================================================
 // === SuiteSparseQR_solve (sparse case) =======================================
@@ -917,43 +872,32 @@ template <typename Entry, typename Int> cholmod_sparse *SuiteSparseQR_solve // r
     return (Xsparse) ;
 }
 
+
+// explicit instantiations
+
 template cholmod_sparse *SuiteSparseQR_solve <double, int32_t>
 (
-    // inputs, not modified:
-    int system,                 // which system to solve (0,1,2,3)
-    SuiteSparseQR_factorization <double, int32_t> *QR, // of an m-by-n sparse matrix A
-    cholmod_sparse *Bsparse,    // right-hand-side, m-by-nrhs or n-by-nrhs
-    // workspace and parameters
-    cholmod_common *cc
+    int system, SuiteSparseQR_factorization <double, int32_t> *QR,
+    cholmod_sparse *Bsparse, cholmod_common *cc
 ) ;
-template cholmod_sparse *SuiteSparseQR_solve <double, int64_t>
-(
-    // inputs, not modified:
-    int system,                 // which system to solve (0,1,2,3)
-    SuiteSparseQR_factorization <double, int64_t> *QR, // of an m-by-n sparse matrix A
-    cholmod_sparse *Bsparse,    // right-hand-side, m-by-nrhs or n-by-nrhs
-    // workspace and parameters
-    cholmod_common *cc
-) ;
-
 template cholmod_sparse *SuiteSparseQR_solve <Complex, int32_t>
 (
-    // inputs, not modified:
-    int system,                 // which system to solve (0,1,2,3)
-    SuiteSparseQR_factorization <Complex, int32_t> *QR,  // of an m-by-n sparse matrix A
-    cholmod_sparse *Bsparse,    // right-hand-side, m-by-nrhs or n-by-nrhs
-    // workspace and parameters
-    cholmod_common *cc
+    int system, SuiteSparseQR_factorization <Complex, int32_t> *QR,
+    cholmod_sparse *Bsparse, cholmod_common *cc
 ) ;
+
+template cholmod_sparse *SuiteSparseQR_solve <double, int64_t>
+(
+    int system, SuiteSparseQR_factorization <double, int64_t> *QR,
+    cholmod_sparse *Bsparse, cholmod_common *cc
+) ;
+
 template cholmod_sparse *SuiteSparseQR_solve <Complex, int64_t>
 (
-    // inputs, not modified:
-    int system,                 // which system to solve (0,1,2,3)
-    SuiteSparseQR_factorization <Complex, int64_t> *QR,  // of an m-by-n sparse matrix A
-    cholmod_sparse *Bsparse,    // right-hand-side, m-by-nrhs or n-by-nrhs
-    // workspace and parameters
-    cholmod_common *cc
+    int system, SuiteSparseQR_factorization <Complex, int64_t> *QR,
+    cholmod_sparse *Bsparse, cholmod_common *cc
 ) ;
+
 
 // =============================================================================
 // === spqr_private_get_H_vectors ==============================================
@@ -1567,47 +1511,32 @@ template <typename Entry, typename Int> cholmod_dense *SuiteSparseQR_qmult
 }
 
 
+// explicit instantiations
+
 template cholmod_dense *SuiteSparseQR_qmult <double, int32_t>
 (
-    // inputs, not modified
-    int method,             // 0,1,2,3
-    SuiteSparseQR_factorization <double, int32_t> *QR,
-    cholmod_dense *Xdense,  // size m-by-n with leading dimension ldx
-
-    // workspace and parameters
-    cholmod_common *cc
-) ;
-template cholmod_dense *SuiteSparseQR_qmult <double, int64_t>
-(
-    // inputs, not modified
-    int method,             // 0,1,2,3
-    SuiteSparseQR_factorization <double, int64_t> *QR,
-    cholmod_dense *Xdense,  // size m-by-n with leading dimension ldx
-
-    // workspace and parameters
-    cholmod_common *cc
+    int method, SuiteSparseQR_factorization <double, int32_t> *QR,
+    cholmod_dense *Xdense, cholmod_common *cc
 ) ;
 
 template cholmod_dense *SuiteSparseQR_qmult <Complex, int32_t>
 (
-    // inputs, not modified
-    int method,             // 0,1,2,3
-    SuiteSparseQR_factorization <Complex, int32_t> *QR,
-    cholmod_dense *Xdense,  // size m-by-n with leading dimension ldx
-
-    // workspace and parameters
-    cholmod_common *cc
+    int method, SuiteSparseQR_factorization <Complex, int32_t> *QR,
+    cholmod_dense *Xdense, cholmod_common *cc
 ) ;
+
+template cholmod_dense *SuiteSparseQR_qmult <double, int64_t>
+(
+    int method, SuiteSparseQR_factorization <double, int64_t> *QR,
+    cholmod_dense *Xdense, cholmod_common *cc
+) ;
+
 template cholmod_dense *SuiteSparseQR_qmult <Complex, int64_t>
 (
-    // inputs, not modified
-    int method,             // 0,1,2,3
-    SuiteSparseQR_factorization <Complex, int64_t> *QR,
-    cholmod_dense *Xdense,  // size m-by-n with leading dimension ldx
-
-    // workspace and parameters
-    cholmod_common *cc
+    int method, SuiteSparseQR_factorization <Complex, int64_t> *QR,
+    cholmod_dense *Xdense, cholmod_common *cc
 ) ;
+
 
 // =============================================================================
 // === SuiteSparseQR_qmult (sparse case) =======================================
@@ -1646,43 +1575,33 @@ template <typename Entry, typename Int> cholmod_sparse *SuiteSparseQR_qmult
     return (Ysparse) ;
 }
 
+
+// explicit instantiations
+
 template cholmod_sparse *SuiteSparseQR_qmult <double, int32_t>
 (
-    // inputs, not modified
-    int method,                 // 0,1,2,3
-    SuiteSparseQR_factorization <double, int32_t> *QR,
-    cholmod_sparse *Xsparse,    // size m-by-n
-    // workspace and parameters
-    cholmod_common *cc
-) ;
-template cholmod_sparse *SuiteSparseQR_qmult <double, int64_t>
-(
-    // inputs, not modified
-    int method,                 // 0,1,2,3
-    SuiteSparseQR_factorization <double, int64_t> *QR,
-    cholmod_sparse *Xsparse,    // size m-by-n
-    // workspace and parameters
-    cholmod_common *cc
+    int method, SuiteSparseQR_factorization <double, int32_t> *QR,
+    cholmod_sparse *Xsparse, cholmod_common *cc
 ) ;
 
 template cholmod_sparse *SuiteSparseQR_qmult <Complex, int32_t>
 (
-    // inputs, not modified
-    int method,                 // 0,1,2,3
-    SuiteSparseQR_factorization <Complex, int32_t> *QR,
-    cholmod_sparse *Xsparse,    // size m-by-n
-    // workspace and parameters
-    cholmod_common *cc
+    int method, SuiteSparseQR_factorization <Complex, int32_t> *QR,
+    cholmod_sparse *Xsparse, cholmod_common *cc
 ) ;
+
+template cholmod_sparse *SuiteSparseQR_qmult <double, int64_t>
+(
+    int method, SuiteSparseQR_factorization <double, int64_t> *QR,
+    cholmod_sparse *Xsparse, cholmod_common *cc
+) ;
+
 template cholmod_sparse *SuiteSparseQR_qmult <Complex, int64_t>
 (
-    // inputs, not modified
-    int method,                 // 0,1,2,3
-    SuiteSparseQR_factorization <Complex, int64_t> *QR,
-    cholmod_sparse *Xsparse,    // size m-by-n
-    // workspace and parameters
-    cholmod_common *cc
+    int method, SuiteSparseQR_factorization <Complex, int64_t> *QR,
+    cholmod_sparse *Xsparse, cholmod_common *cc
 ) ;
+
 
 // =============================================================================
 // === SuiteSparseQR_free ======================================================
@@ -1701,27 +1620,29 @@ template <typename Entry, typename Int> int SuiteSparseQR_free
     return (TRUE) ;
 }
 
+
+// explicit instantiations
+
 template int SuiteSparseQR_free <double, int32_t>
 (
-    SuiteSparseQR_factorization <double, int32_t> **QR,
-    cholmod_common *cc
-) ;
-template int SuiteSparseQR_free <double, int64_t>
-(
-    SuiteSparseQR_factorization <double, int64_t> **QR,
-    cholmod_common *cc
+    SuiteSparseQR_factorization <double, int32_t> **QR, cholmod_common *cc
 ) ;
 
 template int SuiteSparseQR_free <Complex, int32_t>
 (
-    SuiteSparseQR_factorization <Complex, int32_t> **QR,
-    cholmod_common *cc
+    SuiteSparseQR_factorization <Complex, int32_t> **QR, cholmod_common *cc
 ) ;
+
+template int SuiteSparseQR_free <double, int64_t>
+(
+    SuiteSparseQR_factorization <double, int64_t> **QR, cholmod_common *cc
+) ;
+
 template int SuiteSparseQR_free <Complex, int64_t>
 (
-    SuiteSparseQR_factorization <Complex, int64_t> **QR,
-    cholmod_common *cc
+    SuiteSparseQR_factorization <Complex, int64_t> **QR, cholmod_common *cc
 ) ;
+
 
 // =============================================================================
 // === SuiteSparseQR_min2norm ==================================================
@@ -1794,39 +1715,33 @@ template <typename Entry, typename Int> cholmod_dense *SuiteSparseQR_min2norm
     return (X) ;
 }
 
+
+// explicit instantiations
+
 template cholmod_dense *SuiteSparseQR_min2norm <double, int32_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,
-    cholmod_sparse *A,
-    cholmod_dense *B,
-    cholmod_common *cc
-) ;
-template cholmod_dense *SuiteSparseQR_min2norm <double, int64_t>
-(
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,
-    cholmod_sparse *A,
-    cholmod_dense *B,
+    int ordering, double tol, cholmod_sparse *A, cholmod_dense *B,
     cholmod_common *cc
 ) ;
 
 template cholmod_dense *SuiteSparseQR_min2norm <Complex, int32_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,
-    cholmod_sparse *A,
-    cholmod_dense *B,
+    int ordering, double tol, cholmod_sparse *A, cholmod_dense *B,
     cholmod_common *cc
 ) ;
+
+template cholmod_dense *SuiteSparseQR_min2norm <double, int64_t>
+(
+    int ordering, double tol, cholmod_sparse *A, cholmod_dense *B,
+    cholmod_common *cc
+) ;
+
 template cholmod_dense *SuiteSparseQR_min2norm <Complex, int64_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,
-    cholmod_sparse *A,
-    cholmod_dense *B,
+    int ordering, double tol,cholmod_sparse *A, cholmod_dense *B,
     cholmod_common *cc
 ) ;
+
 
 // =============================================================================
 // === SuiteSparseQR_min2norm (sparse case) ====================================
@@ -1872,37 +1787,30 @@ template <typename Entry, typename Int> cholmod_sparse *SuiteSparseQR_min2norm /
     return (Xsparse) ;
 }
 
+
+// explicit instantiations
+
 template cholmod_sparse *SuiteSparseQR_min2norm <double, int32_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,
-    cholmod_sparse *A,
-    cholmod_sparse *Bsparse,
-    cholmod_common *cc
-) ;
-template cholmod_sparse *SuiteSparseQR_min2norm <double, int64_t>
-(
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,
-    cholmod_sparse *A,
-    cholmod_sparse *Bsparse,
+    int ordering, double tol, cholmod_sparse *A, cholmod_sparse *Bsparse,
     cholmod_common *cc
 ) ;
 
 template cholmod_sparse *SuiteSparseQR_min2norm <Complex, int32_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,
-    cholmod_sparse *A,
-    cholmod_sparse *Bsparse,
+    int ordering, double tol, cholmod_sparse *A, cholmod_sparse *Bsparse,
     cholmod_common *cc
 ) ;
+
+template cholmod_sparse *SuiteSparseQR_min2norm <double, int64_t>
+(
+    int ordering, double tol, cholmod_sparse *A, cholmod_sparse *Bsparse,
+    cholmod_common *cc
+) ;
+
 template cholmod_sparse *SuiteSparseQR_min2norm <Complex, int64_t>
 (
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,
-    cholmod_sparse *A,
-    cholmod_sparse *Bsparse,
+    int ordering, double tol, cholmod_sparse *A, cholmod_sparse *Bsparse,
     cholmod_common *cc
 ) ;
 

--- a/SPQR/Source/SuiteSparseQR_qmult.cpp
+++ b/SPQR/Source/SuiteSparseQR_qmult.cpp
@@ -352,59 +352,32 @@ template <typename Entry, typename Int> cholmod_dense *SuiteSparseQR_qmult
 }
 
 
-// =============================================================================
+// explicit instantiations
+
+template cholmod_dense *SuiteSparseQR_qmult <double, int32_t>
+(
+    int method, cholmod_sparse *H, cholmod_dense *HTau, int32_t *HPinv,
+    cholmod_dense *Xdense, cholmod_common *cc
+) ;
+
+template cholmod_dense *SuiteSparseQR_qmult <Complex, int32_t>
+(
+    int method, cholmod_sparse *H, cholmod_dense *HTau, int32_t *HPinv,
+    cholmod_dense *Xdense, cholmod_common *cc
+) ;
 
 template cholmod_dense *SuiteSparseQR_qmult <double, int64_t>
 (
-    // inputs, not modified
-    int method,             // 0,1,2,3
-    cholmod_sparse *H,      // either m-by-nh or n-by-nh
-    cholmod_dense *HTau,    // size 1-by-nh
-    int64_t *HPinv,            // size mh
-    cholmod_dense *Xdense,  // size m-by-n with leading dimension ldx
-
-    // workspace and parameters
-    cholmod_common *cc
+    int method, cholmod_sparse *H, cholmod_dense *HTau, int64_t *HPinv,
+    cholmod_dense *Xdense, cholmod_common *cc
 ) ;
-template cholmod_dense *SuiteSparseQR_qmult <double, int32_t>
-(
-    // inputs, not modified
-    int method,             // 0,1,2,3
-    cholmod_sparse *H,      // either m-by-nh or n-by-nh
-    cholmod_dense *HTau,    // size 1-by-nh
-    int32_t *HPinv,            // size mh
-    cholmod_dense *Xdense,  // size m-by-n with leading dimension ldx
-
-    // workspace and parameters
-    cholmod_common *cc
-) ;
-
-// =============================================================================
 
 template cholmod_dense *SuiteSparseQR_qmult <Complex, int64_t>
 (
-    // inputs, not modified
-    int method,             // 0,1,2,3
-    cholmod_sparse *H,      // either m-by-nh or n-by-nh
-    cholmod_dense *HTau,    // size 1-by-nh
-    int64_t *HPinv,            // size mh
-    cholmod_dense *Xdense,  // size m-by-n with leading dimension ldx
-
-    // workspace and parameters
-    cholmod_common *cc
+    int method, cholmod_sparse *H, cholmod_dense *HTau, int64_t *HPinv,
+    cholmod_dense *Xdense, cholmod_common *cc
 ) ;
-template cholmod_dense *SuiteSparseQR_qmult <Complex, int32_t>
-(
-    // inputs, not modified
-    int method,             // 0,1,2,3
-    cholmod_sparse *H,      // either m-by-nh or n-by-nh
-    cholmod_dense *HTau,    // size 1-by-nh
-    int32_t *HPinv,            // size mh
-    cholmod_dense *Xdense,  // size m-by-n with leading dimension ldx
 
-    // workspace and parameters
-    cholmod_common *cc
-) ;
 
 // =============================================================================
 // === SuiteSparseQR_qmult (sparse) ============================================
@@ -727,56 +700,28 @@ template <typename Entry, typename Int> cholmod_sparse *SuiteSparseQR_qmult
 }
 
 
-// =============================================================================
+// explicit instantiations
 
 template cholmod_sparse *SuiteSparseQR_qmult <double, int32_t>
 (
-    // inputs, not modified
-    int method,                 // 0,1,2,3
-    cholmod_sparse *H,          // size m-by-nh or n-by-nh
-    cholmod_dense *HTau,        // size 1-by-nh
-    int32_t *HPinv,                // size mh
-    cholmod_sparse *Xsparse,
-
-    // workspace and parameters
-    cholmod_common *cc
+    int method, cholmod_sparse *H, cholmod_dense *HTau, int32_t *HPinv,
+    cholmod_sparse *Xsparse, cholmod_common *cc
 ) ;
-template cholmod_sparse *SuiteSparseQR_qmult <double, int64_t>
-(
-    // inputs, not modified
-    int method,                 // 0,1,2,3
-    cholmod_sparse *H,          // size m-by-nh or n-by-nh
-    cholmod_dense *HTau,        // size 1-by-nh
-    int64_t *HPinv,                // size mh
-    cholmod_sparse *Xsparse,
-
-    // workspace and parameters
-    cholmod_common *cc
-) ;
-
-// =============================================================================
 
 template cholmod_sparse *SuiteSparseQR_qmult <Complex, int32_t>
 (
-    // inputs, not modified
-    int method,                 // 0,1,2,3
-    cholmod_sparse *H,          // size m-by-nh or n-by-nh
-    cholmod_dense *HTau,        // size 1-by-nh
-    int32_t *HPinv,                // size mh
-    cholmod_sparse *Xsparse,
-
-    // workspace and parameters
-    cholmod_common *cc
+    int method, cholmod_sparse *H, cholmod_dense *HTau, int32_t *HPinv,
+    cholmod_sparse *Xsparse, cholmod_common *cc
 ) ;
+
+template cholmod_sparse *SuiteSparseQR_qmult <double, int64_t>
+(
+    int method, cholmod_sparse *H, cholmod_dense *HTau, int64_t *HPinv,
+    cholmod_sparse *Xsparse, cholmod_common *cc
+) ;
+
 template cholmod_sparse *SuiteSparseQR_qmult <Complex, int64_t>
 (
-    // inputs, not modified
-    int method,                 // 0,1,2,3
-    cholmod_sparse *H,          // size m-by-nh or n-by-nh
-    cholmod_dense *HTau,        // size 1-by-nh
-    int64_t *HPinv,                // size mh
-    cholmod_sparse *Xsparse,
-
-    // workspace and parameters
-    cholmod_common *cc
+    int method, cholmod_sparse *H, cholmod_dense *HTau, int64_t *HPinv,
+    cholmod_sparse *Xsparse, cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_1colamd.cpp
+++ b/SPQR/Source/spqr_1colamd.cpp
@@ -714,130 +714,37 @@ template <typename Entry, typename Int> int spqr_1colamd  // TRUE if OK, FALSE o
     return (TRUE) ;
 }
 
-template int spqr_1colamd <double, int32_t>  // TRUE if OK, FALSE otherwise
+
+// explicit instantiations
+
+template int spqr_1colamd <double, int32_t>
 (
-    // inputs, not modified
-    int ordering,           // all available, except 0:fixed and 3:given
-                            // treated as 1:natural
-    double tol,             // only accept singletons above tol
-    int32_t bncols,            // number of columns of B
-    cholmod_sparse *A,      // m-by-n sparse matrix
-
-    // outputs, neither allocated nor defined on input
-
-    int32_t **p_Q1fill,        // size n+bncols, fill-reducing
-                            // or natural ordering
-
-    int32_t **p_R1p,           // size n1rows+1, R1p [k] = # of nonzeros in kth
-                            // row of R1.  NULL if n1cols == 0.
-    int32_t **p_P1inv,         // size m, singleton row inverse permutation.
-                            // If row i of A is the kth singleton row, then
-                            // P1inv [i] = k.  NULL if n1cols is zero.
-
-    cholmod_sparse **p_Y,   // on output, only the first n-n1cols+1 entries of
-                            // Y->p are defined (if Y is not NULL), where
-                            // Y = [A B] or Y = [A2 B2].  If B is empty and
-                            // there are no column singletons, Y is NULL
-
-    int32_t *p_n1cols,         // number of column singletons found
-    int32_t *p_n1rows,         // number of corresponding rows found
-
-    // workspace and parameters
+    int ordering, double tol, int32_t bncols, cholmod_sparse *A,
+    int32_t **p_Q1fill, int32_t **p_R1p, int32_t **p_P1inv,
+    cholmod_sparse **p_Y, int32_t *p_n1cols, int32_t *p_n1rows,
     cholmod_common *cc
 ) ;
 
-template int spqr_1colamd <Complex, int32_t>  // TRUE if OK, FALSE otherwise
+template int spqr_1colamd <Complex, int32_t>
 (
-    // inputs, not modified
-    int ordering,           // all available, except 0:fixed and 3:given
-                            // treated as 1:natural
-    double tol,             // only accept singletons above tol
-    int32_t bncols,            // number of columns of B
-    cholmod_sparse *A,      // m-by-n sparse matrix
-
-    // outputs, neither allocated nor defined on input
-
-    int32_t **p_Q1fill,        // size n+bncols, fill-reducing
-                            // or natural ordering
-
-    int32_t **p_R1p,           // size n1rows+1, R1p [k] = # of nonzeros in kth
-                            // row of R1.  NULL if n1cols == 0.
-    int32_t **p_P1inv,         // size m, singleton row inverse permutation.
-                            // If row i of A is the kth singleton row, then
-                            // P1inv [i] = k.  NULL if n1cols is zero.
-
-    cholmod_sparse **p_Y,   // on output, only the first n-n1cols+1 entries of
-                            // Y->p are defined (if Y is not NULL), where
-                            // Y = [A B] or Y = [A2 B2].  If B is empty and
-                            // there are no column singletons, Y is NULL
-
-    int32_t *p_n1cols,         // number of column singletons found
-    int32_t *p_n1rows,         // number of corresponding rows found
-
-    // workspace and parameters
+    int ordering, double tol, int32_t bncols, cholmod_sparse *A,
+    int32_t **p_Q1fill, int32_t **p_R1p, int32_t **p_P1inv,
+    cholmod_sparse **p_Y, int32_t *p_n1cols, int32_t *p_n1rows,
     cholmod_common *cc
 ) ;
 
-template  int spqr_1colamd <double, int64_t> // TRUE if OK, FALSE otherwise
+template  int spqr_1colamd <double, int64_t>
 (
-    // inputs, not modified
-    int ordering,           // all available, except 0:fixed and 3:given
-                            // treated as 1:natural
-    double tol,             // only accept singletons above tol
-    int64_t bncols,            // number of columns of B
-    cholmod_sparse *A,      // m-by-n sparse matrix
-
-    // outputs, neither allocated nor defined on input
-
-    int64_t **p_Q1fill,        // size n+bncols, fill-reducing
-                            // or natural ordering
-
-    int64_t **p_R1p,           // size n1rows+1, R1p [k] = # of nonzeros in kth
-                            // row of R1.  NULL if n1cols == 0.
-    int64_t **p_P1inv,         // size m, singleton row inverse permutation.
-                            // If row i of A is the kth singleton row, then
-                            // P1inv [i] = k.  NULL if n1cols is zero.
-
-    cholmod_sparse **p_Y,   // on output, only the first n-n1cols+1 entries of
-                            // Y->p are defined (if Y is not NULL), where
-                            // Y = [A B] or Y = [A2 B2].  If B is empty and
-                            // there are no column singletons, Y is NULL
-
-    int64_t *p_n1cols,         // number of column singletons found
-    int64_t *p_n1rows,         // number of corresponding rows found
-
-    // workspace and parameters
+    int ordering, double tol, int64_t bncols, cholmod_sparse *A,
+    int64_t **p_Q1fill, int64_t **p_R1p, int64_t **p_P1inv,
+    cholmod_sparse **p_Y, int64_t *p_n1cols, int64_t *p_n1rows,
     cholmod_common *cc
 ) ;
 
-template int spqr_1colamd <Complex, int64_t> // TRUE if OK, FALSE otherwise
+template int spqr_1colamd <Complex, int64_t>
 (
-    // inputs, not modified
-    int ordering,           // all available, except 0:fixed and 3:given
-                            // treated as 1:natural
-    double tol,             // only accept singletons above tol
-    int64_t bncols,            // number of columns of B
-    cholmod_sparse *A,      // m-by-n sparse matrix
-
-    // outputs, neither allocated nor defined on input
-
-    int64_t **p_Q1fill,        // size n+bncols, fill-reducing
-                            // or natural ordering
-
-    int64_t **p_R1p,           // size n1rows+1, R1p [k] = # of nonzeros in kth
-                            // row of R1.  NULL if n1cols == 0.
-    int64_t **p_P1inv,         // size m, singleton row inverse permutation.
-                            // If row i of A is the kth singleton row, then
-                            // P1inv [i] = k.  NULL if n1cols is zero.
-
-    cholmod_sparse **p_Y,   // on output, only the first n-n1cols+1 entries of
-                            // Y->p are defined (if Y is not NULL), where
-                            // Y = [A B] or Y = [A2 B2].  If B is empty and
-                            // there are no column singletons, Y is NULL
-
-    int64_t *p_n1cols,         // number of column singletons found
-    int64_t *p_n1rows,         // number of corresponding rows found
-
-    // workspace and parameters
+    int ordering, double tol, int64_t bncols, cholmod_sparse *A,
+    int64_t **p_Q1fill, int64_t **p_R1p, int64_t **p_P1inv,
+    cholmod_sparse **p_Y, int64_t *p_n1cols, int64_t *p_n1rows,
     cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_1factor.cpp
+++ b/SPQR/Source/spqr_1factor.cpp
@@ -755,78 +755,32 @@ template <typename Entry, typename Int> SuiteSparseQR_factorization <Entry, Int>
 }
 
 
-// =============================================================================
+// explicit instantiations
 
-template SuiteSparseQR_factorization <Complex, int32_t> *spqr_1factor <Complex, int32_t>
+template SuiteSparseQR_factorization <double, int32_t> *
+spqr_1factor <double, int32_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // only accept singletons above tol.  If tol <= -2,
-                            // then use the default tolerance
-    int32_t bncols,            // number of columns of B
-    int keepH,              // if TRUE, keep the Householder vectors
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    int32_t ldb,               // if dense, the leading dimension of B
-    int32_t *Bp,               // size bncols+1, column pointers of B
-    int32_t *Bi,               // size bnz = Bp [bncols], row indices of B
-    Complex *Bx,              // size bnz, numerical values of B
-
-    // workspace and parameters
-    cholmod_common *cc
+    int ordering, double tol, int32_t bncols, int keepH, cholmod_sparse *A,
+    int32_t ldb, int32_t *Bp, int32_t *Bi, double *Bx, cholmod_common *cc
 ) ;
 
-
-template SuiteSparseQR_factorization <double, int32_t> *spqr_1factor <double, int32_t>
+template SuiteSparseQR_factorization <Complex, int32_t> *
+spqr_1factor <Complex, int32_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // only accept singletons above tol.  If tol <= -2,
-                            // then use the default tolerance
-    int32_t bncols,            // number of columns of B
-    int keepH,              // if TRUE, keep the Householder vectors
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    int32_t ldb,               // if dense, the leading dimension of B
-    int32_t *Bp,               // size bncols+1, column pointers of B
-    int32_t *Bi,               // size bnz = Bp [bncols], row indices of B
-    double *Bx,              // size bnz, numerical values of B
-
-    // workspace and parameters
-    cholmod_common *cc
+    int ordering, double tol, int32_t bncols, int keepH, cholmod_sparse *A,
+    int32_t ldb, int32_t *Bp, int32_t *Bi, Complex *Bx, cholmod_common *cc
 ) ;
 
-template SuiteSparseQR_factorization <Complex, int64_t> *spqr_1factor <Complex, int64_t>
+template SuiteSparseQR_factorization <double, int64_t> *
+spqr_1factor <double, int64_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // only accept singletons above tol.  If tol <= -2,
-                            // then use the default tolerance
-    int64_t bncols,            // number of columns of B
-    int keepH,              // if TRUE, keep the Householder vectors
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    int64_t ldb,               // if dense, the leading dimension of B
-    int64_t *Bp,               // size bncols+1, column pointers of B
-    int64_t *Bi,               // size bnz = Bp [bncols], row indices of B
-    Complex *Bx,              // size bnz, numerical values of B
-
-    // workspace and parameters
-    cholmod_common *cc
+    int ordering, double tol, int64_t bncols, int keepH, cholmod_sparse *A,
+    int64_t ldb, int64_t *Bp, int64_t *Bi, double *Bx, cholmod_common *cc
 ) ;
 
-
-template SuiteSparseQR_factorization <double, int64_t> *spqr_1factor <double, int64_t>
+template SuiteSparseQR_factorization <Complex, int64_t> *
+spqr_1factor <Complex, int64_t>
 (
-    // inputs, not modified
-    int ordering,           // all, except 3:given treated as 0:fixed
-    double tol,             // only accept singletons above tol.  If tol <= -2,
-                            // then use the default tolerance
-    int64_t bncols,            // number of columns of B
-    int keepH,              // if TRUE, keep the Householder vectors
-    cholmod_sparse *A,      // m-by-n sparse matrix
-    int64_t ldb,               // if dense, the leading dimension of B
-    int64_t *Bp,               // size bncols+1, column pointers of B
-    int64_t *Bi,               // size bnz = Bp [bncols], row indices of B
-    double *Bx,              // size bnz, numerical values of B
-
-    // workspace and parameters
-    cholmod_common *cc
+    int ordering, double tol, int64_t bncols, int keepH, cholmod_sparse *A,
+    int64_t ldb, int64_t *Bp, int64_t *Bi, Complex *Bx, cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_1fixed.cpp
+++ b/SPQR/Source/spqr_1fixed.cpp
@@ -304,110 +304,32 @@ template <typename Entry, typename Int> int spqr_1fixed
 }
 
 
-// =============================================================================
-
-template int spqr_1fixed <Complex, int32_t>
-(
-    // inputs, not modified
-    double tol,             // only accept singletons above tol
-    int32_t bncols,            // number of columns of B
-    cholmod_sparse *A,      // m-by-n sparse matrix
-
-    // output arrays, neither allocated nor defined on input.
-
-    int32_t **p_R1p,           // size n1rows+1, R1p [k] = # of nonzeros in kth
-                            // row of R1.  NULL if n1cols == 0.
-    int32_t **p_P1inv,         // size m, singleton row inverse permutation.
-                            // If row i of A is the kth singleton row, then
-                            // P1inv [i] = k.  NULL if n1cols is zero.
-
-    cholmod_sparse **p_Y,   // on output, only the first n-n1cols+1 entries of
-                            // Y->p are defined (if Y is not NULL), where
-                            // Y = [A B] or Y = [A2 B2].  If B is empty and
-                            // there are no column singletons, Y is NULL
-
-    int32_t *p_n1cols,         // number of column singletons found
-    int32_t *p_n1rows,         // number of corresponding rows found
-
-    // workspace and parameters
-    cholmod_common *cc
-) ;
-template int spqr_1fixed <Complex, int64_t>
-(
-    // inputs, not modified
-    double tol,             // only accept singletons above tol
-    int64_t bncols,            // number of columns of B
-    cholmod_sparse *A,      // m-by-n sparse matrix
-
-    // output arrays, neither allocated nor defined on input.
-
-    int64_t **p_R1p,           // size n1rows+1, R1p [k] = # of nonzeros in kth
-                            // row of R1.  NULL if n1cols == 0.
-    int64_t **p_P1inv,         // size m, singleton row inverse permutation.
-                            // If row i of A is the kth singleton row, then
-                            // P1inv [i] = k.  NULL if n1cols is zero.
-
-    cholmod_sparse **p_Y,   // on output, only the first n-n1cols+1 entries of
-                            // Y->p are defined (if Y is not NULL), where
-                            // Y = [A B] or Y = [A2 B2].  If B is empty and
-                            // there are no column singletons, Y is NULL
-
-    int64_t *p_n1cols,         // number of column singletons found
-    int64_t *p_n1rows,         // number of corresponding rows found
-
-    // workspace and parameters
-    cholmod_common *cc
-) ;
+// explicit instantiations
 
 template int spqr_1fixed <double, int32_t>
 (
-    // inputs, not modified
-    double tol,             // only accept singletons above tol
-    int32_t bncols,            // number of columns of B
-    cholmod_sparse *A,      // m-by-n sparse matrix
-
-    // output arrays, neither allocated nor defined on input.
-
-    int32_t **p_R1p,           // size n1rows+1, R1p [k] = # of nonzeros in kth
-                            // row of R1.  NULL if n1cols == 0.
-    int32_t **p_P1inv,         // size m, singleton row inverse permutation.
-                            // If row i of A is the kth singleton row, then
-                            // P1inv [i] = k.  NULL if n1cols is zero.
-
-    cholmod_sparse **p_Y,   // on output, only the first n-n1cols+1 entries of
-                            // Y->p are defined (if Y is not NULL), where
-                            // Y = [A B] or Y = [A2 B2].  If B is empty and
-                            // there are no column singletons, Y is NULL
-
-    int32_t *p_n1cols,         // number of column singletons found
-    int32_t *p_n1rows,         // number of corresponding rows found
-
-    // workspace and parameters
-    cholmod_common *cc
+    double tol, int32_t bncols, cholmod_sparse *A,
+    int32_t **p_R1p, int32_t **p_P1inv, cholmod_sparse **p_Y,
+    int32_t *p_n1cols, int32_t *p_n1rows, cholmod_common *cc
 ) ;
+
+template int spqr_1fixed <Complex, int32_t>
+(
+    double tol, int32_t bncols, cholmod_sparse *A,
+    int32_t **p_R1p, int32_t **p_P1inv, cholmod_sparse **p_Y,
+    int32_t *p_n1cols, int32_t *p_n1rows, cholmod_common *cc
+) ;
+
 template int spqr_1fixed <double, int64_t>
 (
-    // inputs, not modified
-    double tol,             // only accept singletons above tol
-    int64_t bncols,            // number of columns of B
-    cholmod_sparse *A,      // m-by-n sparse matrix
+    double tol, int64_t bncols, cholmod_sparse *A,
+    int64_t **p_R1p, int64_t **p_P1inv, cholmod_sparse **p_Y,
+    int64_t *p_n1cols, int64_t *p_n1rows, cholmod_common *cc
+) ;
 
-    // output arrays, neither allocated nor defined on input.
-
-    int64_t **p_R1p,           // size n1rows+1, R1p [k] = # of nonzeros in kth
-                            // row of R1.  NULL if n1cols == 0.
-    int64_t **p_P1inv,         // size m, singleton row inverse permutation.
-                            // If row i of A is the kth singleton row, then
-                            // P1inv [i] = k.  NULL if n1cols is zero.
-
-    cholmod_sparse **p_Y,   // on output, only the first n-n1cols+1 entries of
-                            // Y->p are defined (if Y is not NULL), where
-                            // Y = [A B] or Y = [A2 B2].  If B is empty and
-                            // there are no column singletons, Y is NULL
-
-    int64_t *p_n1cols,         // number of column singletons found
-    int64_t *p_n1rows,         // number of corresponding rows found
-
-    // workspace and parameters
-    cholmod_common *cc
+template int spqr_1fixed <Complex, int64_t>
+(
+    double tol, int64_t bncols, cholmod_sparse *A,
+    int64_t **p_R1p, int64_t **p_P1inv, cholmod_sparse **p_Y,
+    int64_t *p_n1cols, int64_t *p_n1rows, cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_analyze.cpp
+++ b/SPQR/Source/spqr_analyze.cpp
@@ -1800,42 +1800,17 @@ template <typename Int> spqr_symbolic <Int> *spqr_analyze
     return (QRsym) ;
 }
 
+
+// explicit instantiations
+
 template spqr_symbolic <int32_t> *spqr_analyze <int32_t>
 (
-    // inputs, not modified
-    cholmod_sparse *A,
-    int ordering,           // all options available
-    int32_t *Quser,            // user provided ordering, if given (may be NULL)
-
-    int do_rank_detection,  // if TRUE, then rank deficient matrices may be
-                            // considered during numerical factorization,
-    // with tol >= 0 (tol < 0 is also allowed).  If FALSE, then the tol
-    // parameter is ignored by the numerical factorization, and no rank
-    // detection is performed.  Ignored when using GPU acceleration
-    // (no rank detection is performed in that case).
-
-    int keepH,              // if TRUE, keep the Householder vectors
-
-    // workspace and parameters
-    cholmod_common *cc
+    cholmod_sparse *A, int ordering, int32_t *Quser, int do_rank_detection,
+    int keepH, cholmod_common *cc
 ) ;
 
 template spqr_symbolic <int64_t> *spqr_analyze <int64_t>
 (
-    // inputs, not modified
-    cholmod_sparse *A,
-    int ordering,           // all options available
-    int64_t *Quser,            // user provided ordering, if given (may be NULL)
-
-    int do_rank_detection,  // if TRUE, then rank deficient matrices may be
-                            // considered during numerical factorization,
-    // with tol >= 0 (tol < 0 is also allowed).  If FALSE, then the tol
-    // parameter is ignored by the numerical factorization, and no rank
-    // detection is performed.  Ignored when using GPU acceleration
-    // (no rank detection is performed in that case).
-
-    int keepH,              // if TRUE, keep the Householder vectors
-
-    // workspace and parameters
-    cholmod_common *cc
+    cholmod_sparse *A, int ordering, int64_t *Quser, int do_rank_detection,
+    int keepH, cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_append.cpp
+++ b/SPQR/Source/spqr_append.cpp
@@ -134,62 +134,25 @@ template <typename Entry, typename Int> int spqr_append       // TRUE/FALSE if O
     return (TRUE) ;
 }
 
-template int spqr_append <double, int32_t>       // TRUE/FALSE if OK or not
+
+// explicit instantiations
+
+template int spqr_append <double, int32_t>
 (
-    // inputs, not modified
-    double *X,           // size m-by-1
-    int32_t *P,            // size m, or NULL; permutation to apply to X.
-                        // P [k] = i if row k of A is row i of X
-
-    // input/output
-    cholmod_sparse *A,  // size m-by-(A->ncol) where A->ncol > n must hold
-    int32_t *p_n,          // n = # of columns of A so far; increased one
-
-    // workspace and parameters
-    cholmod_common *cc
+    double *X, int32_t *P, cholmod_sparse *A, int32_t *p_n, cholmod_common *cc
 ) ;
 
-template int spqr_append <Complex, int32_t>       // TRUE/FALSE if OK or not
+template int spqr_append <Complex, int32_t>
 (
-    // inputs, not modified
-    Complex *X,           // size m-by-1
-    int32_t *P,            // size m, or NULL; permutation to apply to X.
-                        // P [k] = i if row k of A is row i of X
-
-    // input/output
-    cholmod_sparse *A,  // size m-by-(A->ncol) where A->ncol > n must hold
-    int32_t *p_n,          // n = # of columns of A so far; increased one
-
-    // workspace and parameters
-    cholmod_common *cc
+    Complex *X, int32_t *P, cholmod_sparse *A, int32_t *p_n, cholmod_common *cc
 ) ;
 
-template int spqr_append <double, int64_t>       // TRUE/FALSE if OK or not
+template int spqr_append <double, int64_t>
 (
-    // inputs, not modified
-    double *X,           // size m-by-1
-    int64_t *P,            // size m, or NULL; permutation to apply to X.
-                        // P [k] = i if row k of A is row i of X
-
-    // input/output
-    cholmod_sparse *A,  // size m-by-(A->ncol) where A->ncol > n must hold
-    int64_t *p_n,          // n = # of columns of A so far; increased one
-
-    // workspace and parameters
-    cholmod_common *cc
+    double *X, int64_t *P, cholmod_sparse *A, int64_t *p_n, cholmod_common *cc
 ) ;
 
-template int spqr_append <Complex, int64_t>       // TRUE/FALSE if OK or not
+template int spqr_append <Complex, int64_t>
 (
-    // inputs, not modified
-    Complex *X,           // size m-by-1
-    int64_t *P,            // size m, or NULL; permutation to apply to X.
-                        // P [k] = i if row k of A is row i of X
-
-    // input/output
-    cholmod_sparse *A,  // size m-by-(A->ncol) where A->ncol > n must hold
-    int64_t *p_n,          // n = # of columns of A so far; increased one
-
-    // workspace and parameters
-    cholmod_common *cc
+    Complex *X, int64_t *P, cholmod_sparse *A, int64_t *p_n, cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_assemble.cpp
+++ b/SPQR/Source/spqr_assemble.cpp
@@ -445,143 +445,54 @@ template <typename Entry, typename Int> void spqr_assemble
     /* the Stair is now complete */
     ASSERT (Stair [fn-1] == fm) ;
 }
+
+
+// explicit instantiations
+
 template void spqr_assemble <double, int32_t>
 (
-    /* inputs, not modified */
-    int32_t f,                 /* front to assemble F */
-    int32_t fm,                /* number of rows of F */
-    int keepH,              /* if TRUE, then construct row pattern of H */
-    int32_t *Super,
-    int32_t *Rp,
-    int32_t *Rj,
-    int32_t *Sp,
-    int32_t *Sj,
-    int32_t *Sleft,
-    int32_t *Child,
-    int32_t *Childp,
-    double *Sx,
-    int32_t *Fmap,
-    int32_t *Cm,
-    double **Cblock,
+    int32_t f, int32_t fm, int keepH, int32_t *Super, int32_t *Rp, int32_t *Rj,
+    int32_t *Sp, int32_t *Sj, int32_t *Sleft, int32_t *Child, int32_t *Childp,
+    double *Sx, int32_t *Fmap, int32_t *Cm, double **Cblock,
 #ifndef NDEBUG
     char *Rdead,
 #endif
     int32_t *Hr,
-
-    /* input/output */
-    int32_t *Stair,
-    int32_t *Hii,              /* if keepH, construct list of row indices for F */
-    // input only
-    int32_t *Hip,
-
-    /* outputs, not defined on input */
-    double *F,
-
-    /* workspace, not defined on input or output */
-    int32_t *Cmap
+    int32_t *Stair, int32_t *Hii, int32_t *Hip,double *F, int32_t *Cmap
 ) ;
+
 template void spqr_assemble <Complex, int32_t>
 (
-    /* inputs, not modified */
-    int32_t f,                 /* front to assemble F */
-    int32_t fm,                /* number of rows of F */
-    int keepH,              /* if TRUE, then construct row pattern of H */
-    int32_t *Super,
-    int32_t *Rp,
-    int32_t *Rj,
-    int32_t *Sp,
-    int32_t *Sj,
-    int32_t *Sleft,
-    int32_t *Child,
-    int32_t *Childp,
-    Complex *Sx,
-    int32_t *Fmap,
-    int32_t *Cm,
-    Complex **Cblock,
+    int32_t f, int32_t fm, int keepH, int32_t *Super, int32_t *Rp, int32_t *Rj,
+    int32_t *Sp, int32_t *Sj, int32_t *Sleft, int32_t *Child, int32_t *Childp,
+    Complex *Sx, int32_t *Fmap, int32_t *Cm, Complex **Cblock,
 #ifndef NDEBUG
     char *Rdead,
 #endif
     int32_t *Hr,
-
-    /* input/output */
-    int32_t *Stair,
-    int32_t *Hii,              /* if keepH, construct list of row indices for F */
-    // input only
-    int32_t *Hip,
-
-    /* outputs, not defined on input */
-    Complex *F,
-
-    /* workspace, not defined on input or output */
-    int32_t *Cmap
+    int32_t *Stair, int32_t *Hii, int32_t *Hip, Complex *F,int32_t *Cmap
 ) ;
+
 template void spqr_assemble <double, int64_t>
 (
-    /* inputs, not modified */
-    int64_t f,                 /* front to assemble F */
-    int64_t fm,                /* number of rows of F */
-    int keepH,              /* if TRUE, then construct row pattern of H */
-    int64_t *Super,
-    int64_t *Rp,
-    int64_t *Rj,
-    int64_t *Sp,
-    int64_t *Sj,
-    int64_t *Sleft,
-    int64_t *Child,
-    int64_t *Childp,
-    double *Sx,
-    int64_t *Fmap,
-    int64_t *Cm,
-    double **Cblock,
+    int64_t f, int64_t fm, int keepH, int64_t *Super, int64_t *Rp, int64_t *Rj,
+    int64_t *Sp, int64_t *Sj, int64_t *Sleft, int64_t *Child, int64_t *Childp,
+    double *Sx, int64_t *Fmap, int64_t *Cm, double **Cblock,
 #ifndef NDEBUG
     char *Rdead,
 #endif
     int64_t *Hr,
-
-    /* input/output */
-    int64_t *Stair,
-    int64_t *Hii,              /* if keepH, construct list of row indices for F */
-    // input only
-    int64_t *Hip,
-
-    /* outputs, not defined on input */
-    double *F,
-
-    /* workspace, not defined on input or output */
-    int64_t *Cmap
+    int64_t *Stair, int64_t *Hii, int64_t *Hip, double *F, int64_t *Cmap
 ) ;
+
 template void spqr_assemble <Complex, int64_t>
 (
-    /* inputs, not modified */
-    int64_t f,                 /* front to assemble F */
-    int64_t fm,                /* number of rows of F */
-    int keepH,              /* if TRUE, then construct row pattern of H */
-    int64_t *Super,
-    int64_t *Rp,
-    int64_t *Rj,
-    int64_t *Sp,
-    int64_t *Sj,
-    int64_t *Sleft,
-    int64_t *Child,
-    int64_t *Childp,
-    Complex *Sx,
-    int64_t *Fmap,
-    int64_t *Cm,
-    Complex **Cblock,
+    int64_t f, int64_t fm, int keepH, int64_t *Super, int64_t *Rp, int64_t *Rj,
+    int64_t *Sp, int64_t *Sj, int64_t *Sleft, int64_t *Child, int64_t *Childp,
+    Complex *Sx, int64_t *Fmap, int64_t *Cm, Complex **Cblock,
 #ifndef NDEBUG
     char *Rdead,
 #endif
     int64_t *Hr,
-
-    /* input/output */
-    int64_t *Stair,
-    int64_t *Hii,              /* if keepH, construct list of row indices for F */
-    // input only
-    int64_t *Hip,
-
-    /* outputs, not defined on input */
-    Complex *F,
-
-    /* workspace, not defined on input or output */
-    int64_t *Cmap
+    int64_t *Stair, int64_t *Hii, int64_t *Hip, Complex *F, int64_t *Cmap
 ) ;

--- a/SPQR/Source/spqr_cholmod_wrappers.cpp
+++ b/SPQR/Source/spqr_cholmod_wrappers.cpp
@@ -1,55 +1,44 @@
 #include "spqr.hpp"
-template <> void *spqr_malloc <int64_t> (size_t n, size_t size, cholmod_common *Common)
-{
-    return cholmod_l_malloc (n, size, Common) ;
-}
+
+// template specializations for int32_t and int64_t
+
 template <> void *spqr_malloc <int32_t> (size_t n, size_t size, cholmod_common *Common)
 {
     return cholmod_malloc (n, size, Common) ;
 }
-
-template <> void *spqr_calloc <int64_t> (size_t n, size_t size, cholmod_common *Common)
+template <> void *spqr_malloc <int64_t> (size_t n, size_t size, cholmod_common *Common)
 {
-    return cholmod_l_calloc (n, size, Common) ;
+    return cholmod_l_malloc (n, size, Common) ;
 }
+
 template <> void *spqr_calloc <int32_t> (size_t n, size_t size, cholmod_common *Common)
 {
     return cholmod_calloc (n, size, Common) ;
 }
-
-template <> void *spqr_free <int64_t> (size_t n, size_t size, void *p, cholmod_common *Common)
+template <> void *spqr_calloc <int64_t> (size_t n, size_t size, cholmod_common *Common)
 {
-    return cholmod_l_free (n, size, p, Common) ;
+    return cholmod_l_calloc (n, size, Common) ;
 }
+
 template <> void *spqr_free <int32_t> (size_t n, size_t size, void *p, cholmod_common *Common)
 {
     return cholmod_free (n, size, p, Common) ;
 }
+template <> void *spqr_free <int64_t> (size_t n, size_t size, void *p, cholmod_common *Common)
+{
+    return cholmod_l_free (n, size, p, Common) ;
+}
 
-template <> void *spqr_realloc <int32_t>	/* returns pointer to reallocated block */
+template <> void *spqr_realloc <int32_t>
 (
-    /* ---- input ---- */
-    size_t nnew,	/* requested # of items in reallocated block */
-    size_t size,	/* size of each item */
-    /* ---- in/out --- */
-    void *p,		/* block of memory to realloc */
-    size_t *n,		/* current size on input, nnew on output if successful*/
-    /* --------------- */
-    cholmod_common *Common
+    size_t nnew, size_t size, void *p, size_t *n, cholmod_common *Common
 )
 {
     return cholmod_realloc (nnew, size, p, n, Common) ;
 }
-template <> void *spqr_realloc <int64_t>	/* returns pointer to reallocated block */
+template <> void *spqr_realloc <int64_t>
 (
-    /* ---- input ---- */
-    size_t nnew,	/* requested # of items in reallocated block */
-    size_t size,	/* size of each item */
-    /* ---- in/out --- */
-    void *p,		/* block of memory to realloc */
-    size_t *n,		/* current size on input, nnew on output if successful*/
-    /* --------------- */
-    cholmod_common *Common
+    size_t nnew, size_t size, void *p, size_t *n, cholmod_common *Common
 )
 {
     return cholmod_l_realloc (nnew, size, p, n, Common) ;
@@ -57,32 +46,16 @@ template <> void *spqr_realloc <int64_t>	/* returns pointer to reallocated block
 
 template <> cholmod_sparse *spqr_allocate_sparse <int32_t>
 (
-    /* ---- input ---- */
-    size_t nrow,	/* # of rows of A */
-    size_t ncol,	/* # of columns of A */
-    size_t nzmax,	/* max # of nonzeros of A */
-    int sorted,		/* TRUE if columns of A sorted, FALSE otherwise */
-    int packed,		/* TRUE if A will be packed, FALSE otherwise */
-    int stype,		/* stype of A */
-    int xtype,		/* CHOLMOD_PATTERN, _REAL, _COMPLEX, or _ZOMPLEX */
-    /* --------------- */
-    cholmod_common *Common
+    size_t nrow, size_t ncol, size_t nzmax, int sorted, int packed,
+    int stype, int xtype, cholmod_common *Common
 )
 {
     return cholmod_allocate_sparse (nrow, ncol, nzmax, sorted, packed, stype, xtype, Common) ;
 }
 template <> cholmod_sparse *spqr_allocate_sparse <int64_t>
 (
-    /* ---- input ---- */
-    size_t nrow,	/* # of rows of A */
-    size_t ncol,	/* # of columns of A */
-    size_t nzmax,	/* max # of nonzeros of A */
-    int sorted,		/* TRUE if columns of A sorted, FALSE otherwise */
-    int packed,		/* TRUE if A will be packed, FALSE otherwise */
-    int stype,		/* stype of A */
-    int xtype,		/* CHOLMOD_PATTERN, _REAL, _COMPLEX, or _ZOMPLEX */
-    /* --------------- */
-    cholmod_common *Common
+    size_t nrow, size_t ncol, size_t nzmax, int sorted, int packed,
+    int stype, int xtype, cholmod_common *Common
 )
 {
     return cholmod_l_allocate_sparse (nrow, ncol, nzmax, sorted, packed, stype, xtype, Common) ;
@@ -90,20 +63,14 @@ template <> cholmod_sparse *spqr_allocate_sparse <int64_t>
 
 template <> int spqr_free_sparse <int32_t>
 (
-    /* ---- in/out --- */
-    cholmod_sparse **A,	/* matrix to deallocate, NULL on output */
-    /* --------------- */
-    cholmod_common *Common
+    cholmod_sparse **A, cholmod_common *Common
 )
 {
     return cholmod_free_sparse (A, Common) ;
 }
 template <> int spqr_free_sparse <int64_t>
 (
-    /* ---- in/out --- */
-    cholmod_sparse **A,	/* matrix to deallocate, NULL on output */
-    /* --------------- */
-    cholmod_common *Common
+    cholmod_sparse **A, cholmod_common *Common
 )
 {
     return cholmod_l_free_sparse (A, Common) ;
@@ -111,24 +78,14 @@ template <> int spqr_free_sparse <int64_t>
 
 template <> int spqr_reallocate_sparse <int32_t>
 (
-    /* ---- input ---- */
-    size_t nznew,	/* new # of entries in A */
-    /* ---- in/out --- */
-    cholmod_sparse *A,	/* matrix to reallocate */
-    /* --------------- */
-    cholmod_common *Common
+    size_t nznew, cholmod_sparse *A, cholmod_common *Common
 )
 {
     return cholmod_reallocate_sparse (nznew, A, Common) ;
 }
 template <> int spqr_reallocate_sparse <int64_t>
 (
-    /* ---- input ---- */
-    size_t nznew,	/* new # of entries in A */
-    /* ---- in/out --- */
-    cholmod_sparse *A,	/* matrix to reallocate */
-    /* --------------- */
-    cholmod_common *Common
+    size_t nznew, cholmod_sparse *A, cholmod_common *Common
 )
 {
     return cholmod_l_reallocate_sparse (nznew, A, Common) ;
@@ -136,13 +93,7 @@ template <> int spqr_reallocate_sparse <int64_t>
 
 template <> cholmod_dense *spqr_allocate_dense <int32_t>
 (
-    /* ---- input ---- */
-    size_t nrow,	/* # of rows of matrix */
-    size_t ncol,	/* # of columns of matrix */
-    size_t d,		/* leading dimension */
-    int xtype,		/* CHOLMOD_REAL, _COMPLEX, or _ZOMPLEX */
-    /* --------------- */
-    cholmod_common *Common
+    size_t nrow, size_t ncol, size_t d, int xtype, cholmod_common *Common
 )
 {
     return cholmod_allocate_dense (nrow, ncol, d, xtype, Common) ;
@@ -150,13 +101,7 @@ template <> cholmod_dense *spqr_allocate_dense <int32_t>
 
 template <> cholmod_dense *spqr_allocate_dense <int64_t>
 (
-    /* ---- input ---- */
-    size_t nrow,	/* # of rows of matrix */
-    size_t ncol,	/* # of columns of matrix */
-    size_t d,		/* leading dimension */
-    int xtype,		/* CHOLMOD_REAL, _COMPLEX, or _ZOMPLEX */
-    /* --------------- */
-    cholmod_common *Common
+    size_t nrow, size_t ncol, size_t d, int xtype, cholmod_common *Common
 )
 {
     return cholmod_l_allocate_dense (nrow, ncol, d, xtype, Common) ;
@@ -164,20 +109,14 @@ template <> cholmod_dense *spqr_allocate_dense <int64_t>
 
 template <> int spqr_free_dense <int32_t>
 (
-    /* ---- in/out --- */
-    cholmod_dense **X,	/* dense matrix to deallocate, NULL on output */
-    /* --------------- */
-    cholmod_common *Common
+    cholmod_dense **X, cholmod_common *Common
 )
 {
     return cholmod_free_dense (X, Common) ;
 }
 template <> int spqr_free_dense <int64_t>
 (
-    /* ---- in/out --- */
-    cholmod_dense **X,	/* dense matrix to deallocate, NULL on output */
-    /* --------------- */
-    cholmod_common *Common
+    cholmod_dense **X, cholmod_common *Common
 )
 {
     return cholmod_l_free_dense (X, Common) ;
@@ -185,20 +124,14 @@ template <> int spqr_free_dense <int64_t>
 
 template <> cholmod_factor *spqr_allocate_factor <int32_t>
 (
-    /* ---- input ---- */
-    size_t n,		/* L is n-by-n */
-    /* --------------- */
-    cholmod_common *Common
+    size_t n, cholmod_common *Common
 )
 {
     return cholmod_allocate_factor (n, Common) ;
 }
 template <> cholmod_factor *spqr_allocate_factor <int64_t>
 (
-    /* ---- input ---- */
-    size_t n,		/* L is n-by-n */
-    /* --------------- */
-    cholmod_common *Common
+    size_t n, cholmod_common *Common
 )
 {
     return cholmod_l_allocate_factor (n, Common) ;
@@ -206,20 +139,14 @@ template <> cholmod_factor *spqr_allocate_factor <int64_t>
 
 template <> int spqr_free_factor <int32_t>
 (
-    /* ---- in/out --- */
-    cholmod_factor **L,	/* factor to free, NULL on output */
-    /* --------------- */
-    cholmod_common *Common
+    cholmod_factor **L, cholmod_common *Common
 )
 {
     return cholmod_free_factor (L, Common) ;
 }
 template <> int spqr_free_factor <int64_t>
 (
-    /* ---- in/out --- */
-    cholmod_factor **L,	/* factor to free, NULL on output */
-    /* --------------- */
-    cholmod_common *Common
+    cholmod_factor **L, cholmod_common *Common
 )
 {
     return cholmod_l_free_factor (L, Common) ;
@@ -227,36 +154,19 @@ template <> int spqr_free_factor <int64_t>
 
 template <> int spqr_allocate_work <int32_t>
 (
-    /* ---- input ---- */
-    size_t nrow,	/* size: Common->Flag (nrow), Common->Head (nrow+1) */
-    size_t iworksize,	/* size of Common->Iwork */
-    size_t xworksize,	/* size of Common->Xwork */
-    /* --------------- */
-    cholmod_common *Common
+    size_t nrow, size_t iworksize, size_t xworksize, cholmod_common *Common
 )
 {
     return cholmod_allocate_work (nrow, iworksize, xworksize, Common) ;
 }
 template <> int spqr_allocate_work <int64_t>
 (
-    /* ---- input ---- */
-    size_t nrow,	/* size: Common->Flag (nrow), Common->Head (nrow+1) */
-    size_t iworksize,	/* size of Common->Iwork */
-    size_t xworksize,	/* size of Common->Xwork */
-    /* --------------- */
-    cholmod_common *Common
+    size_t nrow, size_t iworksize, size_t xworksize, cholmod_common *Common
 )
 {
     return cholmod_l_allocate_work (nrow, iworksize, xworksize, Common) ;
 }
 
-template <> int spqr_amd <int64_t> 
-(
-    cholmod_sparse *A, int64_t *fset, size_t fsize, int64_t *Perm, cholmod_common *Common
-)
-{
-    return cholmod_l_amd (A, fset, fsize, Perm, Common) ;
-}
 template <> int spqr_amd <int32_t> 
 (
     cholmod_sparse *A, int32_t *fset, size_t fsize, int32_t *Perm, cholmod_common *Common
@@ -264,13 +174,12 @@ template <> int spqr_amd <int32_t>
 {
     return cholmod_amd (A, fset, fsize, Perm, Common) ;
 }
-
-template <> int spqr_metis <int64_t> 
+template <> int spqr_amd <int64_t> 
 (
-    cholmod_sparse *A, int64_t *fset, size_t fsize, int postorder, int64_t *Perm, cholmod_common *Common
+    cholmod_sparse *A, int64_t *fset, size_t fsize, int64_t *Perm, cholmod_common *Common
 )
 {
-    return cholmod_l_metis (A, fset, fsize, postorder, Perm, Common) ;
+    return cholmod_l_amd (A, fset, fsize, Perm, Common) ;
 }
 
 template <> int spqr_metis <int32_t> 
@@ -280,14 +189,14 @@ template <> int spqr_metis <int32_t>
 {
     return cholmod_metis (A, fset, fsize, postorder, Perm, Common) ;
 }
-
-template <> cholmod_sparse *spqr_transpose <int64_t> 
+template <> int spqr_metis <int64_t> 
 (
-    cholmod_sparse *A, int values, cholmod_common *Common
+    cholmod_sparse *A, int64_t *fset, size_t fsize, int postorder, int64_t *Perm, cholmod_common *Common
 )
 {
-    return cholmod_l_transpose (A, values, Common) ;
+    return cholmod_l_metis (A, fset, fsize, postorder, Perm, Common) ;
 }
+
 template <> cholmod_sparse *spqr_transpose <int32_t> 
 (
     cholmod_sparse *A, int values, cholmod_common *Common
@@ -295,20 +204,19 @@ template <> cholmod_sparse *spqr_transpose <int32_t>
 {
     return cholmod_transpose (A, values, Common) ;
 }
+template <> cholmod_sparse *spqr_transpose <int64_t> 
+(
+    cholmod_sparse *A, int values, cholmod_common *Common
+)
+{
+    return cholmod_l_transpose (A, values, Common) ;
+}
 
 template <>
 cholmod_factor *spqr_analyze_p2 <int32_t>
 (
-    /* ---- input ---- */
-    int for_whom,       /* FOR_SPQR     (0): for SPQR but not GPU-accelerated
-                           FOR_CHOLESKY (1): for Cholesky (GPU or not)
-                           FOR_SPQRGPU  (2): for SPQR with GPU acceleration */
-    cholmod_sparse *A,	/* matrix to order and analyze */
-    int32_t *UserPerm,	/* user-provided permutation, size A->nrow */
-    int32_t *fset,	/* subset of 0:(A->ncol)-1 */
-    size_t fsize,	/* size of fset */
-    /* --------------- */
-    cholmod_common *Common
+    int for_whom, cholmod_sparse *A, int32_t *UserPerm,
+    int32_t *fset, size_t fsize, cholmod_common *Common
 )
 {
     return cholmod_analyze_p2 (for_whom, A, UserPerm, fset, fsize, Common) ;
@@ -316,16 +224,8 @@ cholmod_factor *spqr_analyze_p2 <int32_t>
 template <>
 cholmod_factor *spqr_analyze_p2 <int64_t>
 (
-    /* ---- input ---- */
-    int for_whom,       /* FOR_SPQR     (0): for SPQR but not GPU-accelerated
-                           FOR_CHOLESKY (1): for Cholesky (GPU or not)
-                           FOR_SPQRGPU  (2): for SPQR with GPU acceleration */
-    cholmod_sparse *A,	/* matrix to order and analyze */
-    int64_t *UserPerm,	/* user-provided permutation, size A->nrow */
-    int64_t *fset,	/* subset of 0:(A->ncol)-1 */
-    size_t fsize,	/* size of fset */
-    /* --------------- */
-    cholmod_common *Common
+    int for_whom, cholmod_sparse *A, int64_t *UserPerm,
+    int64_t *fset, size_t fsize, cholmod_common *Common
 )
 {
     return cholmod_l_analyze_p2 (for_whom, A, UserPerm, fset, fsize, Common) ;
@@ -333,72 +233,38 @@ cholmod_factor *spqr_analyze_p2 <int64_t>
 
 template <> int spqr_colamd <int32_t>
 (
-    /* ---- input ---- */
-    cholmod_sparse *A,	/* matrix to order */
-    int32_t *fset,	/* subset of 0:(A->ncol)-1 */
-    size_t fsize,	/* size of fset */
-    int postorder,	/* if TRUE, follow with a coletree postorder */
-    /* ---- output --- */
-    int32_t *Perm,	/* size A->nrow, output permutation */
-    /* --------------- */
-    cholmod_common *Common
+    cholmod_sparse *A, int32_t *fset, size_t fsize, int postorder,
+    int32_t *Perm, cholmod_common *Common
 )
 {
     return cholmod_colamd (A, fset, fsize, postorder, Perm, Common) ;
 }
 template <> int spqr_colamd <int64_t>
 (
-    /* ---- input ---- */
-    cholmod_sparse *A,	/* matrix to order */
-    int64_t *fset,	/* subset of 0:(A->ncol)-1 */
-    size_t fsize,	/* size of fset */
-    int postorder,	/* if TRUE, follow with a coletree postorder */
-    /* ---- output --- */
-    int64_t *Perm,	/* size A->nrow, output permutation */
-    /* --------------- */
-    cholmod_common *Common
+    cholmod_sparse *A, int64_t *fset, size_t fsize, int postorder,
+    int64_t *Perm, cholmod_common *Common
 )
 {
     return cholmod_l_colamd (A, fset, fsize, postorder, Perm, Common) ;
 }
 
-template <> int32_t spqr_postorder <int32_t>	/* return # of nodes postordered */
+template <> int32_t spqr_postorder <int32_t>
 (
-    /* ---- input ---- */
-    int32_t *Parent,	/* size n. Parent [j] = p if p is the parent of j */
-    size_t n,
-    int32_t *Weight_p,	/* size n, optional. Weight [j] is weight of node j */
-    /* ---- output --- */
-    int32_t *Post,	/* size n. Post [k] = j is kth in postordered tree */
-    /* --------------- */
+    int32_t *Parent, size_t n, int32_t *Weight_p, int32_t *Post,
     cholmod_common *Common
 )
 {
     return cholmod_postorder (Parent, n, Weight_p, Post, Common) ;
 }
-template <> int64_t spqr_postorder <int64_t>	/* return # of nodes postordered */
+template <> int64_t spqr_postorder <int64_t>
 (
-    /* ---- input ---- */
-    int64_t *Parent,	/* size n. Parent [j] = p if p is the parent of j */
-    size_t n,
-    int64_t *Weight_p,	/* size n, optional. Weight [j] is weight of node j */
-    /* ---- output --- */
-    int64_t *Post,	/* size n. Post [k] = j is kth in postordered tree */
-    /* --------------- */
+    int64_t *Parent, size_t n, int64_t *Weight_p, int64_t *Post,
     cholmod_common *Common
 )
 {
     return cholmod_l_postorder (Parent, n, Weight_p, Post, Common) ;
 }
 
-template <> int64_t spqr_nnz <int64_t>
-(
-    cholmod_sparse *A,
-    cholmod_common *Common
-)
-{
-    return cholmod_l_nnz(A, Common) ;
-}
 template <> int64_t spqr_nnz <int32_t>
 (
     cholmod_sparse *A,
@@ -407,25 +273,25 @@ template <> int64_t spqr_nnz <int32_t>
 {
     return cholmod_nnz(A, Common) ;
 }
+template <> int64_t spqr_nnz <int64_t>
+(
+    cholmod_sparse *A,
+    cholmod_common *Common
+)
+{
+    return cholmod_l_nnz(A, Common) ;
+}
 
 template <> cholmod_sparse *spqr_dense_to_sparse <int32_t>
 (
-    /* ---- input ---- */
-    cholmod_dense *X,	/* matrix to copy */
-    int values,		/* TRUE if values to be copied, FALSE otherwise */
-    /* --------------- */
-    cholmod_common *Common
+    cholmod_dense *X, int values, cholmod_common *Common
 )
 {
     return cholmod_dense_to_sparse(X, values, Common) ;
 }
 template <> cholmod_sparse *spqr_dense_to_sparse <int64_t>
 (
-    /* ---- input ---- */
-    cholmod_dense *X,	/* matrix to copy */
-    int values,		/* TRUE if values to be copied, FALSE otherwise */
-    /* --------------- */
-    cholmod_common *Common
+    cholmod_dense *X, int values, cholmod_common *Common
 )
 {
     return cholmod_l_dense_to_sparse(X, values, Common) ;
@@ -433,46 +299,30 @@ template <> cholmod_sparse *spqr_dense_to_sparse <int64_t>
 
 template <> cholmod_dense *spqr_sparse_to_dense <int32_t>
 (
-    /* ---- input ---- */
-    cholmod_sparse *A,	/* matrix to copy */
-    /* --------------- */
-    cholmod_common *Common
+    cholmod_sparse *A, cholmod_common *Common
 )
 {
     return cholmod_sparse_to_dense (A, Common) ;
 }
 template <> cholmod_dense *spqr_sparse_to_dense <int64_t>
 (
-    /* ---- input ---- */
-    cholmod_sparse *A,	/* matrix to copy */
-    /* --------------- */
-    cholmod_common *Common
+    cholmod_sparse *A, cholmod_common *Common
 )
 {
     return cholmod_l_sparse_to_dense (A, Common) ;
 }
 
-template <> cholmod_sparse *spqr_speye <int64_t>
-(
-    /* ---- input ---- */
-    size_t nrow,	/* # of rows of A */
-    size_t ncol,	/* # of columns of A */
-    int xtype,		/* CHOLMOD_PATTERN, _REAL, _COMPLEX, or _ZOMPLEX */
-    /* --------------- */
-    cholmod_common *Common
-)
-{
-    return cholmod_l_speye(nrow, ncol, xtype, Common) ;
-}
 template <> cholmod_sparse *spqr_speye <int32_t>
 (
-    /* ---- input ---- */
-    size_t nrow,	/* # of rows of A */
-    size_t ncol,	/* # of columns of A */
-    int xtype,		/* CHOLMOD_PATTERN, _REAL, _COMPLEX, or _ZOMPLEX */
-    /* --------------- */
-    cholmod_common *Common
+    size_t nrow, size_t ncol, int xtype, cholmod_common *Common
 )
 {
     return cholmod_speye(nrow, ncol, xtype, Common) ;
+}
+template <> cholmod_sparse *spqr_speye <int64_t>
+(
+    size_t nrow, size_t ncol, int xtype, cholmod_common *Common
+)
+{
+    return cholmod_l_speye(nrow, ncol, xtype, Common) ;
 }

--- a/SPQR/Source/spqr_cpack.cpp
+++ b/SPQR/Source/spqr_cpack.cpp
@@ -106,63 +106,26 @@ template <typename Entry, typename Int> Int spqr_cpack     // returns # of rows 
     PR (("Cpack rank %ld cm %ld cn %ld\n", rank, cm, cn)) ;
     return (cm) ;                       // return # of rows in C
 }
-template int32_t spqr_cpack <double, int32_t>     // returns # of rows in C
+
+
+// explicit instantiations
+
+template int32_t spqr_cpack <double, int32_t>
 (
-    // input, not modified
-    int32_t m,                 // # of rows in F
-    int32_t n,                 // # of columns in F
-    int32_t npiv,              // number of pivotal columns in F
-    int32_t rank,              // the C block starts at F (rank,npiv)
-
-    // input, not modified unless the pack occurs in-place
-    double *F,               // m-by-n frontal matrix in column-major order
-
-    // output, contents not defined on input
-    double *C                // packed columns of C, of size cm-by-cn in upper
-                            // trapezoidal form.
+    int32_t m, int32_t n, int32_t npiv, int32_t rank, double *F, double *C
 ) ;
-template int32_t spqr_cpack <Complex, int32_t>     // returns # of rows in C
+
+template int32_t spqr_cpack <Complex, int32_t>
 (
-    // input, not modified
-    int32_t m,                 // # of rows in F
-    int32_t n,                 // # of columns in F
-    int32_t npiv,              // number of pivotal columns in F
-    int32_t rank,              // the C block starts at F (rank,npiv)
-
-    // input, not modified unless the pack occurs in-place
-    Complex *F,               // m-by-n frontal matrix in column-major order
-
-    // output, contents not defined on input
-    Complex *C                // packed columns of C, of size cm-by-cn in upper
-                            // trapezoidal form.
+    int32_t m, int32_t n, int32_t npiv, int32_t rank, Complex *F, Complex *C
 ) ;
-template int64_t spqr_cpack <double, int64_t>     // returns # of rows in C
+
+template int64_t spqr_cpack <double, int64_t>
 (
-    // input, not modified
-    int64_t m,                 // # of rows in F
-    int64_t n,                 // # of columns in F
-    int64_t npiv,              // number of pivotal columns in F
-    int64_t rank,              // the C block starts at F (rank,npiv)
-
-    // input, not modified unless the pack occurs in-place
-    double *F,               // m-by-n frontal matrix in column-major order
-
-    // output, contents not defined on input
-    double *C                // packed columns of C, of size cm-by-cn in upper
-                            // trapezoidal form.
+    int64_t m, int64_t n, int64_t npiv, int64_t rank, double *F, double *C
 ) ;
-template int64_t spqr_cpack <Complex, int64_t>     // returns # of rows in C
+
+template int64_t spqr_cpack <Complex, int64_t>
 (
-    // input, not modified
-    int64_t m,                 // # of rows in F
-    int64_t n,                 // # of columns in F
-    int64_t npiv,              // number of pivotal columns in F
-    int64_t rank,              // the C block starts at F (rank,npiv)
-
-    // input, not modified unless the pack occurs in-place
-    Complex *F,               // m-by-n frontal matrix in column-major order
-
-    // output, contents not defined on input
-    Complex *C                // packed columns of C, of size cm-by-cn in upper
-                            // trapezoidal form.
+    int64_t m, int64_t n, int64_t npiv, int64_t rank, Complex *F, Complex *C
 ) ;

--- a/SPQR/Source/spqr_csize.cpp
+++ b/SPQR/Source/spqr_csize.cpp
@@ -32,19 +32,15 @@ template <typename Int> Int spqr_csize     // returns # of entries in C of a chi
     return (csize) ;
 }
 
-template int32_t spqr_csize <int32_t>     // returns # of entries in C of a child
+
+// explicit instantiations
+
+template int32_t spqr_csize <int32_t>
 (
-    // input, not modified
-    int32_t c,                 // child c
-    int32_t *Rp,               // size nf+1, pointers for pattern of R
-    int32_t *Cm,               // size nf, Cm [c] = # of rows in child C
-    int32_t *Super             // size nf, pivotal columns in each front
+    int32_t c, int32_t *Rp, int32_t *Cm, int32_t *Super
 ) ;
-template int64_t spqr_csize <int64_t>     // returns # of entries in C of a child
+
+template int64_t spqr_csize <int64_t>
 (
-    // input, not modified
-    int64_t c,                 // child c
-    int64_t *Rp,               // size nf+1, pointers for pattern of R
-    int64_t *Cm,               // size nf, Cm [c] = # of rows in child C
-    int64_t *Super             // size nf, pivotal columns in each front
+    int64_t c, int64_t *Rp, int64_t *Cm, int64_t *Super
 ) ;

--- a/SPQR/Source/spqr_cumsum.cpp
+++ b/SPQR/Source/spqr_cumsum.cpp
@@ -46,19 +46,14 @@ template <typename Int> Int spqr_cumsum
     return (itot) ;
 }
 
+
+// explicit instantiations
+
 template int32_t spqr_cumsum <int32_t>
 (
-    // input, not modified
-    int32_t n,
-
-    // input/output
-    int32_t *X                         // size n+1. X = cumsum ([0 X])
+    int32_t n, int32_t *X
 ) ;
 template int64_t spqr_cumsum <int64_t>
 (
-    // input, not modified
-    int64_t n,
-
-    // input/output
-    int64_t *X                         // size n+1. X = cumsum ([0 X])
+    int64_t n, int64_t *X
 ) ;

--- a/SPQR/Source/spqr_debug.cpp
+++ b/SPQR/Source/spqr_debug.cpp
@@ -234,27 +234,18 @@ template <typename Int> Int spqrDebug_rhsize    // returns # of entries in R+H
 }
 
 
-template int32_t spqrDebug_rhsize    // returns # of entries in R+H
+// explicit instantiations
+
+template int32_t spqrDebug_rhsize <int32_t>
 (
-    // input, not modified
-    int32_t m,                 // # of rows in F
-    int32_t n,                 // # of columns in F
-    int32_t npiv,              // number of pivotal columns in F
-    int32_t *Stair,            // size n; column j is dead if Stair [j] == 0.
-                            // Only the first npiv columns can be dead.
-    cholmod_common *cc
+    int32_t m, int32_t n, int32_t npiv, int32_t *Stair, cholmod_common *cc
 ) ;
 
-template int64_t spqrDebug_rhsize    // returns # of entries in R+H
+template int64_t spqrDebug_rhsize <int64_t>
 (
-    // input, not modified
-    int64_t m,                 // # of rows in F
-    int64_t n,                 // # of columns in F
-    int64_t npiv,              // number of pivotal columns in F
-    int64_t *Stair,            // size n; column j is dead if Stair [j] == 0.
-                            // Only the first npiv columns can be dead.
-    cholmod_common *cc
+    int64_t m, int64_t n, int64_t npiv, int64_t *Stair, cholmod_common *cc
 ) ;
+
 
 // =============================================================================
 // === spqrDebug_dump_Parent ===================================================
@@ -276,6 +267,9 @@ template <typename Int> void spqrDebug_dump_Parent (Int n, Int *Parent, const ch
     }
     fclose (pfile) ;
 }
+
+
+// explicit instantiations
 
 template void spqrDebug_dump_Parent <int32_t> (int32_t n, int32_t *Parent, const char *filename) ;
 

--- a/SPQR/Source/spqr_factorize.cpp
+++ b/SPQR/Source/spqr_factorize.cpp
@@ -174,9 +174,9 @@ template <typename Entry, typename Int> spqr_numeric <Entry, Int> *spqr_factoriz
     cholmod_sparse **Ahandle,
 
     // inputs, not modified
-    Int freeA,                     // if TRUE, free A on output
+    Int freeA,                      // if TRUE, free A on output
     double tol,                     // for rank detection
-    Int ntol,                      // apply tol only to first ntol columns
+    Int ntol,                       // apply tol only to first ntol columns
     spqr_symbolic <Int> *QRsym,
 
     // workspace and parameters
@@ -747,59 +747,29 @@ template <typename Entry, typename Int> spqr_numeric <Entry, Int> *spqr_factoriz
     return (QRnum) ;
 }
 
+
+// explicit instantiations
+
 template spqr_numeric <double, int32_t> *spqr_factorize <double, int32_t>
 (
-    // input, optionally freed on output
-    cholmod_sparse **Ahandle,
-
-    // inputs, not modified
-    int32_t freeA,                     // if TRUE, free A on output
-    double tol,                     // for rank detection
-    int32_t ntol,                      // apply tol only to first ntol columns
-    spqr_symbolic <int32_t> *QRsym,
-
-    // workspace and parameters
-    cholmod_common *cc
+    cholmod_sparse **Ahandle, int32_t freeA, double tol, int32_t ntol,
+    spqr_symbolic <int32_t> *QRsym, cholmod_common *cc
 ) ;
+
 template spqr_numeric <Complex, int32_t> *spqr_factorize <Complex, int32_t>
 (
-    // input, optionally freed on output
-    cholmod_sparse **Ahandle,
-
-    // inputs, not modified
-    int32_t freeA,                     // if TRUE, free A on output
-    double tol,                     // for rank detection
-    int32_t ntol,                      // apply tol only to first ntol columns
-    spqr_symbolic <int32_t> *QRsym,
-
-    // workspace and parameters
-    cholmod_common *cc
+    cholmod_sparse **Ahandle, int32_t freeA, double tol, int32_t ntol,
+    spqr_symbolic <int32_t> *QRsym, cholmod_common *cc
 ) ;
+
 template spqr_numeric <double, int64_t> *spqr_factorize <double, int64_t>
 (
-    // input, optionally freed on output
-    cholmod_sparse **Ahandle,
-
-    // inputs, not modified
-    int64_t freeA,                     // if TRUE, free A on output
-    double tol,                     // for rank detection
-    int64_t ntol,                      // apply tol only to first ntol columns
-    spqr_symbolic <int64_t> *QRsym,
-
-    // workspace and parameters
-    cholmod_common *cc
+    cholmod_sparse **Ahandle, int64_t freeA, double tol, int64_t ntol,
+    spqr_symbolic <int64_t> *QRsym, cholmod_common *cc
 ) ;
+
 template spqr_numeric <Complex, int64_t> *spqr_factorize <Complex, int64_t>
 (
-    // input, optionally freed on output
-    cholmod_sparse **Ahandle,
-
-    // inputs, not modified
-    int64_t freeA,                     // if TRUE, free A on output
-    double tol,                     // for rank detection
-    int64_t ntol,                      // apply tol only to first ntol columns
-    spqr_symbolic <int64_t> *QRsym,
-
-    // workspace and parameters
-    cholmod_common *cc
+    cholmod_sparse **Ahandle, int64_t freeA, double tol, int64_t ntol,
+    spqr_symbolic <int64_t> *QRsym, cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_fcsize.cpp
+++ b/SPQR/Source/spqr_fcsize.cpp
@@ -29,19 +29,14 @@ template <typename Int> Int spqr_fcsize    // returns # of entries in C of curre
     return (csize) ;                        // return # of entries in C
 }
 
-template int32_t spqr_fcsize <int32_t>    // returns # of entries in C of current front F
+
+// explicit instantiations
+
+template int32_t spqr_fcsize <int32_t>
 (
-    // input, not modified
-    int32_t m,                 // # of rows in F
-    int32_t n,                 // # of columns in F
-    int32_t npiv,              // number of pivotal columns in F
-    int32_t rank               // the C block starts at F (rank,npiv)
+    int32_t m, int32_t n, int32_t npiv, int32_t rank
 ) ;
-template int64_t spqr_fcsize <int64_t>    // returns # of entries in C of current front F
+template int64_t spqr_fcsize <int64_t>
 (
-    // input, not modified
-    int64_t m,                 // # of rows in F
-    int64_t n,                 // # of columns in F
-    int64_t npiv,              // number of pivotal columns in F
-    int64_t rank               // the C block starts at F (rank,npiv)
+    int64_t m, int64_t n, int64_t npiv, int64_t rank
 ) ;

--- a/SPQR/Source/spqr_freefac.cpp
+++ b/SPQR/Source/spqr_freefac.cpp
@@ -51,32 +51,29 @@ template <typename Entry, typename Int> void spqr_freefac
     *QR_handle = NULL ;
 }
 
-// =============================================================================
+
+// explicit instantiations
+
 template void spqr_freefac <double, int32_t>
 (
     SuiteSparseQR_factorization <double, int32_t> **QR_handle,
-
-    // workspace and parameters
     cholmod_common *cc
 ) ;
+
 template void spqr_freefac <Complex, int32_t>
 (
     SuiteSparseQR_factorization <Complex, int32_t> **QR_handle,
-
-    // workspace and parameters
     cholmod_common *cc
 ) ;
+
 template void spqr_freefac <double, int64_t>
 (
     SuiteSparseQR_factorization <double, int64_t> **QR_handle,
-
-    // workspace and parameters
     cholmod_common *cc
 ) ;
+
 template void spqr_freefac <Complex, int64_t>
 (
     SuiteSparseQR_factorization <Complex, int64_t> **QR_handle,
-
-    // workspace and parameters
     cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_freenum.cpp
+++ b/SPQR/Source/spqr_freenum.cpp
@@ -68,32 +68,29 @@ template <typename Entry, typename Int> void spqr_freenum
     *QRnum_handle = NULL ;
 }
 
+
+// explicit instantiations
+
 template void spqr_freenum <double, int32_t>
 (
     spqr_numeric <double, int32_t> **QRnum_handle,
-
-    // workspace and parameters
     cholmod_common *cc
 ) ;
-template void spqr_freenum <double, int64_t>
-(
-    spqr_numeric <double, int64_t> **QRnum_handle,
 
-    // workspace and parameters
-    cholmod_common *cc
-) ;
 template void spqr_freenum <Complex, int32_t>
 (
     spqr_numeric <Complex, int32_t> **QRnum_handle,
-
-    // workspace and parameters
     cholmod_common *cc
 ) ;
+
+template void spqr_freenum <double, int64_t>
+(
+    spqr_numeric <double, int64_t> **QRnum_handle,
+    cholmod_common *cc
+) ;
+
 template void spqr_freenum <Complex, int64_t>
 (
     spqr_numeric <Complex, int64_t> **QRnum_handle,
-
-    // workspace and parameters
     cholmod_common *cc
 ) ;
-// =============================================================================

--- a/SPQR/Source/spqr_freesym.cpp
+++ b/SPQR/Source/spqr_freesym.cpp
@@ -91,17 +91,15 @@ template <typename Int> void spqr_freesym
     *QRsym_handle = NULL ;
 }
 
+
+// explicit instantiations
+
 template void spqr_freesym <int32_t>
 (
-    spqr_symbolic <int32_t> **QRsym_handle,
-
-    // workspace and parameters
-    cholmod_common *cc
+    spqr_symbolic <int32_t> **QRsym_handle, cholmod_common *cc
 ) ;
+
 template void spqr_freesym <int64_t>
 (
-    spqr_symbolic <int64_t> **QRsym_handle,
-
-    // workspace and parameters
-    cholmod_common *cc
+    spqr_symbolic <int64_t> **QRsym_handle, cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_front.cpp
+++ b/SPQR/Source/spqr_front.cpp
@@ -576,123 +576,33 @@ template <typename Entry, typename Int> Int spqr_front
     return (rank) ;
 }
 
+
+// explicit instantiations
+
 template int32_t spqr_front <double, int32_t>
 (
-    // input, not modified
-    int32_t m,             // F is m-by-n with leading dimension m
-    int32_t n,
-    int32_t npiv,          // number of pivot columns
-    double tol,         // a column is flagged as dead if its norm is <= tol
-    int32_t ntol,          // apply tol only to first ntol pivot columns
-    int32_t fchunk,        // block size for compact WY Householder reflections,
-                        // treated as 1 if fchunk <= 1
-
-    // input/output
-    double *F,           // frontal matrix F of size m-by-n
-    int32_t *Stair,        // size n, entries F (Stair[k]:m-1, k) are all zero,
-                        // for each k = 0:n-1, and remain zero on output.
-    char *Rdead,        // size npiv; all zero on input.  If k is dead,
-                        // Rdead [k] is set to 1
-
-    // output, not defined on input
-    double *Tau,         // size n, Householder coefficients
-
-    // workspace, undefined on input and output
-    double *W,           // size b*n, where b = min (fchunk,n,m)
-
-    // input/output
-    double *wscale,
-    double *wssq,
-
-    cholmod_common *cc
+    int32_t m, int32_t n, int32_t npiv, double tol, int32_t ntol,
+    int32_t fchunk, double *F, int32_t *Stair, char *Rdead, double *Tau,
+    double *W, double *wscale, double *wssq, cholmod_common *cc
 ) ;
+
 template int32_t spqr_front <Complex, int32_t>
 (
-    // input, not modified
-    int32_t m,             // F is m-by-n with leading dimension m
-    int32_t n,
-    int32_t npiv,          // number of pivot columns
-    double tol,         // a column is flagged as dead if its norm is <= tol
-    int32_t ntol,          // apply tol only to first ntol pivot columns
-    int32_t fchunk,        // block size for compact WY Householder reflections,
-                        // treated as 1 if fchunk <= 1
-
-    // input/output
-    Complex *F,           // frontal matrix F of size m-by-n
-    int32_t *Stair,        // size n, entries F (Stair[k]:m-1, k) are all zero,
-                        // for each k = 0:n-1, and remain zero on output.
-    char *Rdead,        // size npiv; all zero on input.  If k is dead,
-                        // Rdead [k] is set to 1
-
-    // output, not defined on input
-    Complex *Tau,         // size n, Householder coefficients
-
-    // workspace, undefined on input and output
-    Complex *W,           // size b*n, where b = min (fchunk,n,m)
-
-    // input/output
-    double *wscale,
-    double *wssq,
-
-    cholmod_common *cc
+    int32_t m, int32_t n, int32_t npiv, double tol, int32_t ntol,
+    int32_t fchunk, Complex *F, int32_t *Stair, char *Rdead, Complex *Tau,
+    Complex *W, double *wscale, double *wssq, cholmod_common *cc
 ) ;
+
 template int64_t spqr_front <double, int64_t>
 (
-    // input, not modified
-    int64_t m,             // F is m-by-n with leading dimension m
-    int64_t n,
-    int64_t npiv,          // number of pivot columns
-    double tol,         // a column is flagged as dead if its norm is <= tol
-    int64_t ntol,          // apply tol only to first ntol pivot columns
-    int64_t fchunk,        // block size for compact WY Householder reflections,
-                        // treated as 1 if fchunk <= 1
-
-    // input/output
-    double *F,           // frontal matrix F of size m-by-n
-    int64_t *Stair,        // size n, entries F (Stair[k]:m-1, k) are all zero,
-                        // for each k = 0:n-1, and remain zero on output.
-    char *Rdead,        // size npiv; all zero on input.  If k is dead,
-                        // Rdead [k] is set to 1
-
-    // output, not defined on input
-    double *Tau,         // size n, Householder coefficients
-
-    // workspace, undefined on input and output
-    double *W,           // size b*n, where b = min (fchunk,n,m)
-
-    // input/output
-    double *wscale,
-    double *wssq,
-
-    cholmod_common *cc
+    int64_t m, int64_t n, int64_t npiv, double tol, int64_t ntol,
+    int64_t fchunk, double *F, int64_t *Stair, char *Rdead, double *Tau,
+    double *W, double *wscale, double *wssq, cholmod_common *cc
 ) ;
+
 template int64_t spqr_front <Complex, int64_t>
 (
-    // input, not modified
-    int64_t m,             // F is m-by-n with leading dimension m
-    int64_t n,
-    int64_t npiv,          // number of pivot columns
-    double tol,         // a column is flagged as dead if its norm is <= tol
-    int64_t ntol,          // apply tol only to first ntol pivot columns
-    int64_t fchunk,        // block size for compact WY Householder reflections,
-                        // treated as 1 if fchunk <= 1
-
-    // input/output
-    Complex *F,           // frontal matrix F of size m-by-n
-    int64_t *Stair,        // size n, entries F (Stair[k]:m-1, k) are all zero,
-                        // for each k = 0:n-1, and remain zero on output.
-    char *Rdead,        // size npiv; all zero on input.  If k is dead,
-                        // Rdead [k] is set to 1
-
-    // output, not defined on input
-    Complex *Tau,         // size n, Householder coefficients
-
-    // workspace, undefined on input and output
-    Complex *W,           // size b*n, where b = min (fchunk,n,m)
-
-    // input/output
-    double *wscale,
-    double *wssq,
-
-    cholmod_common *cc
+    int64_t m, int64_t n, int64_t npiv, double tol, int64_t ntol,
+    int64_t fchunk, Complex *F, int64_t *Stair, char *Rdead, Complex *Tau,
+    Complex *W, double *wscale, double *wssq, cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_fsize.cpp
+++ b/SPQR/Source/spqr_fsize.cpp
@@ -133,35 +133,17 @@ template <typename Int> Int spqr_fsize     // returns # of rows of F
 
     return (fm) ;
 }
-template int32_t spqr_fsize <int32_t>     // returns # of rows of F
-(
-    // inputs, not modified
-    int32_t f,
-    int32_t *Super,            // size nf, from QRsym
-    int32_t *Rp,               // size nf, from QRsym
-    int32_t *Rj,               // size rjsize, from QRsym
-    int32_t *Sleft,            // size n+2, from QRsym
-    int32_t *Child,            // size nf, from QRsym
-    int32_t *Childp,           // size nf+1, from QRsym
-    int32_t *Cm,               // size nf
 
-    // outputs, not defined on input
-    int32_t *Fmap,             // size n
-    int32_t *Stair             // size fn
+
+// explicit instantiations
+
+template int32_t spqr_fsize <int32_t>
+(
+    int32_t f, int32_t *Super, int32_t *Rp, int32_t *Rj, int32_t *Sleft,
+    int32_t *Child, int32_t *Childp, int32_t *Cm, int32_t *Fmap, int32_t *Stair
 ) ;
-template int64_t spqr_fsize <int64_t>     // returns # of rows of F
+template int64_t spqr_fsize <int64_t>
 (
-    // inputs, not modified
-    int64_t f,
-    int64_t *Super,            // size nf, from QRsym
-    int64_t *Rp,               // size nf, from QRsym
-    int64_t *Rj,               // size rjsize, from QRsym
-    int64_t *Sleft,            // size n+2, from QRsym
-    int64_t *Child,            // size nf, from QRsym
-    int64_t *Childp,           // size nf+1, from QRsym
-    int64_t *Cm,               // size nf
-
-    // outputs, not defined on input
-    int64_t *Fmap,             // size n
-    int64_t *Stair             // size fn
+    int64_t f, int64_t *Super, int64_t *Rp, int64_t *Rj, int64_t *Sleft,
+    int64_t *Child, int64_t *Childp, int64_t *Cm, int64_t *Fmap, int64_t *Stair
 ) ;

--- a/SPQR/Source/spqr_happly.cpp
+++ b/SPQR/Source/spqr_happly.cpp
@@ -384,234 +384,62 @@ template <typename Entry, typename Int> void spqr_happly
     }
 }
 
+
+// explicit instantiations
+
 template void spqr_private_do_panel <double, int32_t>
 (
-    // inputs, not modified
-    int method,         // which method to use (0,1,2,3)
-    int32_t m,
-    int32_t n,
-    int32_t v,             // number of Householder vectors in the panel
-    int32_t *Wi,           // Wi [0:v-1] defines the pattern of the panel
-    int32_t h1,            // load H (h1) to H (h2-1) into V
-    int32_t h2,
-
-    // FUTURE : make H cholmod_sparse:
-    int32_t *Hp,           // Householder vectors: mh-by-nh sparse matrix
-    int32_t *Hi,
-    double *Hx,
-
-    double *Tau,         // Householder coefficients (size nh)
-
-    // input/output
-    int32_t *Wmap,         // inverse of Wi on input, set to all EMPTY on output
-    double *X,           // m-by-n with leading dimension m
-
-    // workspace, undefined on input and output
-    double *V,           // dense panel
-    double *C,           // workspace
-    double *W,           // workspace
-    cholmod_common *cc
-) ;
-
-template void spqr_private_do_panel <double, int64_t>
-(
-    // inputs, not modified
-    int method,         // which method to use (0,1,2,3)
-    int64_t m,
-    int64_t n,
-    int64_t v,             // number of Householder vectors in the panel
-    int64_t *Wi,           // Wi [0:v-1] defines the pattern of the panel
-    int64_t h1,            // load H (h1) to H (h2-1) into V
-    int64_t h2,
-
-    // FUTURE : make H cholmod_sparse:
-    int64_t *Hp,           // Householder vectors: mh-by-nh sparse matrix
-    int64_t *Hi,
-    double *Hx,
-
-    double *Tau,         // Householder coefficients (size nh)
-
-    // input/output
-    int64_t *Wmap,         // inverse of Wi on input, set to all EMPTY on output
-    double *X,           // m-by-n with leading dimension m
-
-    // workspace, undefined on input and output
-    double *V,           // dense panel
-    double *C,           // workspace
-    double *W,           // workspace
+    int method, int32_t m, int32_t n, int32_t v, int32_t *Wi,
+    int32_t h1, int32_t h2, int32_t *Hp, int32_t *Hi, double *Hx,
+    double *Tau, int32_t *Wmap, double *X, double *V, double *C, double *W,
     cholmod_common *cc
 ) ;
 
 template void spqr_private_do_panel <Complex, int32_t>
 (
-    // inputs, not modified
-    int method,         // which method to use (0,1,2,3)
-    int32_t m,
-    int32_t n,
-    int32_t v,             // number of Householder vectors in the panel
-    int32_t *Wi,           // Wi [0:v-1] defines the pattern of the panel
-    int32_t h1,            // load H (h1) to H (h2-1) into V
-    int32_t h2,
+    int method, int32_t m, int32_t n, int32_t v, int32_t *Wi,
+    int32_t h1, int32_t h2, int32_t *Hp,  int32_t *Hi, Complex *Hx,
+    Complex *Tau, int32_t *Wmap, Complex *X, Complex *V, Complex *C, Complex *W,
+    cholmod_common *cc
+) ;
 
-    // FUTURE : make H cholmod_sparse:
-    int32_t *Hp,           // Householder vectors: mh-by-nh sparse matrix
-    int32_t *Hi,
-    Complex *Hx,
-
-    Complex *Tau,         // Householder coefficients (size nh)
-
-    // input/output
-    int32_t *Wmap,         // inverse of Wi on input, set to all EMPTY on output
-    Complex *X,           // m-by-n with leading dimension m
-
-    // workspace, undefined on input and output
-    Complex *V,           // dense panel
-    Complex *C,           // workspace
-    Complex *W,           // workspace
+template void spqr_private_do_panel <double, int64_t>
+(
+    int method, int64_t m, int64_t n, int64_t v, int64_t *Wi,
+    int64_t h1, int64_t h2, int64_t *Hp,  int64_t *Hi, double *Hx,
+    double *Tau, int64_t *Wmap, double *X, double *V, double *C, double *W,
     cholmod_common *cc
 ) ;
 
 template void spqr_private_do_panel <Complex, int64_t>
 (
-    // inputs, not modified
-    int method,         // which method to use (0,1,2,3)
-    int64_t m,
-    int64_t n,
-    int64_t v,             // number of Householder vectors in the panel
-    int64_t *Wi,           // Wi [0:v-1] defines the pattern of the panel
-    int64_t h1,            // load H (h1) to H (h2-1) into V
-    int64_t h2,
-
-    // FUTURE : make H cholmod_sparse:
-    int64_t *Hp,           // Householder vectors: mh-by-nh sparse matrix
-    int64_t *Hi,
-    Complex *Hx,
-
-    Complex *Tau,         // Householder coefficients (size nh)
-
-    // input/output
-    int64_t *Wmap,         // inverse of Wi on input, set to all EMPTY on output
-    Complex *X,           // m-by-n with leading dimension m
-
-    // workspace, undefined on input and output
-    Complex *V,           // dense panel
-    Complex *C,           // workspace
-    Complex *W,           // workspace
+    int method, int64_t m, int64_t n, int64_t v, int64_t *Wi,
+    int64_t h1, int64_t h2, int64_t *Hp, int64_t *Hi, Complex *Hx,
+    Complex *Tau, int64_t *Wmap, Complex *X, Complex *V, Complex *C, Complex *W,
     cholmod_common *cc
 ) ;
+
 template void spqr_happly <double, int32_t>
 (
-    // input
-    int method,     // 0,1,2,3
-
-    int32_t m,         // X is m-by-n with leading dimension m
-    int32_t n,
-
-    // FUTURE : make H cholmod_sparse:
-    int32_t nh,        // number of Householder vectors
-    int32_t *Hp,       // size nh+1, column pointers for H
-    int32_t *Hi,       // size hnz = Hp [nh], row indices of H
-    double *Hx,      // size hnz, Householder values.  Note that the first
-                    // entry in each column must be equal to 1.0
-
-    double *Tau,     // size nh
-
-    // input/output
-    double *X,       // size m-by-n with leading dimension m
-
-    // workspace
-    int32_t vmax,
-    int32_t hchunk,
-    int32_t *Wi,       // size vmax
-    int32_t *Wmap,     // size MAX(mh,1) where H is mh-by-nh; all EMPTY
-    double *C,       // size csize
-    double *V,       // size vsize
-    cholmod_common *cc
+    int method, int32_t m, int32_t n, int32_t nh, int32_t *Hp, int32_t *Hi,
+    double *Hx, double *Tau, double *X, int32_t vmax, int32_t hchunk,
+    int32_t *Wi, int32_t *Wmap, double *C, double *V, cholmod_common *cc
 ) ;
 template void spqr_happly <Complex, int32_t>
 (
-    // input
-    int method,     // 0,1,2,3
-
-    int32_t m,         // X is m-by-n with leading dimension m
-    int32_t n,
-
-    // FUTURE : make H cholmod_sparse:
-    int32_t nh,        // number of Householder vectors
-    int32_t *Hp,       // size nh+1, column pointers for H
-    int32_t *Hi,       // size hnz = Hp [nh], row indices of H
-    Complex *Hx,      // size hnz, Householder values.  Note that the first
-                    // entry in each column must be equal to 1.0
-
-    Complex *Tau,     // size nh
-
-    // input/output
-    Complex *X,       // size m-by-n with leading dimension m
-
-    // workspace
-    int32_t vmax,
-    int32_t hchunk,
-    int32_t *Wi,       // size vmax
-    int32_t *Wmap,     // size MAX(mh,1) where H is mh-by-nh; all EMPTY
-    Complex *C,       // size csize
-    Complex *V,       // size vsize
-    cholmod_common *cc
+    int method, int32_t m, int32_t n, int32_t nh,  int32_t *Hp, int32_t *Hi,
+    Complex *Hx, Complex *Tau, Complex *X, int32_t vmax, int32_t hchunk,
+    int32_t *Wi, int32_t *Wmap, Complex *C, Complex *V, cholmod_common *cc
 ) ;
 template void spqr_happly <double, int64_t>
 (
-    // input
-    int method,     // 0,1,2,3
-
-    int64_t m,         // X is m-by-n with leading dimension m
-    int64_t n,
-
-    // FUTURE : make H cholmod_sparse:
-    int64_t nh,        // number of Householder vectors
-    int64_t *Hp,       // size nh+1, column pointers for H
-    int64_t *Hi,       // size hnz = Hp [nh], row indices of H
-    double *Hx,      // size hnz, Householder values.  Note that the first
-                    // entry in each column must be equal to 1.0
-
-    double *Tau,     // size nh
-
-    // input/output
-    double *X,       // size m-by-n with leading dimension m
-
-    // workspace
-    int64_t vmax,
-    int64_t hchunk,
-    int64_t *Wi,       // size vmax
-    int64_t *Wmap,     // size MAX(mh,1) where H is mh-by-nh; all EMPTY
-    double *C,       // size csize
-    double *V,       // size vsize
-    cholmod_common *cc
+    int method, int64_t m, int64_t n, int64_t nh, int64_t *Hp, int64_t *Hi,
+    double *Hx, double *Tau, double *X, int64_t vmax, int64_t hchunk,
+    int64_t *Wi, int64_t *Wmap, double *C, double *V, cholmod_common *cc
 ) ;
 template void spqr_happly <Complex, int64_t>
 (
-    // input
-    int method,     // 0,1,2,3
-
-    int64_t m,         // X is m-by-n with leading dimension m
-    int64_t n,
-
-    // FUTURE : make H cholmod_sparse:
-    int64_t nh,        // number of Householder vectors
-    int64_t *Hp,       // size nh+1, column pointers for H
-    int64_t *Hi,       // size hnz = Hp [nh], row indices of H
-    Complex *Hx,      // size hnz, Householder values.  Note that the first
-                    // entry in each column must be equal to 1.0
-
-    Complex *Tau,     // size nh
-
-    // input/output
-    Complex *X,       // size m-by-n with leading dimension m
-
-    // workspace
-    int64_t vmax,
-    int64_t hchunk,
-    int64_t *Wi,       // size vmax
-    int64_t *Wmap,     // size MAX(mh,1) where H is mh-by-nh; all EMPTY
-    Complex *C,       // size csize
-    Complex *V,       // size vsize
-    cholmod_common *cc
+    int method, int64_t m, int64_t n, int64_t nh, int64_t *Hp, int64_t *Hi,
+    Complex *Hx, Complex *Tau, Complex *X, int64_t vmax, int64_t hchunk,
+    int64_t *Wi, int64_t *Wmap, Complex *C, Complex *V, cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_happly_work.cpp
+++ b/SPQR/Source/spqr_happly_work.cpp
@@ -14,7 +14,7 @@
 template <typename Int> int spqr_happly_work
 (
     // input
-    int method,     // 0,1,2,3 
+    int method,     // 0,1,2,3
 
     Int m,         // X is m-by-n
     Int n,
@@ -25,8 +25,8 @@ template <typename Int> int spqr_happly_work
     Int hchunk,
 
     // outputs; sizes of workspaces needed
-    Int *p_vmax, 
-    Int *p_vsize, 
+    Int *p_vmax,
+    Int *p_vsize,
     Int *p_csize
 )
 {
@@ -100,39 +100,17 @@ template <typename Int> int spqr_happly_work
     return (ok) ;
 }
 
+
+// explicit instantiations
+
 template int spqr_happly_work <int32_t>
 (
-    // input
-    int method,     // 0,1,2,3 
-
-    int32_t m,         // X is m-by-n
-    int32_t n,
-
-    // FUTURE : make H cholmod_sparse:
-    int32_t nh,        // number of Householder vectors
-    int32_t *Hp,       // size nh+1, column pointers for H
-    int32_t hchunk,
-
-    // outputs; sizes of workspaces needed
-    int32_t *p_vmax, 
-    int32_t *p_vsize, 
-    int32_t *p_csize
+    int method, int32_t m, int32_t n, int32_t nh, int32_t *Hp, int32_t hchunk,
+    int32_t *p_vmax, int32_t *p_vsize, int32_t *p_csize
 ) ;
+
 template int spqr_happly_work <int64_t>
 (
-    // input
-    int method,     // 0,1,2,3 
-
-    int64_t m,         // X is m-by-n
-    int64_t n,
-
-    // FUTURE : make H cholmod_sparse:
-    int64_t nh,        // number of Householder vectors
-    int64_t *Hp,       // size nh+1, column pointers for H
-    int64_t hchunk,
-
-    // outputs; sizes of workspaces needed
-    int64_t *p_vmax, 
-    int64_t *p_vsize, 
-    int64_t *p_csize
+    int method, int64_t m, int64_t n, int64_t nh, int64_t *Hp, int64_t hchunk,
+    int64_t *p_vmax, int64_t *p_vsize, int64_t *p_csize
 ) ;

--- a/SPQR/Source/spqr_hpinv.cpp
+++ b/SPQR/Source/spqr_hpinv.cpp
@@ -168,39 +168,29 @@ template <typename Entry, typename Int> void spqr_hpinv
     }
 }
 
+
+// explicit instantiations
+
 template void spqr_hpinv <double, int32_t>
 (
-    // input
-    spqr_symbolic <int32_t> *QRsym,
-    // input/output
-    spqr_numeric <double, int32_t> *QRnum,
-    // workspace
-    int32_t *W              // size QRnum->m
+    spqr_symbolic <int32_t> *QRsym, spqr_numeric <double, int32_t> *QRnum,
+    int32_t *W
 ) ;
+
 template void spqr_hpinv <Complex, int32_t>
 (
-    // input
-    spqr_symbolic <int32_t> *QRsym,
-    // input/output
-    spqr_numeric <Complex, int32_t> *QRnum,
-    // workspace
-    int32_t *W              // size QRnum->m
+    spqr_symbolic <int32_t> *QRsym, spqr_numeric <Complex, int32_t> *QRnum,
+    int32_t *W
 ) ;
+
 template void spqr_hpinv <double, int64_t>
 (
-    // input
-    spqr_symbolic <int64_t> *QRsym,
-    // input/output
-    spqr_numeric <double, int64_t> *QRnum,
-    // workspace
-    int64_t *W              // size QRnum->m
+    spqr_symbolic <int64_t> *QRsym, spqr_numeric <double, int64_t> *QRnum,
+    int64_t *W
 ) ;
+
 template void spqr_hpinv <Complex, int64_t>
 (
-    // input
-    spqr_symbolic <int64_t> *QRsym,
-    // input/output
-    spqr_numeric <Complex, int64_t> *QRnum,
-    // workspace
-    int64_t *W              // size QRnum->m
+    spqr_symbolic <int64_t> *QRsym, spqr_numeric <Complex, int64_t> *QRnum,
+    int64_t *W
 ) ;

--- a/SPQR/Source/spqr_kernel.cpp
+++ b/SPQR/Source/spqr_kernel.cpp
@@ -339,23 +339,25 @@ template <typename Entry, typename Int> void spqr_kernel // _worker
     Work [stack].wssq   = wssq   ;
 }
 
-template void spqr_kernel <double, int32_t> // _worker
+
+// explicit instantiations
+
+template void spqr_kernel <double, int32_t>
 (
-    int32_t task,
-    spqr_blob <double, int32_t> *Blob
+    int32_t task, spqr_blob <double, int32_t> *Blob
 ) ;
-template void spqr_kernel <Complex, int32_t> // _worker
+
+template void spqr_kernel <Complex, int32_t>
 (
-    int32_t task,
-    spqr_blob <Complex, int32_t> *Blob
+    int32_t task, spqr_blob <Complex, int32_t> *Blob
 ) ;
-template void spqr_kernel <double, int64_t> // _worker
+
+template void spqr_kernel <double, int64_t>
 (
-    int64_t task,
-    spqr_blob <double, int64_t> *Blob
+    int64_t task, spqr_blob <double, int64_t> *Blob
 ) ;
-template void spqr_kernel <Complex, int64_t> // _worker
+
+template void spqr_kernel <Complex, int64_t>
 (
-    int64_t task,
-    spqr_blob <Complex, int64_t> *Blob
+    int64_t task, spqr_blob <Complex, int64_t> *Blob
 ) ;

--- a/SPQR/Source/spqr_larftb.cpp
+++ b/SPQR/Source/spqr_larftb.cpp
@@ -156,91 +156,29 @@ template <typename Entry, typename Int> void spqr_larftb
     }
 }
 
+
+// explicit instantiations
+
 template void spqr_larftb <double, int32_t>
 (
-    // inputs, not modified (V is modified and then restored on output)
-    int method,     // 0,1,2,3
-    int32_t m,         // C is m-by-n
-    int32_t n,
-    int32_t k,         // V is v-by-k
-                    // for methods 0 and 1, v = m,
-                    // for methods 2 and 3, v = n
-    int32_t ldc,       // leading dimension of C
-    int32_t ldv,       // leading dimension of V
-    double *V,       // V is v-by-k, unit lower triangular (diag not stored)
-    double *Tau,     // size k, the k Householder coefficients
-
-    // input/output
-    double *C,       // C is m-by-n, with leading dimension ldc
-
-    // workspace, not defined on input or output
-    double *W,       // for methods 0,1: size k*k + n*k
-                    // for methods 2,3: size k*k + m*k
-    cholmod_common *cc
+    int method, int32_t m, int32_t n, int32_t k, int32_t ldc, int32_t ldv,
+    double *V, double *Tau, double *C, double *W, cholmod_common *cc
 ) ;
+
 template void spqr_larftb <Complex, int32_t>
 (
-    // inputs, not modified (V is modified and then restored on output)
-    int method,     // 0,1,2,3
-    int32_t m,         // C is m-by-n
-    int32_t n,
-    int32_t k,         // V is v-by-k
-                    // for methods 0 and 1, v = m,
-                    // for methods 2 and 3, v = n
-    int32_t ldc,       // leading dimension of C
-    int32_t ldv,       // leading dimension of V
-    Complex *V,       // V is v-by-k, unit lower triangular (diag not stored)
-    Complex *Tau,     // size k, the k Householder coefficients
-
-    // input/output
-    Complex *C,       // C is m-by-n, with leading dimension ldc
-
-    // workspace, not defined on input or output
-    Complex *W,       // for methods 0,1: size k*k + n*k
-                    // for methods 2,3: size k*k + m*k
-    cholmod_common *cc
+    int method, int32_t m, int32_t n, int32_t k, int32_t ldc, int32_t ldv,
+    Complex *V, Complex *Tau, Complex *C, Complex *W, cholmod_common *cc
 ) ;
+
 template void spqr_larftb <double, int64_t>
 (
-    // inputs, not modified (V is modified and then restored on output)
-    int method,     // 0,1,2,3
-    int64_t m,         // C is m-by-n
-    int64_t n,
-    int64_t k,         // V is v-by-k
-                    // for methods 0 and 1, v = m,
-                    // for methods 2 and 3, v = n
-    int64_t ldc,       // leading dimension of C
-    int64_t ldv,       // leading dimension of V
-    double *V,       // V is v-by-k, unit lower triangular (diag not stored)
-    double *Tau,     // size k, the k Householder coefficients
-
-    // input/output
-    double *C,       // C is m-by-n, with leading dimension ldc
-
-    // workspace, not defined on input or output
-    double *W,       // for methods 0,1: size k*k + n*k
-                    // for methods 2,3: size k*k + m*k
-    cholmod_common *cc
+    int method, int64_t m, int64_t n, int64_t k, int64_t ldc, int64_t ldv,
+    double *V, double *Tau, double *C, double *W, cholmod_common *cc
 ) ;
+
 template void spqr_larftb <Complex, int64_t>
 (
-    // inputs, not modified (V is modified and then restored on output)
-    int method,     // 0,1,2,3
-    int64_t m,         // C is m-by-n
-    int64_t n,
-    int64_t k,         // V is v-by-k
-                    // for methods 0 and 1, v = m,
-                    // for methods 2 and 3, v = n
-    int64_t ldc,       // leading dimension of C
-    int64_t ldv,       // leading dimension of V
-    Complex *V,       // V is v-by-k, unit lower triangular (diag not stored)
-    Complex *Tau,     // size k, the k Householder coefficients
-
-    // input/output
-    Complex *C,       // C is m-by-n, with leading dimension ldc
-
-    // workspace, not defined on input or output
-    Complex *W,       // for methods 0,1: size k*k + n*k
-                    // for methods 2,3: size k*k + m*k
-    cholmod_common *cc
+    int method, int64_t m, int64_t n, int64_t k, int64_t ldc, int64_t ldv,
+    Complex *V, Complex *Tau, Complex *C, Complex *W, cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_maxcolnorm.cpp
+++ b/SPQR/Source/spqr_maxcolnorm.cpp
@@ -69,35 +69,25 @@ template <typename Entry, typename Int> double spqr_maxcolnorm
     return (maxnorm) ;
 }
 
+
+// explicit instantiations
+
 template double spqr_maxcolnorm <double, int32_t>
 (
-    // inputs, not modified
-    cholmod_sparse *A,
-
-    // workspace and parameters
-    cholmod_common *cc
+    cholmod_sparse *A, cholmod_common *cc
 ) ;
+
 template double spqr_maxcolnorm <Complex, int32_t>
 (
-    // inputs, not modified
-    cholmod_sparse *A,
-
-    // workspace and parameters
-    cholmod_common *cc
+    cholmod_sparse *A, cholmod_common *cc
 ) ;
+
 template double spqr_maxcolnorm <double, int64_t>
 (
-    // inputs, not modified
-    cholmod_sparse *A,
-
-    // workspace and parameters
-    cholmod_common *cc
+    cholmod_sparse *A, cholmod_common *cc
 ) ;
+
 template double spqr_maxcolnorm <Complex, int64_t>
 (
-    // inputs, not modified
-    cholmod_sparse *A,
-
-    // workspace and parameters
-    cholmod_common *cc
+    cholmod_sparse *A, cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_panel.cpp
+++ b/SPQR/Source/spqr_panel.cpp
@@ -147,94 +147,33 @@ template <typename Entry, typename Int> void spqr_panel
     }
 }
 
+
+// explicit instantiations
+
 template void spqr_panel <Complex, int32_t>
 (
-    // input
-    int method,         // 0,1,2,3
-    int32_t m,
-    int32_t n,
-    int32_t v,             // length of the first vector in V
-    int32_t h,             // number of Householder vectors in the panel
-    int32_t *Vi,           // Vi [0:v-1] defines the pattern of the panel
-    Complex *V,           // v-by-h, panel of Householder vectors
-    Complex *Tau,         // size h, Householder coefficients for the panel
-    int32_t ldx,
-
-    // input/output
-    Complex *X,           // m-by-n with leading dimension ldx
-
-    // workspace
-    Complex *C,           // method 0,1: v-by-n;  method 2,3: m-by-v
-    Complex *W,           // method 0,1: h*h+n*h; method 2,3: h*h+m*h
-
-    cholmod_common *cc
-) ;
-
-template void spqr_panel <Complex, int64_t>
-(
-    // input
-    int method,         // 0,1,2,3
-    int64_t m,
-    int64_t n,
-    int64_t v,             // length of the first vector in V
-    int64_t h,             // number of Householder vectors in the panel
-    int64_t *Vi,           // Vi [0:v-1] defines the pattern of the panel
-    Complex *V,           // v-by-h, panel of Householder vectors
-    Complex *Tau,         // size h, Householder coefficients for the panel
-    int64_t ldx,
-
-    // input/output
-    Complex *X,           // m-by-n with leading dimension ldx
-
-    // workspace
-    Complex *C,           // method 0,1: v-by-n;  method 2,3: m-by-v
-    Complex *W,           // method 0,1: h*h+n*h; method 2,3: h*h+m*h
-
+    int method, int32_t m, int32_t n, int32_t v, int32_t h, int32_t *Vi,
+    Complex *V, Complex *Tau, int32_t ldx, Complex *X,  Complex *C, Complex *W,
     cholmod_common *cc
 ) ;
 
 template void spqr_panel <double, int32_t>
 (
-    // input
-    int method,         // 0,1,2,3
-    int32_t m,
-    int32_t n,
-    int32_t v,             // length of the first vector in V
-    int32_t h,             // number of Householder vectors in the panel
-    int32_t *Vi,           // Vi [0:v-1] defines the pattern of the panel
-    double *V,           // v-by-h, panel of Householder vectors
-    double *Tau,         // size h, Householder coefficients for the panel
-    int32_t ldx,
+    int method, int32_t m, int32_t n, int32_t v, int32_t h, int32_t *Vi,
+    double *V, double *Tau, int32_t ldx, double *X,  double *C, double *W,
+    cholmod_common *cc
+) ;
 
-    // input/output
-    double *X,           // m-by-n with leading dimension ldx
-
-    // workspace
-    double *C,           // method 0,1: v-by-n;  method 2,3: m-by-v
-    double *W,           // method 0,1: h*h+n*h; method 2,3: h*h+m*h
-
+template void spqr_panel <Complex, int64_t>
+(
+    int method, int64_t m, int64_t n, int64_t v, int64_t h, int64_t *Vi,
+    Complex *V, Complex *Tau, int64_t ldx, Complex *X, Complex *C, Complex *W,
     cholmod_common *cc
 ) ;
 
 template void spqr_panel <double, int64_t>
 (
-    // input
-    int method,         // 0,1,2,3
-    int64_t m,
-    int64_t n,
-    int64_t v,             // length of the first vector in V
-    int64_t h,             // number of Householder vectors in the panel
-    int64_t *Vi,           // Vi [0:v-1] defines the pattern of the panel
-    double *V,           // v-by-h, panel of Householder vectors
-    double *Tau,         // size h, Householder coefficients for the panel
-    int64_t ldx,
-
-    // input/output
-    double *X,           // m-by-n with leading dimension ldx
-
-    // workspace
-    double *C,           // method 0,1: v-by-n;  method 2,3: m-by-v
-    double *W,           // method 0,1: h*h+n*h; method 2,3: h*h+m*h
-
+    int method, int64_t m, int64_t n, int64_t v, int64_t h, int64_t *Vi,
+    double *V, double *Tau, int64_t ldx, double *X, double *C, double *W,
     cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_parallel.cpp
+++ b/SPQR/Source/spqr_parallel.cpp
@@ -99,28 +99,27 @@ template <typename Entry, typename Int> void spqr_parallel
         spqr_zippy <Entry, Int> (ntasks-1, Blob) ;
     task::spawn_root_and_wait (a) ;
 }
+
+
+// explicit instantiations
+
 template void spqr_parallel <double, int32_t>
 (
-    int32_t ntasks,
-    int nthreads,
-    spqr_blob <double, int32_t> *Blob
+    int32_t ntasks, int nthreads, spqr_blob <double, int32_t> *Blob
 ) ;
+
 template void spqr_parallel <Complex, int32_t>
 (
-    int32_t ntasks,
-    int nthreads,
-    spqr_blob <Complex, int32_t> *Blob
+    int32_t ntasks, int nthreads, spqr_blob <Complex, int32_t> *Blob
 ) ;
+
 template void spqr_parallel <double, int64_t>
 (
-    int64_t ntasks,
-    int nthreads,
-    spqr_blob <double, int64_t> *Blob
+    int64_t ntasks, int nthreads, spqr_blob <double, int64_t> *Blob
 ) ;
+
 template void spqr_parallel <Complex, int64_t>
 (
-    int64_t ntasks,
-    int nthreads,
-    spqr_blob <Complex, int64_t> *Blob
+    int64_t ntasks, int nthreads, spqr_blob <Complex, int64_t> *Blob
 ) ;
 #endif

--- a/SPQR/Source/spqr_rconvert.cpp
+++ b/SPQR/Source/spqr_rconvert.cpp
@@ -304,187 +304,38 @@ template <typename Entry, typename Int> void spqr_rconvert
         row1 += rm ;                        // count the squeezed rows of R
     }
 }
+
+
+// explicit instantiations
+
 template void spqr_rconvert <double, int32_t>
 (
-    // inputs, not modified
-    spqr_symbolic <int32_t> *QRsym,
-    spqr_numeric <double, int32_t> *QRnum,
-
-    int32_t n1rows,        // added to each row index of Ra, Rb, and H
-    int32_t econ,          // only get entries in rows n1rows to econ-1
-    int32_t n2,            // Ra = R (:,0:n2-1), Rb = R (:,n2:n-1)
-    int getT,           // if true, get Rb' instead of Rb
-
-    // input/output
-    // FUTURE : make Ra, Rb, H2 cholmod_sparse:
-    int32_t *Rap,          // size n2+1; on input, Rap [j] is the column pointer
-                        // for Ra.  Incremented on output by the number of
-                        // entries added to column j of Ra.
-
-    // output, not defined on input
-    int32_t *Rai,          // size rnz1 = nnz(Ra); row indices of Ra
-    double *Rax,         // size rnz; numerical values of Ra
-
-    // input/output
-    int32_t *Rbp,          // if getT is false:
-                        // size (n-n2)+1; on input, Rbp [j] is the column
-                        // pointer for Rb.  Incremented on output by the number
-                        // of entries added to column j of Rb.
-                        // if getT is true:
-                        // size econ+1; on input, Rbp [i] is the row
-                        // pointer for Rb.  Incremented on output by the number
-                        // of entries added to row i of Rb.
-
-    // output, not defined on input
-    int32_t *Rbi,          // size rnz2 = nnz(Rb); indices of Rb
-    double *Rbx,         // size rnz2; numerical values of Rb
-
-    // input
-    int32_t *H2p,          // size nh+1; H2p [j] is the column pointer for H.
-                        // H2p, H2i, and H2x are ignored if H was not kept
-                        // during factorization.  nh computed by rcount
-
-    // output, not defined on input
-    int32_t *H2i,          // size hnz = nnz(H); indices of H
-    double *H2x,         // size hnz; numerical values of H
-
-    double *H2Tau        // size nh; Householder coefficients
+    spqr_symbolic <int32_t> *QRsym, spqr_numeric <double, int32_t> *QRnum,
+    int32_t n1rows, int32_t econ, int32_t n2, int getT, int32_t *Rap,
+    int32_t *Rai, double *Rax, int32_t *Rbp, int32_t *Rbi, double *Rbx,
+    int32_t *H2p, int32_t *H2i, double *H2x, double *H2Tau
 ) ;
+
 template void spqr_rconvert <Complex, int32_t>
 (
-    // inputs, not modified
-    spqr_symbolic <int32_t> *QRsym,
-    spqr_numeric <Complex, int32_t> *QRnum,
-
-    int32_t n1rows,        // added to each row index of Ra, Rb, and H
-    int32_t econ,          // only get entries in rows n1rows to econ-1
-    int32_t n2,            // Ra = R (:,0:n2-1), Rb = R (:,n2:n-1)
-    int getT,           // if true, get Rb' instead of Rb
-
-    // input/output
-    // FUTURE : make Ra, Rb, H2 cholmod_sparse:
-    int32_t *Rap,          // size n2+1; on input, Rap [j] is the column pointer
-                        // for Ra.  Incremented on output by the number of
-                        // entries added to column j of Ra.
-
-    // output, not defined on input
-    int32_t *Rai,          // size rnz1 = nnz(Ra); row indices of Ra
-    Complex *Rax,         // size rnz; numerical values of Ra
-
-    // input/output
-    int32_t *Rbp,          // if getT is false:
-                        // size (n-n2)+1; on input, Rbp [j] is the column
-                        // pointer for Rb.  Incremented on output by the number
-                        // of entries added to column j of Rb.
-                        // if getT is true:
-                        // size econ+1; on input, Rbp [i] is the row
-                        // pointer for Rb.  Incremented on output by the number
-                        // of entries added to row i of Rb.
-
-    // output, not defined on input
-    int32_t *Rbi,          // size rnz2 = nnz(Rb); indices of Rb
-    Complex *Rbx,         // size rnz2; numerical values of Rb
-
-    // input
-    int32_t *H2p,          // size nh+1; H2p [j] is the column pointer for H.
-                        // H2p, H2i, and H2x are ignored if H was not kept
-                        // during factorization.  nh computed by rcount
-
-    // output, not defined on input
-    int32_t *H2i,          // size hnz = nnz(H); indices of H
-    Complex *H2x,         // size hnz; numerical values of H
-
-    Complex *H2Tau        // size nh; Householder coefficients
+    spqr_symbolic <int32_t> *QRsym, spqr_numeric <Complex, int32_t> *QRnum,
+    int32_t n1rows, int32_t econ, int32_t n2, int getT, int32_t *Rap,
+    int32_t *Rai, Complex *Rax, int32_t *Rbp, int32_t *Rbi, Complex *Rbx,
+    int32_t *H2p, int32_t *H2i, Complex *H2x, Complex *H2Tau
 ) ;
+
 template void spqr_rconvert <double, int64_t>
 (
-    // inputs, not modified
-    spqr_symbolic <int64_t> *QRsym,
-    spqr_numeric <double, int64_t> *QRnum,
-
-    int64_t n1rows,        // added to each row index of Ra, Rb, and H
-    int64_t econ,          // only get entries in rows n1rows to econ-1
-    int64_t n2,            // Ra = R (:,0:n2-1), Rb = R (:,n2:n-1)
-    int getT,           // if true, get Rb' instead of Rb
-
-    // input/output
-    // FUTURE : make Ra, Rb, H2 cholmod_sparse:
-    int64_t *Rap,          // size n2+1; on input, Rap [j] is the column pointer
-                        // for Ra.  Incremented on output by the number of
-                        // entries added to column j of Ra.
-
-    // output, not defined on input
-    int64_t *Rai,          // size rnz1 = nnz(Ra); row indices of Ra
-    double *Rax,         // size rnz; numerical values of Ra
-
-    // input/output
-    int64_t *Rbp,          // if getT is false:
-                        // size (n-n2)+1; on input, Rbp [j] is the column
-                        // pointer for Rb.  Incremented on output by the number
-                        // of entries added to column j of Rb.
-                        // if getT is true:
-                        // size econ+1; on input, Rbp [i] is the row
-                        // pointer for Rb.  Incremented on output by the number
-                        // of entries added to row i of Rb.
-
-    // output, not defined on input
-    int64_t *Rbi,          // size rnz2 = nnz(Rb); indices of Rb
-    double *Rbx,         // size rnz2; numerical values of Rb
-
-    // input
-    int64_t *H2p,          // size nh+1; H2p [j] is the column pointer for H.
-                        // H2p, H2i, and H2x are ignored if H was not kept
-                        // during factorization.  nh computed by rcount
-
-    // output, not defined on input
-    int64_t *H2i,          // size hnz = nnz(H); indices of H
-    double *H2x,         // size hnz; numerical values of H
-
-    double *H2Tau        // size nh; Householder coefficients
+    spqr_symbolic <int64_t> *QRsym, spqr_numeric <double, int64_t> *QRnum,
+    int64_t n1rows, int64_t econ, int64_t n2, int getT, int64_t *Rap,
+    int64_t *Rai, double *Rax, int64_t *Rbp, int64_t *Rbi, double *Rbx,
+    int64_t *H2p, int64_t *H2i, double *H2x, double *H2Tau
 ) ;
+
 template void spqr_rconvert <Complex, int64_t>
 (
-    // inputs, not modified
-    spqr_symbolic <int64_t> *QRsym,
-    spqr_numeric <Complex, int64_t> *QRnum,
-
-    int64_t n1rows,        // added to each row index of Ra, Rb, and H
-    int64_t econ,          // only get entries in rows n1rows to econ-1
-    int64_t n2,            // Ra = R (:,0:n2-1), Rb = R (:,n2:n-1)
-    int getT,           // if true, get Rb' instead of Rb
-
-    // input/output
-    // FUTURE : make Ra, Rb, H2 cholmod_sparse:
-    int64_t *Rap,          // size n2+1; on input, Rap [j] is the column pointer
-                        // for Ra.  Incremented on output by the number of
-                        // entries added to column j of Ra.
-
-    // output, not defined on input
-    int64_t *Rai,          // size rnz1 = nnz(Ra); row indices of Ra
-    Complex *Rax,         // size rnz; numerical values of Ra
-
-    // input/output
-    int64_t *Rbp,          // if getT is false:
-                        // size (n-n2)+1; on input, Rbp [j] is the column
-                        // pointer for Rb.  Incremented on output by the number
-                        // of entries added to column j of Rb.
-                        // if getT is true:
-                        // size econ+1; on input, Rbp [i] is the row
-                        // pointer for Rb.  Incremented on output by the number
-                        // of entries added to row i of Rb.
-
-    // output, not defined on input
-    int64_t *Rbi,          // size rnz2 = nnz(Rb); indices of Rb
-    Complex *Rbx,         // size rnz2; numerical values of Rb
-
-    // input
-    int64_t *H2p,          // size nh+1; H2p [j] is the column pointer for H.
-                        // H2p, H2i, and H2x are ignored if H was not kept
-                        // during factorization.  nh computed by rcount
-
-    // output, not defined on input
-    int64_t *H2i,          // size hnz = nnz(H); indices of H
-    Complex *H2x,         // size hnz; numerical values of H
-
-    Complex *H2Tau        // size nh; Householder coefficients
+    spqr_symbolic <int64_t> *QRsym, spqr_numeric <Complex, int64_t> *QRnum,
+    int64_t n1rows, int64_t econ, int64_t n2, int getT, int64_t *Rap,
+    int64_t *Rai, Complex *Rax, int64_t *Rbp,int64_t *Rbi, Complex *Rbx,
+    int64_t *H2p, int64_t *H2i, Complex *H2x, Complex *H2Tau
 ) ;

--- a/SPQR/Source/spqr_rcount.cpp
+++ b/SPQR/Source/spqr_rcount.cpp
@@ -219,95 +219,33 @@ template <typename Entry, typename Int> void spqr_rcount
     }
 }
 
+
+// explicit instantiations
+
 template void spqr_rcount <double, int32_t>
 (
-    // inputs, not modified
-    spqr_symbolic <int32_t> *QRsym,
-    spqr_numeric <double, int32_t> *QRnum,
-
-    int32_t n1rows,        // added to each row index of Ra and Rb
-    int32_t econ,          // only get entries in rows n1rows to econ-1
-    int32_t n2,            // Ra = R (:,0:n2-1), Rb = R (:,n2:n-1)
-    int getT,           // if true, count Rb' instead of Rb
-
-    // input/output
-    // FUTURE : make Ra, Rb, H2 cholmod_sparse
-    int32_t *Ra,           // size n2; Ra [j] += nnz (R (:,j)) if j < n2
-    int32_t *Rb,           // If getT is false: size n-n2 and
-                        // Rb [j-n2] += nnz (R (:,j)) if j >= n2.
-                        // If getT is true: size econ, and
-                        // Rb [i] += nnz (R (i, n2:n-1))
-    int32_t *H2p,          // size rjsize+1.  Column pointers for H.
-                        // Only computed if H was kept during factorization.
-                        // Only H2p [0..nh] is used.
-    int32_t *p_nh          // number of Householder vectors (nh <= rjsize)
+    spqr_symbolic <int32_t> *QRsym, spqr_numeric <double, int32_t> *QRnum,
+    int32_t n1rows, int32_t econ, int32_t n2, int getT,
+    int32_t *Ra, int32_t *Rb, int32_t *H2p, int32_t *p_nh
 ) ;
+
 template void spqr_rcount <Complex, int32_t>
 (
-    // inputs, not modified
-    spqr_symbolic <int32_t> *QRsym,
-    spqr_numeric <Complex, int32_t> *QRnum,
-
-    int32_t n1rows,        // added to each row index of Ra and Rb
-    int32_t econ,          // only get entries in rows n1rows to econ-1
-    int32_t n2,            // Ra = R (:,0:n2-1), Rb = R (:,n2:n-1)
-    int getT,           // if true, count Rb' instead of Rb
-
-    // input/output
-    // FUTURE : make Ra, Rb, H2 cholmod_sparse
-    int32_t *Ra,           // size n2; Ra [j] += nnz (R (:,j)) if j < n2
-    int32_t *Rb,           // If getT is false: size n-n2 and
-                        // Rb [j-n2] += nnz (R (:,j)) if j >= n2.
-                        // If getT is true: size econ, and
-                        // Rb [i] += nnz (R (i, n2:n-1))
-    int32_t *H2p,          // size rjsize+1.  Column pointers for H.
-                        // Only computed if H was kept during factorization.
-                        // Only H2p [0..nh] is used.
-    int32_t *p_nh          // number of Householder vectors (nh <= rjsize)
+    spqr_symbolic <int32_t> *QRsym, spqr_numeric <Complex, int32_t> *QRnum,
+    int32_t n1rows, int32_t econ, int32_t n2, int getT, 
+    int32_t *Ra, int32_t *Rb, int32_t *H2p, int32_t *p_nh
 ) ;
+
 template void spqr_rcount <double, int64_t>
 (
-    // inputs, not modified
-    spqr_symbolic <int64_t> *QRsym,
-    spqr_numeric <double, int64_t> *QRnum,
-
-    int64_t n1rows,        // added to each row index of Ra and Rb
-    int64_t econ,          // only get entries in rows n1rows to econ-1
-    int64_t n2,            // Ra = R (:,0:n2-1), Rb = R (:,n2:n-1)
-    int getT,           // if true, count Rb' instead of Rb
-
-    // input/output
-    // FUTURE : make Ra, Rb, H2 cholmod_sparse
-    int64_t *Ra,           // size n2; Ra [j] += nnz (R (:,j)) if j < n2
-    int64_t *Rb,           // If getT is false: size n-n2 and
-                        // Rb [j-n2] += nnz (R (:,j)) if j >= n2.
-                        // If getT is true: size econ, and
-                        // Rb [i] += nnz (R (i, n2:n-1))
-    int64_t *H2p,          // size rjsize+1.  Column pointers for H.
-                        // Only computed if H was kept during factorization.
-                        // Only H2p [0..nh] is used.
-    int64_t *p_nh          // number of Householder vectors (nh <= rjsize)
+    spqr_symbolic <int64_t> *QRsym, spqr_numeric <double, int64_t> *QRnum,
+    int64_t n1rows, int64_t econ, int64_t n2, int getT,
+    int64_t *Ra, int64_t *Rb, int64_t *H2p, int64_t *p_nh
 ) ;
+
 template void spqr_rcount <Complex, int64_t>
 (
-    // inputs, not modified
-    spqr_symbolic <int64_t> *QRsym,
-    spqr_numeric <Complex, int64_t> *QRnum,
-
-    int64_t n1rows,        // added to each row index of Ra and Rb
-    int64_t econ,          // only get entries in rows n1rows to econ-1
-    int64_t n2,            // Ra = R (:,0:n2-1), Rb = R (:,n2:n-1)
-    int getT,           // if true, count Rb' instead of Rb
-
-    // input/output
-    // FUTURE : make Ra, Rb, H2 cholmod_sparse
-    int64_t *Ra,           // size n2; Ra [j] += nnz (R (:,j)) if j < n2
-    int64_t *Rb,           // If getT is false: size n-n2 and
-                        // Rb [j-n2] += nnz (R (:,j)) if j >= n2.
-                        // If getT is true: size econ, and
-                        // Rb [i] += nnz (R (i, n2:n-1))
-    int64_t *H2p,          // size rjsize+1.  Column pointers for H.
-                        // Only computed if H was kept during factorization.
-                        // Only H2p [0..nh] is used.
-    int64_t *p_nh          // number of Householder vectors (nh <= rjsize)
+    spqr_symbolic <int64_t> *QRsym, spqr_numeric <Complex, int64_t> *QRnum,
+    int64_t n1rows, int64_t econ, int64_t n2, int getT,
+    int64_t *Ra, int64_t *Rb, int64_t *H2p, int64_t *p_nh
 ) ;

--- a/SPQR/Source/spqr_rhpack.cpp
+++ b/SPQR/Source/spqr_rhpack.cpp
@@ -144,74 +144,29 @@ template <typename Entry, typename Int> Int spqr_rhpack   // returns # of entrie
     return (R-R0) ;                     // return # of packed entries
 }
 
-template int32_t spqr_rhpack <double, int32_t>   // returns # of entries in R+H
+
+// explicit instantiations
+
+template int32_t spqr_rhpack <double, int32_t>
 (
-    // input, not modified
-    int keepH,              // if true, then H is packed
-    int32_t m,                 // # of rows in F
-    int32_t n,                 // # of columns in F
-    int32_t npiv,              // number of pivotal columns in F
-    int32_t *Stair,            // size npiv; column j is dead if Stair [j] == 0.
-                            // Only the first npiv columns can be dead.
-
-    // input, not modified (unless the pack occurs in-place)
-    double *F,               // m-by-n frontal matrix in column-major order
-
-    // output, contents not defined on input
-    double *R,               // packed columns of R+H
-    int32_t *p_rm              // number of rows in R block
+    int keepH, int32_t m, int32_t n, int32_t npiv, int32_t *Stair, double *F,
+    double *R, int32_t *p_rm
 ) ;
 
-template int32_t spqr_rhpack <Complex, int32_t>   // returns # of entries in R+H
+template int32_t spqr_rhpack <Complex, int32_t>
 (
-    // input, not modified
-    int keepH,              // if true, then H is packed
-    int32_t m,                 // # of rows in F
-    int32_t n,                 // # of columns in F
-    int32_t npiv,              // number of pivotal columns in F
-    int32_t *Stair,            // size npiv; column j is dead if Stair [j] == 0.
-                            // Only the first npiv columns can be dead.
-
-    // input, not modified (unless the pack occurs in-place)
-    Complex *F,               // m-by-n frontal matrix in column-major order
-
-    // output, contents not defined on input
-    Complex *R,               // packed columns of R+H
-    int32_t *p_rm              // number of rows in R block
+    int keepH, int32_t m, int32_t n, int32_t npiv, int32_t *Stair, Complex *F,
+    Complex *R, int32_t *p_rm
 ) ;
 
-template int64_t spqr_rhpack <double, int64_t>   // returns # of entries in R+H
+template int64_t spqr_rhpack <double, int64_t>
 (
-    // input, not modified
-    int keepH,              // if true, then H is packed
-    int64_t m,                 // # of rows in F
-    int64_t n,                 // # of columns in F
-    int64_t npiv,              // number of pivotal columns in F
-    int64_t *Stair,            // size npiv; column j is dead if Stair [j] == 0.
-                            // Only the first npiv columns can be dead.
-
-    // input, not modified (unless the pack occurs in-place)
-    double *F,               // m-by-n frontal matrix in column-major order
-
-    // output, contents not defined on input
-    double *R,               // packed columns of R+H
-    int64_t *p_rm              // number of rows in R block
+    int keepH, int64_t m, int64_t n, int64_t npiv, int64_t *Stair, double *F,
+    double *R, int64_t *p_rm
 ) ;
 
-template int64_t spqr_rhpack <Complex, int64_t>   // returns # of entries in R+H
+template int64_t spqr_rhpack <Complex, int64_t>
 (
-    // input, not modified
-    int keepH,              // if true, then H is packed
-    int64_t m,                 // # of rows in F
-    int64_t n,                 // # of columns in F
-    int64_t npiv,              // number of pivotal columns in F
-    int64_t *Stair,            // size npiv; column j is dead if Stair [j] == 0.
-                            // Only the first npiv columns can be dead.
-
-    // input, not modified (unless the pack occurs in-place)
-    Complex *F,               // m-by-n frontal matrix in column-major order
-
-    // output, contents not defined on input
-    Complex *R,               // packed columns of R+H
-    int64_t *p_rm              // number of rows in R block
+    int keepH, int64_t m, int64_t n, int64_t npiv, int64_t *Stair, Complex *F,
+    Complex *R, int64_t *p_rm
 ) ;

--- a/SPQR/Source/spqr_rmap.cpp
+++ b/SPQR/Source/spqr_rmap.cpp
@@ -113,24 +113,25 @@ template <typename Entry, typename Int> int spqr_rmap
     return (TRUE) ;
 }
 
+
+// explicit instantiations
+
 template int spqr_rmap <double, int32_t>
 (
-    SuiteSparseQR_factorization <double, int32_t> *QR,
-    cholmod_common *cc
+    SuiteSparseQR_factorization <double, int32_t> *QR, cholmod_common *cc
 ) ;
+
 template int spqr_rmap <Complex, int32_t>
 (
-    SuiteSparseQR_factorization <Complex, int32_t> *QR,
-    cholmod_common *cc
+    SuiteSparseQR_factorization <Complex, int32_t> *QR, cholmod_common *cc
 ) ;
 
 template int spqr_rmap <double, int64_t>
 (
-    SuiteSparseQR_factorization <double, int64_t> *QR,
-    cholmod_common *cc
+    SuiteSparseQR_factorization <double, int64_t> *QR, cholmod_common *cc
 ) ;
+
 template int spqr_rmap <Complex, int64_t>
 (
-    SuiteSparseQR_factorization <Complex, int64_t> *QR,
-    cholmod_common *cc
+    SuiteSparseQR_factorization <Complex, int64_t> *QR, cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_rsolve.cpp
+++ b/SPQR/Source/spqr_rsolve.cpp
@@ -382,84 +382,31 @@ template <typename Entry, typename Int> void spqr_rsolve
     }
 }
 
+
+// explicit instantiations
+
 template void spqr_rsolve <double, int32_t>
 (
-    // inputs
     SuiteSparseQR_factorization <double, int32_t> *QR,
-    int use_Q1fill,         // if TRUE, do X=E*(R\B), otherwise do X=R\B
-
-    int32_t nrhs,              // number of columns of B
-    int32_t ldb,               // leading dimension of B
-    double *B,               // size m-by-nrhs with leading dimesion ldb
-
-    // output
-    double *X,               // size n-by-nrhs with leading dimension n
-
-    // workspace
-    double **Rcolp,          // size QRnum->maxfrank
-    int32_t *Rlive,            // size QRnum->maxfrank
-    double *W,               // size QRnum->maxfrank * nrhs
-
-    cholmod_common *cc
+    int use_Q1fill, int32_t nrhs, int32_t ldb, double *B,  double *X,
+    double **Rcolp, int32_t *Rlive, double *W, cholmod_common *cc
 ) ;
 template void spqr_rsolve <Complex, int32_t>
 (
-    // inputs
     SuiteSparseQR_factorization <Complex, int32_t> *QR,
-    int use_Q1fill,         // if TRUE, do X=E*(R\B), otherwise do X=R\B
-
-    int32_t nrhs,              // number of columns of B
-    int32_t ldb,               // leading dimension of B
-    Complex *B,               // size m-by-nrhs with leading dimesion ldb
-
-    // output
-    Complex *X,               // size n-by-nrhs with leading dimension n
-
-    // workspace
-    Complex **Rcolp,          // size QRnum->maxfrank
-    int32_t *Rlive,            // size QRnum->maxfrank
-    Complex *W,               // size QRnum->maxfrank * nrhs
-
-    cholmod_common *cc
+    int use_Q1fill, int32_t nrhs, int32_t ldb, Complex *B, Complex *X,
+    Complex **Rcolp, int32_t *Rlive, Complex *W, cholmod_common *cc
 ) ;
 
 template void spqr_rsolve <double, int64_t>
 (
-    // inputs
     SuiteSparseQR_factorization <double, int64_t> *QR,
-    int use_Q1fill,         // if TRUE, do X=E*(R\B), otherwise do X=R\B
-
-    int64_t nrhs,              // number of columns of B
-    int64_t ldb,               // leading dimension of B
-    double *B,               // size m-by-nrhs with leading dimesion ldb
-
-    // output
-    double *X,               // size n-by-nrhs with leading dimension n
-
-    // workspace
-    double **Rcolp,          // size QRnum->maxfrank
-    int64_t *Rlive,            // size QRnum->maxfrank
-    double *W,               // size QRnum->maxfrank * nrhs
-
-    cholmod_common *cc
+    int use_Q1fill, int64_t nrhs, int64_t ldb, double *B, double *X,
+    double **Rcolp, int64_t *Rlive, double *W, cholmod_common *cc
 ) ;
 template void spqr_rsolve <Complex, int64_t>
 (
-    // inputs
     SuiteSparseQR_factorization <Complex, int64_t> *QR,
-    int use_Q1fill,         // if TRUE, do X=E*(R\B), otherwise do X=R\B
-
-    int64_t nrhs,              // number of columns of B
-    int64_t ldb,               // leading dimension of B
-    Complex *B,               // size m-by-nrhs with leading dimesion ldb
-
-    // output
-    Complex *X,               // size n-by-nrhs with leading dimension n
-
-    // workspace
-    Complex **Rcolp,          // size QRnum->maxfrank
-    int64_t *Rlive,            // size QRnum->maxfrank
-    Complex *W,               // size QRnum->maxfrank * nrhs
-
-    cholmod_common *cc
+    int use_Q1fill, int64_t nrhs, int64_t ldb, Complex *B, Complex *X,
+    Complex **Rcolp, int64_t *Rlive, Complex *W, cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_shift.cpp
+++ b/SPQR/Source/spqr_shift.cpp
@@ -32,19 +32,15 @@ template <typename Int> void spqr_shift
     }
 }
 
+
+// explicit instantiations
+
 template void spqr_shift <int32_t>
 (
-    // input, not modified
-    int32_t n,
-
-    // input/output
-    int32_t *X                     // size n+1
+    int32_t n, int32_t *X
 ) ;
+
 template void spqr_shift <int64_t>
 (
-    // input, not modified
-    int64_t n,
-
-    // input/output
-    int64_t *X                     // size n+1
+    int64_t n, int64_t *X
 ) ;

--- a/SPQR/Source/spqr_stranspose1.cpp
+++ b/SPQR/Source/spqr_stranspose1.cpp
@@ -164,52 +164,17 @@ template <typename Int> void spqr_stranspose1
     }
 }
 
+
+// explicit instantiations
+
 template void spqr_stranspose1 <int32_t>
 (
-    // input, not modified
-    cholmod_sparse *A,  // m-by-n
-    int32_t *Qfill,        // size n, fill-reducing column permutation;
-                        // Qfill [k] = j
-                        // if the kth column of S is the jth column of A.
-                        // Identity permutation is used if Qfill is NULL.
-
-    // output, contents not defined on input
-    // FUTURE : make S cholmod_sparse
-    int32_t *Sp,           // size m+1, row pointers of S
-    int32_t *Sj,           // size nz, column indices of S
-    int32_t *PLinv,        // size m, inverse row permutation, PLinv [i] = k
-    int32_t *Sleft,        // size n+2, Sleft [j] ... Sleft [j+1]-1 is the list of
-                        // rows of S whose leftmost column index is j.  The list
-                        // can be empty (that is, Sleft [j] == Sleft [j+1]).
-                        // Sleft [n] is the number of non-empty rows of S, and
-                        // Sleft [n+1] is always m.  That is, Sleft [n] ...
-                        // Sleft [n+1]-1 gives the empty rows of S.
-
-    // workspace, not defined on input or output
-    int32_t *W              // size m
+    cholmod_sparse *A, int32_t *Qfill,
+    int32_t *Sp, int32_t *Sj, int32_t *PLinv, int32_t *Sleft, int32_t *W
 ) ;
 
 template void spqr_stranspose1 <int64_t>
 (
-    // input, not modified
-    cholmod_sparse *A,  // m-by-n
-    int64_t *Qfill,        // size n, fill-reducing column permutation;
-                        // Qfill [k] = j
-                        // if the kth column of S is the jth column of A.
-                        // Identity permutation is used if Qfill is NULL.
-
-    // output, contents not defined on input
-    // FUTURE : make S cholmod_sparse
-    int64_t *Sp,           // size m+1, row pointers of S
-    int64_t *Sj,           // size nz, column indices of S
-    int64_t *PLinv,        // size m, inverse row permutation, PLinv [i] = k
-    int64_t *Sleft,        // size n+2, Sleft [j] ... Sleft [j+1]-1 is the list of
-                        // rows of S whose leftmost column index is j.  The list
-                        // can be empty (that is, Sleft [j] == Sleft [j+1]).
-                        // Sleft [n] is the number of non-empty rows of S, and
-                        // Sleft [n+1] is always m.  That is, Sleft [n] ...
-                        // Sleft [n+1]-1 gives the empty rows of S.
-
-    // workspace, not defined on input or output
-    int64_t *W              // size m
+    cholmod_sparse *A, int64_t *Qfill,
+    int64_t *Sp, int64_t *Sj, int64_t *PLinv, int64_t *Sleft, int64_t *W
 ) ;

--- a/SPQR/Source/spqr_stranspose2.cpp
+++ b/SPQR/Source/spqr_stranspose2.cpp
@@ -66,76 +66,29 @@ template <typename Entry, typename Int> void spqr_stranspose2
     }
 }
 
+
+// explicit instantiations
+
 template void spqr_stranspose2 <double, int32_t>
 (
-    // input, not modified
-    cholmod_sparse *A,  // m-by-n
-    int32_t *Qfill,        // size n, fill-reducing column permutation;
-                        // Qfill [k] = j
-                        // if the kth column of S is the jth column of A.
-                        // Identity permutation is used if Qfill is NULL.
-
-    int32_t *Sp,           // size m+1, row pointers of S
-    int32_t *PLinv,        // size m, inverse row permutation, PLinv [i] = k
-
-    // output, contents not defined on input
-    double *Sx,          // size nz, numerical values of S
-
-    // workspace, not defined on input or output
-    int32_t *W             // size m
+    cholmod_sparse *A, int32_t *Qfill, int32_t *Sp, int32_t *PLinv,
+    double *Sx, int32_t *W
 ) ;
+
 template void spqr_stranspose2 <Complex, int32_t>
 (
-    // input, not modified
-    cholmod_sparse *A,  // m-by-n
-    int32_t *Qfill,        // size n, fill-reducing column permutation;
-                        // Qfill [k] = j
-                        // if the kth column of S is the jth column of A.
-                        // Identity permutation is used if Qfill is NULL.
-
-    int32_t *Sp,           // size m+1, row pointers of S
-    int32_t *PLinv,        // size m, inverse row permutation, PLinv [i] = k
-
-    // output, contents not defined on input
-    Complex *Sx,          // size nz, numerical values of S
-
-    // workspace, not defined on input or output
-    int32_t *W             // size m
+    cholmod_sparse *A, int32_t *Qfill, int32_t *Sp, int32_t *PLinv,
+    Complex *Sx, int32_t *W
 ) ;
 
 template void spqr_stranspose2 <double, int64_t>
 (
-    // input, not modified
-    cholmod_sparse *A,  // m-by-n
-    int64_t *Qfill,        // size n, fill-reducing column permutation;
-                        // Qfill [k] = j
-                        // if the kth column of S is the jth column of A.
-                        // Identity permutation is used if Qfill is NULL.
-
-    int64_t *Sp,           // size m+1, row pointers of S
-    int64_t *PLinv,        // size m, inverse row permutation, PLinv [i] = k
-
-    // output, contents not defined on input
-    double *Sx,          // size nz, numerical values of S
-
-    // workspace, not defined on input or output
-    int64_t *W             // size m
+    cholmod_sparse *A, int64_t *Qfill, int64_t *Sp, int64_t *PLinv,
+    double *Sx, int64_t *W 
 ) ;
+
 template void spqr_stranspose2 <Complex, int64_t>
 (
-    // input, not modified
-    cholmod_sparse *A,  // m-by-n
-    int64_t *Qfill,        // size n, fill-reducing column permutation;
-                        // Qfill [k] = j
-                        // if the kth column of S is the jth column of A.
-                        // Identity permutation is used if Qfill is NULL.
-
-    int64_t *Sp,           // size m+1, row pointers of S
-    int64_t *PLinv,        // size m, inverse row permutation, PLinv [i] = k
-
-    // output, contents not defined on input
-    Complex *Sx,          // size nz, numerical values of S
-
-    // workspace, not defined on input or output
-    int64_t *W             // size m
+    cholmod_sparse *A, int64_t *Qfill, int64_t *Sp, int64_t *PLinv,
+    Complex *Sx, int64_t *W
 ) ;

--- a/SPQR/Source/spqr_tol.cpp
+++ b/SPQR/Source/spqr_tol.cpp
@@ -36,36 +36,25 @@ template <typename Entry, typename Int> double spqr_tol
     return (tol) ;
 }
 
+
+// explicit instantiations
+
 template double spqr_tol <double, int32_t>
 (
-    // inputs, not modified
-    cholmod_sparse *A,
-
-    // workspace and parameters
-    cholmod_common *cc
+    cholmod_sparse *A, cholmod_common *cc
 ) ;
+
 template double spqr_tol <Complex, int32_t>
 (
-    // inputs, not modified
-    cholmod_sparse *A,
-
-    // workspace and parameters
-    cholmod_common *cc
+    cholmod_sparse *A, cholmod_common *cc
 ) ;
 
 template double spqr_tol <double, int64_t>
 (
-    // inputs, not modified
-    cholmod_sparse *A,
-
-    // workspace and parameters
-    cholmod_common *cc
+    cholmod_sparse *A, cholmod_common *cc
 ) ;
+
 template double spqr_tol <Complex, int64_t>
 (
-    // inputs, not modified
-    cholmod_sparse *A,
-
-    // workspace and parameters
-    cholmod_common *cc
+    cholmod_sparse *A, cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_trapezoidal.cpp
+++ b/SPQR/Source/spqr_trapezoidal.cpp
@@ -214,130 +214,37 @@ template <typename Entry, typename Int> Int spqr_trapezoidal // rank of R; EMPTY
     return (rank) ;
 }
 
-template int32_t spqr_trapezoidal <double, int32_t> // rank of R; EMPTY on failure
+
+// explicit instantiations
+
+template int32_t spqr_trapezoidal <double, int32_t>
 (
-    // inputs, not modified
-
-    // FUTURE : make R and T cholmod_sparse:
-    int32_t n,         // R is m-by-n (m is not needed here; can be economy R)
-    int32_t *Rp,       // size n+1, column pointers of R
-    int32_t *Ri,       // size rnz = Rp [n], row indices of R
-    double *Rx,      // size rnz, numerical values of R
-
-    int32_t bncols,    // number of columns of B
-
-    int32_t *Qfill,    // size n+bncols, fill-reducing ordering.  Qfill [k] = j if
-                    // the jth column of A is the kth column of R.  If Qfill is
-                    // NULL, then it is assumed to be the identity
-                    // permutation.
-
-    int skip_if_trapezoidal,        // if R is already in trapezoidal form,
-                                    // and skip_if_trapezoidal is TRUE, then
-                                    // the matrix T is not created.
-
-    // outputs, not allocated on input
-    int32_t **p_Tp,    // size n+1, column pointers of T
-    int32_t **p_Ti,    // size rnz, row indices of T
-    double **p_Tx,   // size rnz, numerical values of T
-
-    int32_t **p_Qtrap,  // size n+bncols, modified Qfill
-
-    // workspace and parameters
+    int32_t n, int32_t *Rp, int32_t *Ri, double *Rx, int32_t bncols,
+    int32_t *Qfill, int skip_if_trapezoidal,
+    int32_t **p_Tp, int32_t **p_Ti, double **p_Tx, int32_t **p_Qtrap,
     cholmod_common *cc
 ) ;
 
-template int32_t spqr_trapezoidal <Complex, int32_t> // rank of R; EMPTY on failure
+template int32_t spqr_trapezoidal <Complex, int32_t>
 (
-    // inputs, not modified
-
-    // FUTURE : make R and T cholmod_sparse:
-    int32_t n,         // R is m-by-n (m is not needed here; can be economy R)
-    int32_t *Rp,       // size n+1, column pointers of R
-    int32_t *Ri,       // size rnz = Rp [n], row indices of R
-    Complex *Rx,      // size rnz, numerical values of R
-
-    int32_t bncols,    // number of columns of B
-
-    int32_t *Qfill,    // size n+bncols, fill-reducing ordering.  Qfill [k] = j if
-                    // the jth column of A is the kth column of R.  If Qfill is
-                    // NULL, then it is assumed to be the identity
-                    // permutation.
-
-    int skip_if_trapezoidal,        // if R is already in trapezoidal form,
-                                    // and skip_if_trapezoidal is TRUE, then
-                                    // the matrix T is not created.
-
-    // outputs, not allocated on input
-    int32_t **p_Tp,    // size n+1, column pointers of T
-    int32_t **p_Ti,    // size rnz, row indices of T
-    Complex **p_Tx,   // size rnz, numerical values of T
-
-    int32_t **p_Qtrap,  // size n+bncols, modified Qfill
-
-    // workspace and parameters
+    int32_t n, int32_t *Rp, int32_t *Ri, Complex *Rx, int32_t bncols,
+    int32_t *Qfill, int skip_if_trapezoidal,
+    int32_t **p_Tp, int32_t **p_Ti, Complex **p_Tx, int32_t **p_Qtrap,
     cholmod_common *cc
 ) ;
 
-template int64_t spqr_trapezoidal <double, int64_t> // rank of R; EMPTY on failure
+template int64_t spqr_trapezoidal <double, int64_t>
 (
-    // inputs, not modified
-
-    // FUTURE : make R and T cholmod_sparse:
-    int64_t n,         // R is m-by-n (m is not needed here; can be economy R)
-    int64_t *Rp,       // size n+1, column pointers of R
-    int64_t *Ri,       // size rnz = Rp [n], row indices of R
-    double *Rx,      // size rnz, numerical values of R
-
-    int64_t bncols,    // number of columns of B
-
-    int64_t *Qfill,    // size n+bncols, fill-reducing ordering.  Qfill [k] = j if
-                    // the jth column of A is the kth column of R.  If Qfill is
-                    // NULL, then it is assumed to be the identity
-                    // permutation.
-
-    int skip_if_trapezoidal,        // if R is already in trapezoidal form,
-                                    // and skip_if_trapezoidal is TRUE, then
-                                    // the matrix T is not created.
-
-    // outputs, not allocated on input
-    int64_t **p_Tp,    // size n+1, column pointers of T
-    int64_t **p_Ti,    // size rnz, row indices of T
-    double **p_Tx,   // size rnz, numerical values of T
-
-    int64_t **p_Qtrap,  // size n+bncols, modified Qfill
-
-    // workspace and parameters
+    int64_t n, int64_t *Rp, int64_t *Ri, double *Rx, int64_t bncols,
+    int64_t *Qfill, int skip_if_trapezoidal, 
+    int64_t **p_Tp, int64_t **p_Ti, double **p_Tx, int64_t **p_Qtrap,
     cholmod_common *cc
 ) ;
 
-template int64_t spqr_trapezoidal <Complex, int64_t> // rank of R; EMPTY on failure
+template int64_t spqr_trapezoidal <Complex, int64_t>
 (
-    // inputs, not modified
-
-    // FUTURE : make R and T cholmod_sparse:
-    int64_t n,         // R is m-by-n (m is not needed here; can be economy R)
-    int64_t *Rp,       // size n+1, column pointers of R
-    int64_t *Ri,       // size rnz = Rp [n], row indices of R
-    Complex *Rx,      // size rnz, numerical values of R
-
-    int64_t bncols,    // number of columns of B
-
-    int64_t *Qfill,    // size n+bncols, fill-reducing ordering.  Qfill [k] = j if
-                    // the jth column of A is the kth column of R.  If Qfill is
-                    // NULL, then it is assumed to be the identity
-                    // permutation.
-
-    int skip_if_trapezoidal,        // if R is already in trapezoidal form,
-                                    // and skip_if_trapezoidal is TRUE, then
-                                    // the matrix T is not created.
-
-    // outputs, not allocated on input
-    int64_t **p_Tp,    // size n+1, column pointers of T
-    int64_t **p_Ti,    // size rnz, row indices of T
-    Complex **p_Tx,   // size rnz, numerical values of T
-
-    int64_t **p_Qtrap,  // size n+bncols, modified Qfill
-
-    // workspace and parameters
+    int64_t n, int64_t *Rp, int64_t *Ri, Complex *Rx, int64_t bncols,
+    int64_t *Qfill, int skip_if_trapezoidal,
+    int64_t **p_Tp, int64_t **p_Ti, Complex **p_Tx, int64_t **p_Qtrap,
     cholmod_common *cc
 ) ;

--- a/SPQR/Source/spqr_type.cpp
+++ b/SPQR/Source/spqr_type.cpp
@@ -12,6 +12,8 @@
 
 #include "spqr.hpp"
 
+// template specializations
+
 template <> int spqr_type <double> (void)
 {
     return (CHOLMOD_REAL) ;


### PR DESCRIPTION
The recently added templates are very effective when it comes to using similar code for 32-bit and 64-bit indices.

Currently, the inline documentation at the function header is repeated (up to 5 times) at the template definition, at the template specializations, at the explicit template instantiations and/or at forward declarations.
That means that one would need to remember to change the documentation at all of these locations (sometimes scattered across different files) if one likes to keep it consistent.
The repeated documentation doesn't add value. Having it in one location is good enough imho.

This PR removes the repeated inline documentation at the template specializations, the explicit template instantiations and forward declarations. It keeps it only at the template definition.
Where the documentation is removed, a more compact form of the argument list is used.
I also tried to use a more consistent order for the different instantiations and specializations.

This is only house-keeping without any functional change. 
There are only a few files where there are some syntax changes. E.g., in `spqrgpu_buildAssemblyMaps.cpp`, `spqrgpu_computeFrontStaging.cpp`, or `spqrgpu_kernel.cpp` where the template declarations were changed to explicit template instantiations.