### PR TITLE
CMake: Import CUDA toolkit targets when importing CHOLMOD_CUDA.

### DIFF
--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -473,14 +473,12 @@ endif ( )
 
 # CHOLMOD_CUDA
 if ( SUITESPARSE_CUDA )
-    # this must be a PUBLIC link, not PRIVATE, so that libraries using
-    # CHOLMOD can link against these libraries
     message ( STATUS "CHOLMOD cuda: " ${CHOLMOD_CUDA} )
-    target_link_libraries ( CHOLMOD PUBLIC ${CHOLMOD_CUDA} )
+    target_link_libraries ( CHOLMOD PRIVATE ${CHOLMOD_CUDA} )
     if ( NOT NSTATIC )
         target_link_libraries ( CHOLMOD_static PUBLIC ${CHOLMOD_CUDA_static} )
     endif ( )
-    target_link_libraries ( CHOLMOD PUBLIC CUDA::nvrtc CUDA::cudart_static
+    target_link_libraries ( CHOLMOD PRIVATE CUDA::nvrtc CUDA::cudart_static
         CUDA::nvToolsExt CUDA::cublas )
     if ( NOT NSTATIC )
         target_link_libraries ( CHOLMOD_static PUBLIC CUDA::nvrtc CUDA::cudart_static

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -269,14 +269,8 @@ add_subdirectory ( GPU )
 if ( SUITESPARSE_CUDA )
     # with CUDA
     message ( STATUS "CUDA libraries: " ${CUDA_LIBRARIES} )
-    set ( CHOLMOD_CUDA CHOLMOD_CUDA ${CUDA_LIBRARIES} )
-    set ( CHOLMOD_CUDA_STATIC CHOLMOD_CUDA_static ${CUDA_LIBRARIES} )
     include_directories ( GPU ${CUDAToolkit_INCLUDE_DIRS} )
     link_directories ( "GPU" "${CUDA_LIBRARIES}" "/usr/local/cuda/lib64/stubs" "/usr/local/cuda/lib64" )
-else ( )
-    # without CUDA and RMM
-    set ( CHOLMOD_CUDA )
-    set ( CHOLMOD_CUDA_STATIC )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -474,9 +468,9 @@ endif ( )
 # CHOLMOD_CUDA
 if ( SUITESPARSE_CUDA )
     message ( STATUS "CHOLMOD cuda: " ${CHOLMOD_CUDA} )
-    target_link_libraries ( CHOLMOD PRIVATE ${CHOLMOD_CUDA} )
+    target_link_libraries ( CHOLMOD PRIVATE CHOLMOD_CUDA ${CUDA_LIBRARIES} )
     if ( NOT NSTATIC )
-        target_link_libraries ( CHOLMOD_static PUBLIC ${CHOLMOD_CUDA_static} )
+        target_link_libraries ( CHOLMOD_static PUBLIC CHOLMOD_CUDA_static ${CUDA_LIBRARIES} )
     endif ( )
     target_link_libraries ( CHOLMOD PRIVATE CUDA::nvrtc CUDA::cudart_static
         CUDA::nvToolsExt CUDA::cublas )
@@ -605,9 +599,9 @@ if ( DEMO )
     endif ( )
 
     # Libraries required for Demo programs
-    target_link_libraries ( cholmod_demo   PUBLIC CHOLMOD ${CHOLMOD_CUDA} SuiteSparse::SuiteSparseConfig )
-    target_link_libraries ( cholmod_l_demo PUBLIC CHOLMOD ${CHOLMOD_CUDA} SuiteSparse::SuiteSparseConfig )
-    target_link_libraries ( cholmod_simple PUBLIC CHOLMOD ${CHOLMOD_CUDA} )
+    target_link_libraries ( cholmod_demo   PUBLIC CHOLMOD CHOLMOD_CUDA SuiteSparse::SuiteSparseConfig )
+    target_link_libraries ( cholmod_l_demo PUBLIC CHOLMOD CHOLMOD_CUDA SuiteSparse::SuiteSparseConfig )
+    target_link_libraries ( cholmod_simple PUBLIC CHOLMOD CHOLMOD_CUDA )
 
 else ( )
 

--- a/CHOLMOD/Config/CHOLMOD_CUDAConfig.cmake.in
+++ b/CHOLMOD/Config/CHOLMOD_CUDAConfig.cmake.in
@@ -34,6 +34,11 @@ set ( CHOLMOD_CUDA_VERSION_MINOR @CHOLMOD_VERSION_MINOR@ )
 set ( CHOLMOD_CUDA_VERSION_PATCH @CHOLMOD_VERSION_SUB@ )
 set ( CHOLMOD_CUDA_VERSION "@CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@" )
 
+if ( @SUITESPARSE_CUDA@ )
+    # Look for NVIDIA CUDA toolkit if CHOLMOD_CUDA was built as a non-empty library.
+    FindCUDAToolkit ( @CUDAToolkit_VERSION_MAJOR@ REQUIRED )
+endif ( )
+
 include ( ${CMAKE_CURRENT_LIST_DIR}/CHOLMOD_CUDATargets.cmake )
 
 # The following is only for backward compatibility with FindCHOLMOD_CUDA.

--- a/CHOLMOD/GPU/CMakeLists.txt
+++ b/CHOLMOD/GPU/CMakeLists.txt
@@ -92,9 +92,7 @@ set_target_properties ( CHOLMOD_CUDA_static PROPERTIES POSITION_INDEPENDENT_CODE
 endif ( )
 
 if ( SUITESPARSE_CUDA )
-    # this must be a PUBLIC link, not PRIVATE, so the CHOLMOD library
-    # itself can link against these libraries
-    target_link_libraries ( CHOLMOD_CUDA PUBLIC CUDA::nvrtc CUDA::cudart_static
+    target_link_libraries ( CHOLMOD_CUDA PRIVATE CUDA::nvrtc CUDA::cudart_static
         CUDA::nvToolsExt CUDA::cublas )
     if ( NOT NSTATIC )
         target_link_libraries ( CHOLMOD_CUDA_static PUBLIC CUDA::nvrtc CUDA::cudart_static


### PR DESCRIPTION
Also don't require that consumers of the shared libraries need to link to CUDA.
