### PR TITLE
CHOLMOD: Automatically look for additional dependency in downstream projects if building with CUDA

### DIFF
--- a/CHOLMOD/Config/CHOLMODConfig.cmake.in
+++ b/CHOLMOD/Config/CHOLMODConfig.cmake.in
@@ -34,6 +34,18 @@ set ( CHOLMOD_VERSION_MINOR @CHOLMOD_VERSION_MINOR@ )
 set ( CHOLMOD_VERSION_PATCH @CHOLMOD_VERSION_SUB@ )
 set ( CHOLMOD_VERSION "@CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@" )
 
+if ( @SUITESPARSE_CUDA@ )
+    # Look for imported targets of additional dependency if CHOLMOD was built with CUDA
+
+    # First check in a common build tree
+    find_package ( CHOLMOD_CUDA @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@
+        PATHS ${CMAKE_SOURCE_DIR}/../CHOLMOD/build NO_DEFAULT_PATH )
+    # Then, check in the currently active CMAKE_MODULE_PATH
+    if ( NOT TARGET SuiteSparse::CHOLMOD_CUDA )
+        find_package ( CHOLMOD_CUDA @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@ REQUIRED )
+    endif ( )
+endif ( )
+
 include ( ${CMAKE_CURRENT_LIST_DIR}/CHOLMODTargets.cmake )
 
 # The following is only for backward compatibility with FindCHOLMOD.


### PR DESCRIPTION
I don't know how to use CUDA. But reading the conditionally added dependency in the `CMakeLists.txt` file from CHOLMOD, the change from this PR might make it pick up the corresponding import target.

@DrTimothyAldenDavis: Could you please check if that makes a difference for you?
