### PR TITLE
CHOLMOD: Don't look for CHOLMOD_CUDA in common source tree when installed

### DIFF
--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -510,9 +510,18 @@ install ( EXPORT CHOLMODTargets
     NAMESPACE SuiteSparse::
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CHOLMOD )
 
+# generate config file to be used in common build tree
+set ( SUITESPARSE_IN_BUILD_TREE on )
 configure_package_config_file (
     Config/CHOLMODConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/CHOLMODConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/CHOLMODConfig.cmake )
+
+# generate config file to be installed
+set ( SUITESPARSE_IN_BUILD_TREE off )
+configure_package_config_file (
+    Config/CHOLMODConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/target/CHOLMODConfig.cmake
     INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CHOLMOD )
 
 write_basic_package_version_file (
@@ -520,7 +529,7 @@ write_basic_package_version_file (
     COMPATIBILITY SameMajorVersion )
 
 install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/CHOLMODConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/target/CHOLMODConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/CHOLMODConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CHOLMOD )
 

--- a/CHOLMOD/Config/CHOLMODConfig.cmake.in
+++ b/CHOLMOD/Config/CHOLMODConfig.cmake.in
@@ -37,11 +37,15 @@ set ( CHOLMOD_VERSION "@CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_
 if ( @SUITESPARSE_CUDA@ )
     # Look for imported targets of additional dependency if CHOLMOD was built with CUDA
 
-    # First check in a common build tree
-    find_package ( CHOLMOD_CUDA @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@
-        PATHS ${CMAKE_SOURCE_DIR}/../CHOLMOD/build NO_DEFAULT_PATH )
-    # Then, check in the currently active CMAKE_MODULE_PATH
-    if ( NOT TARGET SuiteSparse::CHOLMOD_CUDA )
+    if ( @SUITESPARSE_IN_BUILD_TREE@ )
+        # First check in a common build tree
+        find_package ( CHOLMOD_CUDA @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@
+            PATHS ${CMAKE_SOURCE_DIR}/../CHOLMOD/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT TARGET SuiteSparse::CHOLMOD_CUDA )
+            find_package ( CHOLMOD_CUDA @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@ REQUIRED )
+        endif ( )
+    else ( )
         find_package ( CHOLMOD_CUDA @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@ REQUIRED )
     endif ( )
 endif ( )


### PR DESCRIPTION
Create two slightly different `CHOLMODConfig.cmake` files. One that is used in a common build tree before CHOLMOD was installed. And a slightly different one that is installed.
The second one doesn't attempt to look for CHOLMOD_CUDA in the `build` folder of a common source tree.
