### PR TITLE
Create pkg-config files

### DIFF
--- a/AMD/CMakeLists.txt
+++ b/AMD/CMakeLists.txt
@@ -10,7 +10,7 @@
 # get the version
 #-------------------------------------------------------------------------------
 
-cmake_minimum_required ( VERSION 3.19 )
+cmake_minimum_required ( VERSION 3.20 )
 
 set ( AMD_DATE "June 16, 2023" )
 set ( AMD_VERSION_MAJOR 3 )
@@ -145,6 +145,7 @@ endif ( )
 if ( NOT WIN32 )
     target_link_libraries ( AMD PRIVATE m )
     if ( NOT NSTATIC )
+        set ( AMD_STATIC_LIBS "${AMD_STATIC_LIBS} -lm" )
         target_link_libraries ( AMD_static PUBLIC m )
     endif ( )
 endif ( )
@@ -190,6 +191,30 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/AMDConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/AMDConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/AMD )
+
+# create pkg-config file
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/AMD.pc.in
+    AMD.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/AMD.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/AMD/Config/AMD.pc.in
+++ b/AMD/Config/AMD.pc.in
@@ -1,0 +1,17 @@
+# AMD, Copyright (c) 1996-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: AMD
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: Routines for permuting sparse matrices prior to factorization in SuiteSparse
+Version: @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@.@AMD_VERSION_SUB@
+Requires.private: SuiteSparse_config
+Libs: -L${libdir} -lamd
+Libs.private: @AMD_STATIC_LIBS@
+Cflags: -I${includedir}

--- a/BTF/CMakeLists.txt
+++ b/BTF/CMakeLists.txt
@@ -10,7 +10,7 @@
 # get the version
 #-------------------------------------------------------------------------------
 
-cmake_minimum_required ( VERSION 3.19 )
+cmake_minimum_required ( VERSION 3.20 )
 
 set ( BTF_DATE "June 16, 2023" )
 set ( BTF_VERSION_MAJOR 2 )
@@ -128,6 +128,7 @@ endif ( )
 if ( NOT WIN32 )
     target_link_libraries ( BTF PRIVATE m )
     if ( NOT NSTATIC )
+        set ( BTF_STATIC_LIBS "${BTF_STATIC_LIBS} -lm" )
         target_link_libraries ( BTF_static PUBLIC m )
     endif ( )
 endif ( )
@@ -173,6 +174,30 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/BTFConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/BTFConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/BTF )
+
+# create pkg-config file
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/BTF.pc.in
+    BTF.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/BTF.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # report status

--- a/BTF/Config/BTF.pc.in
+++ b/BTF/Config/BTF.pc.in
@@ -1,0 +1,17 @@
+# BTF, Copyright (c) 2004-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: BTF
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: Software package for permuting a matrix into block upper triangular form in SuiteSparse
+Version: @BTF_VERSION_MAJOR@.@BTF_VERSION_MINOR@.@BTF_VERSION_SUB@
+Requires.private: SuiteSparse_config
+Libs: -L${libdir} -lbtf
+Libs.private: @BTF_STATIC_LIBS@
+Cflags: -I${includedir}

--- a/CAMD/CMakeLists.txt
+++ b/CAMD/CMakeLists.txt
@@ -9,7 +9,7 @@
 # get the version
 #-------------------------------------------------------------------------------
 
-cmake_minimum_required ( VERSION 3.19 )
+cmake_minimum_required ( VERSION 3.20 )
 
 set ( CAMD_DATE "June 16, 2023" )
 set ( CAMD_VERSION_MAJOR 3 )
@@ -130,6 +130,7 @@ endif ( )
 if ( NOT WIN32 )
     target_link_libraries ( CAMD PRIVATE m )
     if ( NOT NSTATIC )
+        set ( CAMD_STATIC_LIBS "${CAMD_STATIC_LIBS} -lm" )
         target_link_libraries ( CAMD_static PUBLIC m )
     endif ( )
 endif ( )
@@ -175,6 +176,30 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/CAMDConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/CAMDConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CAMD )
+
+# create pkg-config file
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/CAMD.pc.in
+    CAMD.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/CAMD.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/CAMD/Config/CAMD.pc.in
+++ b/CAMD/Config/CAMD.pc.in
@@ -1,0 +1,17 @@
+# CAMD, Copyright (c) 2007-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: CAMD
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: Routines for permuting sparse matrices prior to factorization in SuiteSparse
+Version: @CAMD_VERSION_MAJOR@.@CAMD_VERSION_MINOR@.@CAMD_VERSION_SUB@
+Requires.private: SuiteSparse_config
+Libs: -L${libdir} -lcamd
+Libs.private: @CAMD_STATIC_LIBS@
+Cflags: -I${includedir}

--- a/CCOLAMD/CMakeLists.txt
+++ b/CCOLAMD/CMakeLists.txt
@@ -9,7 +9,7 @@
 # get the version
 #-------------------------------------------------------------------------------
 
-cmake_minimum_required ( VERSION 3.19 )
+cmake_minimum_required ( VERSION 3.20 )
 
 set ( CCOLAMD_DATE "June 16, 2023" )
 set ( CCOLAMD_VERSION_MAJOR 3 )
@@ -127,6 +127,7 @@ endif ( )
 if ( NOT WIN32 )
     target_link_libraries ( CCOLAMD PRIVATE m )
     if ( NOT NSTATIC )
+        set ( CCOLAMD_STATIC_LIBS "${CCOLAMD_STATIC_LIBS} -lm" )
         target_link_libraries ( CCOLAMD_static PUBLIC m )
     endif ( )
 endif ( )
@@ -172,6 +173,30 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/CCOLAMDConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/CCOLAMDConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CCOLAMD )
+
+# create pkg-config file
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/CCOLAMD.pc.in
+    CCOLAMD.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/CCOLAMD.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/CCOLAMD/Config/CCOLAMD.pc.in
+++ b/CCOLAMD/Config/CCOLAMD.pc.in
@@ -1,0 +1,17 @@
+# CCOLAMD, Copyright (c) 2005-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: CCOLAMD
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: Routines for column approximate minimum degree ordering algorithm in SuiteSparse
+Version: @CCOLAMD_VERSION_MAJOR@.@CCOLAMD_VERSION_MINOR@.@CCOLAMD_VERSION_SUB@
+Requires.private: SuiteSparse_config
+Libs: -L${libdir} -lccolamd
+Libs.private: @CCOLAMD_STATIC_LIBS@
+Cflags: -I${includedir}

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -378,6 +378,7 @@ if ( OPENMP_FOUND )
     target_link_libraries ( CHOLMOD PRIVATE ${OpenMP_C_LIBRARIES} )
     if ( NOT NSTATIC )
         target_link_libraries ( CHOLMOD_static PUBLIC ${OpenMP_C_LIBRARIES} )
+        list ( APPEND CHOLMOD_STATIC_LIBS ${OpenMP_C_LIBRARIES} )
     endif ( )
     set ( CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   ${OpenMP_C_FLAGS} " )
     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_C_FLAGS} " )
@@ -388,9 +389,11 @@ endif ( )
 if ( NOT WIN32 )
     target_link_libraries ( CHOLMOD PRIVATE m )
     if ( NOT NSTATIC )
+        list ( APPEND CHOLMOD_STATIC_LIBS "m" )
         target_link_libraries ( CHOLMOD_static PUBLIC m )
     endif ( )
 endif ( )
+        list ( APPEND CHOLMOD_STATIC_LIBS "m" )
 
 # AMD:
 target_link_libraries ( CHOLMOD PRIVATE SuiteSparse::AMD )
@@ -414,33 +417,36 @@ endif ( )
 
 # BLAS and LAPACK: for the Supernodal Module
 if ( NOT NSUPERNODAL )
-    # BLAS:
-    message ( STATUS "BLAS libraries:      ${BLAS_LIBRARIES} ")
-    message ( STATUS "BLAS include:        ${BLAS_INCLUDE_DIRS} ")
-    message ( STATUS "BLAS linker flags:   ${BLAS_LINKER_FLAGS} ")
-    target_link_libraries ( CHOLMOD PRIVATE ${BLAS_LIBRARIES} )
-    if ( NOT NSTATIC )
-        target_link_libraries ( CHOLMOD_static PUBLIC ${BLAS_LIBRARIES} )
-    endif ( )
-    include_directories ( ${BLAS_INCLUDE_DIRS} )
-
     # LAPACK:
     message ( STATUS "LAPACK libraries:    ${LAPACK_LIBRARIES} ")
     message ( STATUS "LAPACK include:      ${LAPACK_INCLUDE_DIRS} ")
     message ( STATUS "LAPACK linker flags: ${LAPACK_LINKER_FLAGS} ")
     target_link_libraries ( CHOLMOD PRIVATE ${LAPACK_LIBRARIES} )
     if ( NOT NSTATIC )
+        list ( APPEND CHOLMOD_STATIC_LIBS ${LAPACK_LIBRARIES} )
         target_link_libraries ( CHOLMOD_static PUBLIC ${LAPACK_LIBRARIES} )
     endif ( )
     include_directories ( ${LAPACK_INCLUDE_DIR} )
+
+    # BLAS:
+    message ( STATUS "BLAS libraries:      ${BLAS_LIBRARIES} ")
+    message ( STATUS "BLAS include:        ${BLAS_INCLUDE_DIRS} ")
+    message ( STATUS "BLAS linker flags:   ${BLAS_LINKER_FLAGS} ")
+    target_link_libraries ( CHOLMOD PRIVATE ${BLAS_LIBRARIES} )
+    if ( NOT NSTATIC )
+        list ( APPEND CHOLMOD_STATIC_LIBS ${BLAS_LIBRARIES} )
+        target_link_libraries ( CHOLMOD_static PUBLIC ${BLAS_LIBRARIES} )
+    endif ( )
+    include_directories ( ${BLAS_INCLUDE_DIRS} )
 endif ( )
 
 # CAMD and CCOLAMD:
 if ( NOT NCAMD )
     target_link_libraries ( CHOLMOD PRIVATE SuiteSparse::CAMD )
     if ( NOT NSTATIC )
+        set ( CHOLMOD_STATIC_MODULES "${CHOLMOD_STATIC_MODULES} SuiteSparse::CAMD" )
         if ( TARGET SuiteSparse::CAMD_static )
-            target_link_libraries (CHOLMOD_static PUBLIC SuiteSparse::CAMD_static )
+            target_link_libraries ( CHOLMOD_static PUBLIC SuiteSparse::CAMD_static )
         else ( )
             target_link_libraries ( CHOLMOD_static PUBLIC SuiteSparse::CAMD )
         endif ( )
@@ -448,6 +454,7 @@ if ( NOT NCAMD )
 
     target_link_libraries ( CHOLMOD PRIVATE SuiteSparse::CCOLAMD )
     if ( NOT NSTATIC )
+        set ( CHOLMOD_STATIC_MODULES "${CHOLMOD_STATIC_MODULES} SuiteSparse::CCOLAMD" )
         if ( TARGET SuiteSparse::CCOLAMD_static )
             target_link_libraries ( CHOLMOD_static PUBLIC SuiteSparse::CCOLAMD_static )
         else ( )
@@ -513,6 +520,55 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/CHOLMODConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/CHOLMODConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CHOLMOD )
+
+# create pkg-config file
+
+# This might be something like:
+#   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
+# convert to -l flags for pkg-config, i.e.: "-lgomp -lpthread -lm"
+set ( CHOLMOD_STATIC_LIBS_LIST ${CHOLMOD_STATIC_LIBS} )
+set ( CHOLMOD_STATIC_LIBS "" )
+foreach ( _lib ${CHOLMOD_STATIC_LIBS_LIST} )
+    string ( FIND ${_lib} "." _pos REVERSE )
+    if ( ${_pos} EQUAL "-1" )
+        set ( CHOLMOD_STATIC_LIBS "${CHOLMOD_STATIC_LIBS} -l${_lib}" )
+        continue ()
+    endif ( )
+    foreach ( _kind IN ITEMS "IMPORT" "SHARED" "STATIC" )
+        set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
+        if ( ${_lib} MATCHES ${_regex} )
+            string ( REGEX REPLACE ${_regex} "\\2" _libname ${_lib} )
+            if ( NOT "${_libname}" STREQUAL "" )
+                set ( CHOLMOD_STATIC_LIBS "${CHOLMOD_STATIC_LIBS} -l${_libname}" )
+                break ()
+            endif ( )
+        endif ( )
+    endforeach ( )
+endforeach ( )
+message ( STATUS "CHOLMOD_STATIC_LIBS: ${CHOLMOD_STATIC_LIBS}" )
+
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/CHOLMOD.pc.in
+    CHOLMOD.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/CHOLMOD.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/CHOLMOD/Config/CHOLMOD.pc.in
+++ b/CHOLMOD/Config/CHOLMOD.pc.in
@@ -1,0 +1,17 @@
+# CHOLMOD, Copyright (c) 2005-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: LGPL-2.1-or-later AND GPL-2.0-or-later AND Apache-2.0
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: CHOLMOD
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: Routines for factorizing sparse symmetric positive definite matrices in SuiteSparse
+Version: @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@
+Requires.private: SuiteSparse_config AMD COLAMD @CHOLMOD_STATIC_MODULES@
+Libs: -L${libdir} -lcholmod
+Libs.private: @CHOLMOD_STATIC_LIBS@
+Cflags: -I${includedir}

--- a/CHOLMOD/Config/CHOLMOD_CUDA.pc.in
+++ b/CHOLMOD/Config/CHOLMOD_CUDA.pc.in
@@ -1,0 +1,17 @@
+# CHOLMOD_CUDA, Copyright (c) 2005-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+# FIXME: Which flags do we need for static linking?
+
+Name: CHOLMOD_CUDA
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: CHOLMOD/GPU module in SuiteSparse
+Version: @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@
+Libs: -L${libdir} -lcholmod_cuda
+Cflags: -I${includedir}

--- a/CHOLMOD/GPU/CMakeLists.txt
+++ b/CHOLMOD/GPU/CMakeLists.txt
@@ -144,3 +144,27 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/../CHOLMOD_CUDAConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/../CHOLMOD_CUDAConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CHOLMOD_CUDA )
+
+# create pkg-config file
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    ../Config/CHOLMOD_CUDA.pc.in
+    CHOLMOD_CUDA.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/CHOLMOD_CUDA.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )

--- a/COLAMD/CMakeLists.txt
+++ b/COLAMD/CMakeLists.txt
@@ -9,7 +9,7 @@
 # get the version
 #-------------------------------------------------------------------------------
 
-cmake_minimum_required ( VERSION 3.19 )
+cmake_minimum_required ( VERSION 3.20 )
 
 set ( COLAMD_DATE "June 16, 2023" )
 set ( COLAMD_VERSION_MAJOR 3 )
@@ -127,6 +127,7 @@ endif ( )
 if ( NOT WIN32 )
     target_link_libraries ( COLAMD PRIVATE m )
     if ( NOT NSTATIC )
+        set ( COLAMD_STATIC_LIBS "${COLAMD_STATIC_LIBS} -lm" )
         target_link_libraries ( COLAMD_static PUBLIC m )
     endif ( )
 endif ( )
@@ -172,6 +173,30 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/COLAMDConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/COLAMDConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/COLAMD )
+
+# create pkg-config file
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/COLAMD.pc.in
+    COLAMD.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/COLAMD.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/COLAMD/Config/COLAMD.pc.in
+++ b/COLAMD/Config/COLAMD.pc.in
@@ -1,0 +1,17 @@
+# COLAMD, Copyright (c) 1998-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: COLAMD
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: Routines for column approximate minimum degree ordering algorithm in SuiteSparse
+Version: @COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@.@COLAMD_VERSION_SUB@
+Requires.private: SuiteSparse_config
+Libs: -L${libdir} -lcolamd
+Libs.private: @COLAMD_STATIC_LIBS@
+Cflags: -I${includedir}

--- a/CSparse/CMakeLists.txt
+++ b/CSparse/CMakeLists.txt
@@ -120,9 +120,35 @@ endif ( )
 if ( NOT WIN32 )
     target_link_libraries ( csparse PRIVATE m )
     if ( NOT NSTATIC )
+        set ( CSPARSE_STATIC_LIBS "${CSPARSE_STATIC_LIBS} -lm" )
         target_link_libraries ( csparse_static PUBLIC m )
     endif ( )
 endif ( )
+
+
+# create pkg-config file
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE CMAKE_INSTALL_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${CMAKE_INSTALL_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE CMAKE_INSTALL_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${CMAKE_INSTALL_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/CSparse.pc.in
+    CSparse.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/CSparse.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/CSparse/Config/CSparse.pc.in
+++ b/CSparse/Config/CSparse.pc.in
@@ -1,0 +1,16 @@
+# CSparse, Copyright (c) 2006-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: CSparse
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: Direct methods for sparse linear systems in SuiteSparse
+Version: @CSPARSE_VERSION_MAJOR@.@CSPARSE_VERSION_MINOR@.@CSPARSE_VERSION_SUB@
+Libs: -L${libdir} -lcsparse
+Libs.private: @CSPARSE_STATIC_LIBS@
+Cflags: -I${includedir}

--- a/CXSparse/CMakeLists.txt
+++ b/CXSparse/CMakeLists.txt
@@ -9,7 +9,7 @@
 # get the version
 #-------------------------------------------------------------------------------
 
-cmake_minimum_required ( VERSION 3.19 )
+cmake_minimum_required ( VERSION 3.20 )
 
 set ( CXSPARSE_DATE "June 16, 2023" )
 set ( CXSPARSE_VERSION_MAJOR 4 )
@@ -160,6 +160,7 @@ endif ( )
 if ( NOT WIN32 )
     target_link_libraries ( CXSparse PRIVATE m )
     if ( NOT NSTATIC )
+        set ( CXSPARSE_STATIC_LIBS "${CXSPARSE_STATIC_LIBS} -lm" )
         target_link_libraries ( CXSparse_static PUBLIC m )
     endif ( )
 endif ( )
@@ -205,6 +206,30 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/CXSparseConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/CXSparseConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CXSparse )
+
+# create pkg-config file
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/CXSparse.pc.in
+    CXSparse.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/CXSparse.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/CXSparse/Config/CXSparse.pc.in
+++ b/CXSparse/Config/CXSparse.pc.in
@@ -1,0 +1,17 @@
+# CXSparse, Copyright (c) 2006-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: CXSparse
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: Direct methods for sparse linear systems for real and complex matrices in SuiteSparse
+Version: @CXSPARSE_VERSION_MAJOR@.@CXSPARSE_VERSION_MINOR@.@CXSPARSE_VERSION_SUB@
+Requires.private: SuiteSparse_config
+Libs: -L${libdir} -lcxsparse
+Libs.private: @CXSPARSE_STATIC_LIBS@
+Cflags: -I${includedir}

--- a/GPUQREngine/CMakeLists.txt
+++ b/GPUQREngine/CMakeLists.txt
@@ -11,7 +11,7 @@
 #-------------------------------------------------------------------------------
 
 # cmake 3.22 is required to find the BLAS/LAPACK
-cmake_minimum_required ( VERSION 3.19 )
+cmake_minimum_required ( VERSION 3.20 )
 
 set ( GPUQRENGINE_DATE "June 16, 2023" )
 set ( GPUQRENGINE_VERSION_MAJOR 2 )
@@ -263,6 +263,30 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/GPUQREngineConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/GPUQREngineConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/GPUQREngine )
+
+# create pkg-config file
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/GPUQREngine.pc.in
+    GPUQREngine.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/GPUQREngine.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/GPUQREngine/Config/GPUQREngine.pc.in
+++ b/GPUQREngine/Config/GPUQREngine.pc.in
@@ -1,0 +1,17 @@
+# GPUQREngine, Copyright (c) 2013-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+# FIXME: Which flags do we need to statically link CUDA
+
+Name: GPUQREngine
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: GPU-accelerated QR factorization engine supporting SuiteSparseQR in SuiteSparse
+Version: @GPUQRENGINE_VERSION_MAJOR@.@GPUQRENGINE_VERSION_MINOR@.@GPUQRENGINE_VERSION_SUB@
+Libs: -L${libdir} -lgpuqrengine
+Cflags: -I${includedir}

--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -11,7 +11,7 @@
 # get the version
 #-------------------------------------------------------------------------------
 
-cmake_minimum_required ( VERSION 3.16 )
+cmake_minimum_required ( VERSION 3.20 )
 
 set ( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
     ${CMAKE_SOURCE_DIR}/cmake_modules )
@@ -325,6 +325,7 @@ if ( NOT WIN32 )
     set ( GB_M "m" )
     target_link_libraries ( GraphBLAS PRIVATE m )
     if ( NOT NSTATIC )
+        list ( APPEND GRAPHBLAS_STATIC_LIBS "m" )
         target_link_libraries ( GraphBLAS_static PUBLIC m )
     endif ( )
 endif ( )
@@ -333,6 +334,7 @@ endif ( )
 if ( NOT WIN32 )
     target_link_libraries ( GraphBLAS PRIVATE dl )
     if ( NOT NSTATIC )
+        list ( APPEND GRAPHBLAS_STATIC_LIBS "dl" )
         target_link_libraries ( GraphBLAS_static PUBLIC dl )
     endif ( )
 endif ( )
@@ -342,6 +344,7 @@ include ( SuiteSparseAtomic )
 if ( LIBATOMIC_REQUIRED )
     target_link_libraries ( GraphBLAS PRIVATE atomic )
     if ( NOT NSTATIC )
+        list ( APPEND GRAPHBLAS_STATIC_LIBS "atomic" )
         target_link_libraries ( GraphBLAS_static PUBLIC atomic )
     endif ( )
 endif ( )
@@ -361,6 +364,7 @@ if ( OPENMP_FOUND )
     # So this breaks:
     # target_link_libraries ( GraphBLAS PRIVATE OpenMP::OpenMP_C )
     if ( NOT NSTATIC )
+        list ( APPEND GRAPHBLAS_STATIC_LIBS ${OpenMP_C_LIBRARIES} )
         target_link_libraries ( GraphBLAS_static PUBLIC ${OpenMP_C_LIBRARIES} )
         # target_link_libraries ( GraphBLAS_static PUBLIC OpenMP::OpenMP_C )
     endif ( )
@@ -499,6 +503,55 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/GraphBLASConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/GraphBLASConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/GraphBLAS )
+
+# create pkg-config file
+
+# This might be something like:
+#   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
+# convert to -l flags for pkg-config, i.e.: "-lgomp -lpthread -lm"
+set ( GRAPHBLAS_STATIC_LIBS_LIST ${GRAPHBLAS_STATIC_LIBS} )
+set ( GRAPHBLAS_STATIC_LIBS "" )
+foreach ( _lib ${GRAPHBLAS_STATIC_LIBS_LIST} )
+    string ( FIND ${_lib} "." _pos REVERSE )
+    if ( ${_pos} EQUAL "-1" )
+        set ( GRAPHBLAS_STATIC_LIBS "${GRAPHBLAS_STATIC_LIBS} -l${_lib}" )
+        continue ()
+    endif ( )
+    foreach ( _kind IN ITEMS "IMPORT" "SHARED" "STATIC" )
+        set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
+        if ( ${_lib} MATCHES ${_regex} )
+            string ( REGEX REPLACE ${_regex} "\\2" _libname ${_lib} )
+            if ( NOT "${_libname}" STREQUAL "" )
+                set ( GRAPHBLAS_STATIC_LIBS "${GRAPHBLAS_STATIC_LIBS} -l${_libname}" )
+                break ()
+            endif ( )
+        endif ( )
+    endforeach ( )
+endforeach ( )
+message ( STATUS "GRAPHBLAS_STATIC_LIBS: ${GRAPHBLAS_STATIC_LIBS}" )
+
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/GraphBLAS.pc.in
+    GraphBLAS.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/GraphBLAS.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # configure the JITs

--- a/GraphBLAS/Config/GraphBLAS.pc.in
+++ b/GraphBLAS/Config/GraphBLAS.pc.in
@@ -1,0 +1,18 @@
+# GraphBLAS, Copyright (c) 2017-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+# FIXME: Which flags do we need to statically link CUDA?
+
+Name: GraphBLAS
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: Complete implementation of the GraphBLAS standard in SuiteSparse
+Version: @GraphBLAS_VERSION_MAJOR@.@GraphBLAS_VERSION_MINOR@.@GraphBLAS_VERSION_SUB@
+Libs: -L${libdir} -lgraphblas
+Libs.private: @GRAPHBLAS_STATIC_LIBS@
+Cflags: -I${includedir}

--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -419,6 +419,29 @@ if ( NOT NCHOLMOD )
         ${CMAKE_CURRENT_BINARY_DIR}/KLU_CHOLMODConfigVersion.cmake
         DESTINATION ${SUITESPARSE_LIBDIR}/cmake/KLU_CHOLMOD )
 
+    # create pkg-config file
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/KLU_CHOLMOD.pc.in
+        KLU_CHOLMOD.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/KLU_CHOLMOD.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -10,7 +10,7 @@
 # get the version
 #-------------------------------------------------------------------------------
 
-cmake_minimum_required ( VERSION 3.19 )
+cmake_minimum_required ( VERSION 3.20 )
 
 set ( KLU_DATE "June 16, 2023" )
 set ( KLU_VERSION_MAJOR 2 )
@@ -236,6 +236,7 @@ endif ( )
 if ( NOT WIN32 )
     target_link_libraries ( KLU PRIVATE m )
     if ( NOT NSTATIC )
+        set ( KLU_STATIC_LIBS "${KLU_STATIC_LIBS} -lm" )
         target_link_libraries ( KLU_static PUBLIC m )
     endif ( )
 endif ( )
@@ -285,6 +286,7 @@ if ( NOT NCHOLMOD )
     target_link_libraries ( KLU_CHOLMOD PRIVATE
         SuiteSparse::CHOLMOD SuiteSparse::CHOLMOD_CUDA )
     if ( NOT NSTATIC )
+       set ( KLU_STATIC_MODULES "${KLU_STATIC_MODULES} CHOLMOD CHOLMOD_CUDA" )
        if ( TARGET SuiteSparse::CHOLMOD_static )
             target_link_libraries ( KLU_static PUBLIC SuiteSparse::CHOLMOD_static )
             target_link_libraries ( KLU_CHOLMOD_static PUBLIC SuiteSparse::CHOLMOD_static )
@@ -355,6 +357,30 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/KLUConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/KLUConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/KLU )
+
+# create pkg-config file
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/KLU.pc.in
+    KLU.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/KLU.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 if ( NOT NCHOLMOD )
     install ( TARGETS KLU_CHOLMOD

--- a/KLU/Config/KLU.pc.in
+++ b/KLU/Config/KLU.pc.in
@@ -1,0 +1,17 @@
+# KLU, Copyright (c) 2004-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: KLU
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: Routines for solving sparse linear systems of equations in SuiteSparse
+Version: @KLU_VERSION_MAJOR@.@KLU_VERSION_MINOR@.@KLU_VERSION_SUB@
+Requires.private: SuiteSparse_config AMD COLAMD BTF @KLU_STATIC_MODULES@
+Libs: -L${libdir} -lklu
+Libs.private: @KLU_STATIC_LIBS@
+Cflags: -I${includedir}

--- a/KLU/Config/KLU_CHOLMOD.pc.in
+++ b/KLU/Config/KLU_CHOLMOD.pc.in
@@ -1,0 +1,16 @@
+# KLU_CHOLMOD, Copyright (c) 2004-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: KLU_CHOLMOD
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: Routines for sample ordering for KLU in SuiteSparse
+Version: @KLU_VERSION_MAJOR@.@KLU_VERSION_MINOR@.@KLU_VERSION_SUB@
+Requires.private: KLU BTF CHOLMOD CHOLMOD_CUDA
+Libs: -L${libdir} -lklu_cholmod
+Cflags: -I${includedir}

--- a/LDL/CMakeLists.txt
+++ b/LDL/CMakeLists.txt
@@ -9,7 +9,7 @@
 # get the version
 #-------------------------------------------------------------------------------
 
-cmake_minimum_required ( VERSION 3.19 )
+cmake_minimum_required ( VERSION 3.20 )
 
 set ( LDL_DATE "June 16, 2023" )
 set ( LDL_VERSION_MAJOR 3 )
@@ -124,6 +124,7 @@ endif ( )
 if ( NOT WIN32 )
     target_link_libraries ( LDL PRIVATE m )
     if ( NOT NSTATIC )
+        set ( LDL_STATIC_LIBS "${LDL_STATIC_LIBS} -lm" )
         target_link_libraries ( LDL_static PUBLIC m )
     endif ( )
 endif ( )
@@ -188,6 +189,30 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/LDLConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/LDLConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/LDL )
+
+# create pkg-config file
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/LDL.pc.in
+    LDL.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/LDL.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/LDL/Config/LDL.pc.in
+++ b/LDL/Config/LDL.pc.in
@@ -1,0 +1,17 @@
+# LDL, Copyright (c) 2005-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: LDL
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: A sparse LDL' factorization and solve package in SuiteSparse
+Version: @LDL_VERSION_MAJOR@.@LDL_VERSION_MINOR@.@LDL_VERSION_SUB@
+Requires.private: AMD SuiteSparse_config
+Libs: -L${libdir} -lldl
+Libs.private: @LDL_STATIC_LIBS@
+Cflags: -I${includedir}

--- a/Mongoose/CMakeLists.txt
+++ b/Mongoose/CMakeLists.txt
@@ -29,7 +29,7 @@
 #
 #   make distclean
 
-cmake_minimum_required ( VERSION 3.19 )
+cmake_minimum_required ( VERSION 3.20 )
 
 #-------------------------------------------------------------------------------
 # SuiteSparse policies
@@ -487,6 +487,30 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/MongooseConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/MongooseConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/Mongoose )
+
+# create pkg-config file
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/Mongoose.pc.in
+    Mongoose.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/Mongoose.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # report status

--- a/Mongoose/Config/Mongoose.pc.in
+++ b/Mongoose/Config/Mongoose.pc.in
@@ -1,0 +1,16 @@
+# Mongoose, Copyright (c) 2018-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: GPL-3.0-only
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: Mongoose
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: Graph partitioning library in SuiteSparse
+Version: @Mongoose_VERSION_MAJOR@.@Mongoose_VERSION_MINOR@.@Mongoose_VERSION_PATCH@
+Requires.private: SuiteSparse_config
+Libs: -L${libdir} -lmongoose
+Cflags: -I${includedir}

--- a/RBio/CMakeLists.txt
+++ b/RBio/CMakeLists.txt
@@ -9,7 +9,7 @@
 # get the version
 #-------------------------------------------------------------------------------
 
-cmake_minimum_required ( VERSION 3.19 )
+cmake_minimum_required ( VERSION 3.20 )
 
 set ( RBIO_DATE "June 16, 2023" )
 set ( RBIO_VERSION_MAJOR 4 )
@@ -128,6 +128,7 @@ endif ( )
 if ( NOT WIN32 )
     target_link_libraries ( RBio PRIVATE m )
     if ( NOT NSTATIC )
+        set ( RBIO_STATIC_LIBS "${RBIO_STATIC_LIBS} -lm" )
         target_link_libraries ( RBio_static PUBLIC m )
     endif ( )
 endif ( )
@@ -173,6 +174,30 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/RBioConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/RBioConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/RBio )
+
+# create pkg-config file
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/RBio.pc.in
+    RBio.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/RBio.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/RBio/Config/RBio.pc.in
+++ b/RBio/Config/RBio.pc.in
@@ -1,0 +1,17 @@
+# RBio, Copyright (c) 2009-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: RBio
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: MATLAB Toolbox for reading/writing sparse matrices in Rutherford/Boeing format in SuiteSparse
+Version: @RBIO_VERSION_MAJOR@.@RBIO_VERSION_MINOR@.@RBIO_VERSION_SUB@
+Requires.private: SuiteSparse_config
+Libs: -L${libdir} -lrbio
+Libs.private: @RBIO_STATIC_LIBS@
+Cflags: -I${includedir}

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -10,7 +10,7 @@
 # get the version
 #-------------------------------------------------------------------------------
 
-cmake_minimum_required ( VERSION 3.19 )
+cmake_minimum_required ( VERSION 3.20 )
 
 set ( SPEX_DATE "June 16, 2023" )
 set ( SPEX_VERSION_MAJOR 2 )
@@ -168,6 +168,7 @@ endif ( )
 # MPFR:
 target_link_libraries ( SPEX PRIVATE ${MPFR_LIBRARIES} )
 if ( NOT NSTATIC )
+    list ( APPEND SPEX_STATIC_LIBS ${MPFR_STATIC} )
     target_link_libraries ( SPEX_static PUBLIC ${MPFR_STATIC} )
 endif ( )
 
@@ -175,6 +176,7 @@ endif ( )
 # must occur after MPFR
 target_link_libraries ( SPEX PRIVATE ${GMP_LIBRARIES} )
 if ( NOT NSTATIC )
+    list ( APPEND SPEX_STATIC_LIBS ${GMP_STATIC} )
     target_link_libraries ( SPEX_static PUBLIC ${GMP_STATIC} )
 endif ( )
 
@@ -182,6 +184,7 @@ endif ( )
 if ( NOT WIN32 )
     target_link_libraries ( SPEX PRIVATE m )
     if ( NOT NSTATIC )
+        list ( APPEND SPEX_STATIC_LIBS "m" )
         target_link_libraries ( SPEX_static PUBLIC m )
     endif ( )
 endif ( )
@@ -227,6 +230,55 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/SPEXConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/SPEXConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SPEX )
+
+# create pkg-config file
+
+# This might be something like:
+#   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
+# convert to -l flags for pkg-config, i.e.: "-lgomp -lpthread -lm"
+set ( SPEX_STATIC_LIBS_LIST ${SPEX_STATIC_LIBS} )
+set ( SPEX_STATIC_LIBS "" )
+foreach ( _lib ${SPEX_STATIC_LIBS_LIST} )
+        string ( FIND ${_lib} "." _pos REVERSE )
+        if ( ${_pos} EQUAL "-1" )
+            set ( SPEX_STATIC_LIBS "${SPEX_STATIC_LIBS} -l${_lib}" )
+            continue ()
+        endif ( )
+    foreach ( _kind IN ITEMS "IMPORT" "SHARED" "STATIC" )
+        set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
+        if ( ${_lib} MATCHES ${_regex} )
+            string ( REGEX REPLACE ${_regex} "\\2" _libname ${_lib} )
+            if ( NOT "${_libname}" STREQUAL "" )
+                set ( SPEX_STATIC_LIBS "${SPEX_STATIC_LIBS} -l${_libname}" )
+                break ()
+            endif ( )
+        endif ( )
+    endforeach ( )
+endforeach ( )
+message ( STATUS "SPEX_STATIC_LIBS: ${SPEX_STATIC_LIBS}" )
+
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/SPEX.pc.in
+    SPEX.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/SPEX.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/SPEX/Config/SPEX.pc.in
+++ b/SPEX/Config/SPEX.pc.in
@@ -1,0 +1,17 @@
+# SPEX, Copyright (c) 1996-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: SPEX
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: Software package for SParse EXact algebra in SuiteSparse
+Version: @SPEX_VERSION_MAJOR@.@SPEX_VERSION_MINOR@.@SPEX_VERSION_SUB@
+Requires.private: SuiteSparse_config AMD COLAMD
+Libs: -L${libdir} -lspex
+Libs.private: @SPEX_STATIC_LIBS@
+Cflags: -I${includedir}

--- a/SPQR/CMakeLists.txt
+++ b/SPQR/CMakeLists.txt
@@ -225,6 +225,7 @@ if ( OPENMP_FOUND )
     target_link_libraries ( SPQR PRIVATE ${OpenMP_C_LIBRARIES} )
     if ( NOT NSTATIC )
         target_link_libraries ( SPQR_static PUBLIC ${OpenMP_C_LIBRARIES} )
+        list ( APPEND SPQR_STATIC_LIBS ${OpenMP_C_LIBRARIES} )
     endif ( )
     set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} " )
     include_directories ( ${OpenMP_C_INCLUDE_DIRS} )
@@ -234,6 +235,7 @@ endif ( )
 if ( NOT WIN32 )
     target_link_libraries ( SPQR PRIVATE m )
     if ( NOT NSTATIC )
+        list ( APPEND SPQR_STATIC_LIBS "m" )
         target_link_libraries ( SPQR_static PUBLIC m )
     endif ( )
 endif ( )
@@ -258,25 +260,27 @@ if ( NOT NSTATIC )
     endif ( )
 endif ( )
 
-# BLAS:
-message ( STATUS "BLAS libraries:      ${BLAS_LIBRARIES} ")
-message ( STATUS "BLAS include:        ${BLAS_INCLUDE_DIRS} ")
-message ( STATUS "BLAS linker flags:   ${BLAS_LINKER_FLAGS} ")
-target_link_libraries ( SPQR PRIVATE ${BLAS_LIBRARIES} )
-if ( NOT NSTATIC )
-    target_link_libraries ( SPQR_static PUBLIC ${BLAS_LIBRARIES} )
-endif ( )
-include_directories ( ${BLAS_INCLUDE_DIRS} )
-
 # LAPACK:
 message ( STATUS "LAPACK libraries:    ${LAPACK_LIBRARIES} ")
 message ( STATUS "LAPACK include:      ${LAPACK_INCLUDE_DIRS} ")
 message ( STATUS "LAPACK linker flags: ${LAPACK_LINKER_FLAGS} ")
 target_link_libraries ( SPQR PRIVATE ${LAPACK_LIBRARIES} )
 if ( NOT NSTATIC )
+    list ( APPEND SPQR_STATIC_LIBS ${LAPACK_LIBRARIES} )
     target_link_libraries ( SPQR_static PUBLIC ${LAPACK_LIBRARIES} )
 endif ( )
 include_directories ( ${LAPACK_INCLUDE_DIR} )
+
+# BLAS:
+message ( STATUS "BLAS libraries:      ${BLAS_LIBRARIES} ")
+message ( STATUS "BLAS include:        ${BLAS_INCLUDE_DIRS} ")
+message ( STATUS "BLAS linker flags:   ${BLAS_LINKER_FLAGS} ")
+target_link_libraries ( SPQR PRIVATE ${BLAS_LIBRARIES} )
+if ( NOT NSTATIC )
+    list ( APPEND SPQR_STATIC_LIBS ${BLAS_LIBRARIES} )
+    target_link_libraries ( SPQR_static PUBLIC ${BLAS_LIBRARIES} )
+endif ( )
+include_directories ( ${BLAS_INCLUDE_DIRS} )
 
 # CHOLMOD:
 # link with CHOLMOD and its dependencies, both required and optional
@@ -296,7 +300,7 @@ endif ( )
 message ( STATUS "SPQR cuda:  ${SPQR_CUDA_LIBS} " )
 target_link_libraries ( SPQR PRIVATE ${SPQR_CUDA_LIBS} ${CUDA_LIBRARIES} )
 if ( NOT NSTATIC )
-target_link_libraries ( SPQR_static PUBLIC ${SPQR_CUDA_LIBS} ${CUDA_LIBRARIES} )
+    target_link_libraries ( SPQR_static PUBLIC ${SPQR_CUDA_LIBS} ${CUDA_LIBRARIES} )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -343,6 +347,55 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/SPQRConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/SPQRConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SPQR )
+
+# create pkg-config file
+
+# This might be something like:
+#   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
+# convert to -l flags for pkg-config, i.e.: "-lgomp -lpthread -lm"
+set ( SPQR_STATIC_LIBS_LIST ${SPQR_STATIC_LIBS} )
+set ( SPQR_STATIC_LIBS "" )
+foreach ( _lib ${SPQR_STATIC_LIBS_LIST} )
+    string ( FIND ${_lib} "." _pos REVERSE )
+    if ( ${_pos} EQUAL "-1" )
+        set ( SPQR_STATIC_LIBS "${SPQR_STATIC_LIBS} -l${_lib}" )
+        continue ()
+    endif ( )
+    foreach ( _kind IN ITEMS "IMPORT" "SHARED" "STATIC" )
+        set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
+        if ( ${_lib} MATCHES ${_regex} )
+            string ( REGEX REPLACE ${_regex} "\\2" _libname ${_lib} )
+            if ( NOT "${_libname}" STREQUAL "" )
+                set ( SPQR_STATIC_LIBS "${SPQR_STATIC_LIBS} -l${_libname}" )
+                break ()
+            endif ( )
+        endif ( )
+    endforeach ( )
+endforeach ( )
+message ( STATUS "SPQR_STATIC_LIBS: ${SPQR_STATIC_LIBS}" )
+
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/SPQR.pc.in
+    SPQR.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/SPQR.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/SPQR/Config/SPQR.pc.in
+++ b/SPQR/Config/SPQR.pc.in
@@ -1,0 +1,19 @@
+# SPQR, Copyright (c) 2008-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+# FIXME: Which flags do we need to statically link CUDA
+
+Name: SPQR
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: Multithreaded, multifrontal, rank-revealing sparse QR factorization method in SuiteSparse
+Version: @SPQR_VERSION_MAJOR@.@SPQR_VERSION_MINOR@.@SPQR_VERSION_SUB@
+Requires.private: SuiteSparse_config AMD COLAMD CHOLMOD
+Libs: -L${libdir} -lspqr
+Libs.private: @SPQR_STATIC_LIBS@
+Cflags: -I${includedir}

--- a/SPQR/Config/SPQR_CUDA.pc.in
+++ b/SPQR/Config/SPQR_CUDA.pc.in
@@ -1,0 +1,19 @@
+# SPQR_CUDA, Copyright (c) 2008-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+# FIXME: Which flags do we need to statically link CUDA
+
+Name: SPQR_CUDA
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: GPU module for SPQR in SuiteSparse
+Version: @SPQR_VERSION_MAJOR@.@SPQR_VERSION_MINOR@.@SPQR_VERSION_SUB@
+Requires.private: CHOLMOD
+Libs: -L${libdir} -lspqr_cuda
+Libs.private: @SPQR_STATIC_LIBS@
+Cflags: -I${includedir}

--- a/SPQR/SPQRGPU/CMakeLists.txt
+++ b/SPQR/SPQRGPU/CMakeLists.txt
@@ -11,7 +11,7 @@
 #-------------------------------------------------------------------------------
 
 # cmake 3.22 is required to find the BLAS/LAPACK
-cmake_minimum_required ( VERSION 3.19 )
+cmake_minimum_required ( VERSION 3.20 )
 
 message ( STATUS "Building SPQR_CUDA version: v"
     ${SPQR_VERSION_MAJOR}.
@@ -158,3 +158,26 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/../SPQR_CUDAConfigVersion.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SPQR_CUDA )
 
+# create pkg-config file
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    ../Config/SPQR_CUDA.pc.in
+    SPQR_CUDA.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/SPQR_CUDA.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )

--- a/SuiteSparse_GPURuntime/CMakeLists.txt
+++ b/SuiteSparse_GPURuntime/CMakeLists.txt
@@ -10,7 +10,7 @@
 # get the version
 #-------------------------------------------------------------------------------
 
-cmake_minimum_required ( VERSION 3.19 )
+cmake_minimum_required ( VERSION 3.20 )
 
 set ( SUITESPARSE_GPURUNTIME_DATE "June 16, 2023" )
 set ( SUITESPARSE_GPURUNTIME_VERSION_MAJOR 2 )
@@ -195,6 +195,30 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_GPURuntimeConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_GPURuntimeConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SuiteSparse_GPURuntime )
+
+# create pkg-config file
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/SuiteSparse_GPURuntime.pc.in
+    SuiteSparse_GPURuntime.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_GPURuntime.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # report status

--- a/SuiteSparse_GPURuntime/Config/SuiteSparse_GPURuntime.pc.in
+++ b/SuiteSparse_GPURuntime/Config/SuiteSparse_GPURuntime.pc.in
@@ -1,0 +1,18 @@
+# SuiteSparse_GPURuntime, Copyright (c) 2013-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+# FIXME: Which flags do we need to statically link CUDA
+
+Name: SuiteSparse_GPURuntime
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: Helper functions for the GPU in SuiteSparse
+Version: @SUITESPARSE_GPURUNTIME_VERSION_MAJOR@.@SUITESPARSE_GPURUNTIME_VERSION_MINOR@.@SUITESPARSE_GPURUNTIME_VERSION_SUB@
+Requires.private: SuiteSparse_config
+Libs: -L${libdir} -lsuitesparse_gpuruntime
+Cflags: -I${includedir}

--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -205,4 +205,28 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_configConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SuiteSparse_config )
 
+# create pkg-config file
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/SuiteSparse_config.pc.in
+    SuiteSparse_config.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_config.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+
 include ( SuiteSparseReport )

--- a/SuiteSparse_config/Config/SuiteSparse_config.pc.in
+++ b/SuiteSparse_config/Config/SuiteSparse_config.pc.in
@@ -1,0 +1,15 @@
+# SuiteSparse_config, Copyright (c) 2012-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: SuiteSparseConfig
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: Configuration for SuiteSparse
+Version: @SUITESPARSE_VERSION_MAJOR@.@SUITESPARSE_VERSION_MINOR@.@SUITESPARSE_VERSION_SUB@
+Libs: -L${libdir} -lsuitesparseconfig
+Cflags: -I${includedir}

--- a/UMFPACK/CMakeLists.txt
+++ b/UMFPACK/CMakeLists.txt
@@ -200,6 +200,7 @@ if ( OPENMP_FOUND )
     target_link_libraries ( UMFPACK PRIVATE ${OpenMP_C_LIBRARIES} )
     if ( NOT NSTATIC )
         target_link_libraries ( UMFPACK_static PUBLIC ${OpenMP_C_LIBRARIES} )
+        list ( APPEND UMFPACK_STATIC_LIBS ${OpenMP_C_LIBRARIES} )
     endif ( )
     set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} " )
     include_directories ( ${OpenMP_C_INCLUDE_DIRS} )
@@ -209,6 +210,7 @@ endif ( )
 if ( NOT WIN32 )
     target_link_libraries ( UMFPACK PRIVATE m )
     if ( NOT NSTATIC )
+        list ( APPEND UMFPACK_STATIC_LIBS "m" )
         target_link_libraries ( UMFPACK_static PUBLIC m )
     endif ( )
 endif ( )
@@ -231,6 +233,7 @@ message ( STATUS "BLAS include:        ${BLAS_INCLUDE_DIRS} ")
 message ( STATUS "BLAS linker flags:   ${BLAS_LINKER_FLAGS} ")
 target_link_libraries ( UMFPACK PRIVATE ${BLAS_LIBRARIES} )
 if ( NOT NSTATIC )
+    list ( APPEND UMFPACK_STATIC_LIBS ${BLAS_LIBRARIES} )
     target_link_libraries ( UMFPACK_static PUBLIC ${BLAS_LIBRARIES} )
 endif ( )
 include_directories ( ${BLAS_INCLUDE_DIRS} )
@@ -241,6 +244,7 @@ if ( NOT NCHOLMOD )
     target_link_libraries ( UMFPACK PRIVATE
         SuiteSparse::CHOLMOD ${CHOLMOD_CUDA_LIBRARIES} )
     if ( NOT NSTATIC )
+        set ( UMFPACK_STATIC_MODULES "${UMFPACK_STATIC_MODULES} CHOLMOD CHOLMOD_CUDA" )
         target_link_libraries ( UMFPACK_static PUBLIC
             ${CHOLMOD_CUDA_STATIC} )
         if ( TARGET SuiteSparse::CHOLMOD_static )
@@ -292,6 +296,54 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/UMFPACKConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/UMFPACKConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/UMFPACK )
+# create pkg-config file
+
+# This might be something like:
+#   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
+# convert to -l flags for pkg-config, i.e.: "-lgomp -lpthread -lm"
+set ( UMFPACK_STATIC_LIBS_LIST ${UMFPACK_STATIC_LIBS} )
+set ( UMFPACK_STATIC_LIBS "" )
+foreach ( _lib ${UMFPACK_STATIC_LIBS_LIST} )
+    string ( FIND ${_lib} "." _pos REVERSE )
+    if ( ${_pos} EQUAL "-1" )
+        set ( UMFPACK_STATIC_LIBS "${UMFPACK_STATIC_LIBS} -l${_lib}" )
+        continue ()
+    endif ( )
+    foreach ( _kind IN ITEMS "IMPORT" "SHARED" "STATIC" )
+        set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
+        if ( ${_lib} MATCHES ${_regex} )
+            string ( REGEX REPLACE ${_regex} "\\2" _libname ${_lib} )
+            if ( NOT "${_libname}" STREQUAL "" )
+                set ( UMFPACK_STATIC_LIBS "${UMFPACK_STATIC_LIBS} -l${_libname}" )
+                break ()
+            endif ( )
+        endif ( )
+    endforeach ( )
+endforeach ( )
+message ( STATUS "UMFPACK_STATIC_LIBS: ${UMFPACK_STATIC_LIBS}" )
+
+set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+set ( exec_prefix "\${prefix}" )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+    set ( libdir "${SUITESPARSE_LIBDIR}")
+else ( )
+    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+endif ( )
+cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+else ( )
+    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+endif ( )
+configure_file (
+    Config/UMFPACK.pc.in
+    UMFPACK.pc
+    @ONLY
+    NEWLINE_STYLE LF )
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/UMFPACK.pc
+    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/UMFPACK/Config/UMFPACK.pc.in
+++ b/UMFPACK/Config/UMFPACK.pc.in
@@ -1,0 +1,17 @@
+# UMFPACK, Copyright (c) 1995-2023, Timothy A. Davis.
+# All Rights Reserved.
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: UMFPACK
+URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
+Description: Routines solving sparse linear systems via LU factorization in SuiteSparse
+Version: @UMFPACK_VERSION_MAJOR@.@UMFPACK_VERSION_MINOR@.@UMFPACK_VERSION_SUB@
+Requires.private: SuiteSparse_config AMD @UMFPACK_STATIC_MODULES@
+Libs: -L${libdir} -lumfpack
+Libs.private: @UMFPACK_STATIC_LIBS@
+Cflags: -I${includedir}


### PR DESCRIPTION
The CMake modules make it pretty easy to link to any of the SuiteSparse libraries without much knowledge about the host system or dependencies.
Projects not using CMake currently need to find and track the libraries and dependencies manually. For those projects, it would be helpful if SuiteSparse installed pkg-config files which can be used to query compiler flags and linker flags easily across multiple platforms.

This PR adds rules to the CMake files to generate such pkg-config files for the libraries that are built as part of SuiteSparse.

E.g.:
```
$ pkg-config --cflags CHOLMOD
-I/usr/include
$ pkg-config --libs CHOLMOD
-L/usr/lib -lcholmod
```

If the package config files are not installed in a default location, `PKG_CONFIG_PATH` can be set to point to the correct one. E.g.:
```
$ PKG_CONFIG_PATH=~/SuiteSparse/lib/pkgconfig/ pkg-config --libs --static CHOLMOD
-L~/SuiteSparse/lib -lcholmod -lgomp -lthread -lthread -lm -lopenblas -lopenblas -lopenblas -L~/SuiteSparse/lib -lccolamd -lcamd -lcolamd -lamd -lsuitesparseconfig
```
(Note that the last command prints the linker flags for *static* linking.)

I don't know how to use CUDA. So, I don't know which flags need to be added for that. If users would like to link to CUDA, they'd still need to find the correct flags themselves. I left *FIXME* comments in the .pc files of the respective libraries.

The CMake function `cmake_path` was added in version 3.20 according to their documentation. Some CMake files already require version 3.22. For the others, I increased the minimum version to 3.20 (released March 2021).

The `Description` tag could probably be improved. I tried to use one of the first sentences of the documentation of each library to compose a short description and added "in SuiteSparse" to the end. I hope that is ok for a start.
