### PR TITLE
CHOLMOD GPU:  Fix qsort 

### DIFF
--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -480,6 +480,20 @@ if ( SUITESPARSE_CUDA )
         target_link_libraries ( CHOLMOD_static PUBLIC CUDA::nvrtc CUDA::cudart_static
             CUDA::nvToolsExt CUDA::cublas )
     endif ( )
+
+    include ( CheckTypeSize )
+    set ( old_CMAKE_EXTRA_INCLUDE_FILES CMAKE_EXTRA_INCLUDE_FILES )
+    list ( APPEND CMAKE_EXTRA_INCLUDE_FILES "stdlib.h" )
+    check_type_size ( "__compar_fn_t" COMPAR_FN_T )
+    set ( CMAKE_EXTRA_INCLUDE_FILES old_CMAKE_EXTRA_INCLUDE_FILES )
+
+    if ( NOT HAVE_COMPAR_FN_T )
+        target_compile_definitions ( CHOLMOD PRIVATE NCOMPAR_FN_T )
+        if ( NOT NSTATIC )
+            target_compile_definitions ( CHOLMOD_static PRIVATE NCOMPAR_FN_T )
+        endif ( )
+    endif ( )
+
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/CHOLMOD/GPU/CMakeLists.txt
+++ b/CHOLMOD/GPU/CMakeLists.txt
@@ -100,6 +100,19 @@ if ( SUITESPARSE_CUDA )
     endif ( )
 endif ( )
 
+include ( CheckTypeSize )
+set ( old_CMAKE_EXTRA_INCLUDE_FILES CMAKE_EXTRA_INCLUDE_FILES )
+list ( APPEND CMAKE_EXTRA_INCLUDE_FILES "stdlib.h" )
+check_type_size ( "__compar_fn_t" COMPAR_FN_T )
+set ( CMAKE_EXTRA_INCLUDE_FILES old_CMAKE_EXTRA_INCLUDE_FILES )
+
+if ( NOT HAVE_COMPAR_FN_T )
+    target_compile_definitions ( CHOLMOD_CUDA PRIVATE NCOMPAR_FN_T )
+    if ( NOT NSTATIC )
+        target_compile_definitions ( CHOLMOD_CUDA_static PRIVATE NCOMPAR_FN_T )
+    endif ( )
+endif ( )
+
 #-------------------------------------------------------------------------------
 # installation location
 #-------------------------------------------------------------------------------

--- a/CHOLMOD/GPU/CMakeLists.txt
+++ b/CHOLMOD/GPU/CMakeLists.txt
@@ -100,19 +100,6 @@ if ( SUITESPARSE_CUDA )
     endif ( )
 endif ( )
 
-include ( CheckTypeSize )
-set ( old_CMAKE_EXTRA_INCLUDE_FILES CMAKE_EXTRA_INCLUDE_FILES )
-list ( APPEND CMAKE_EXTRA_INCLUDE_FILES "stdlib.h" )
-check_type_size ( "__compar_fn_t" COMPAR_FN_T )
-set ( CMAKE_EXTRA_INCLUDE_FILES old_CMAKE_EXTRA_INCLUDE_FILES )
-
-if ( NOT HAVE_COMPAR_FN_T )
-    target_compile_definitions ( CHOLMOD_CUDA PRIVATE NCOMPAR_FN_T )
-    if ( NOT NSTATIC )
-        target_compile_definitions ( CHOLMOD_CUDA_static PRIVATE NCOMPAR_FN_T )
-    endif ( )
-endif ( )
-
 #-------------------------------------------------------------------------------
 # installation location
 #-------------------------------------------------------------------------------

--- a/CHOLMOD/GPU/t_cholmod_gpu.c
+++ b/CHOLMOD/GPU/t_cholmod_gpu.c
@@ -188,9 +188,9 @@ int TEMPLATE2 (CHOLMOD (gpu_init))
 
 }
 
-#if !defined(NCOMPAR_FN_T)
-typedef int (*__compar_fn_t) (const void*, const void*);
-#enfif
+#if defined(NCOMPAR_FN_T)
+typedef int (*__compar_fn_t)(const void *, const void *);
+#endif
 
 /* ========================================================================== */
 /* === gpu_reorder_descendants ============================================== */

--- a/CHOLMOD/GPU/t_cholmod_gpu.c
+++ b/CHOLMOD/GPU/t_cholmod_gpu.c
@@ -188,6 +188,7 @@ int TEMPLATE2 (CHOLMOD (gpu_init))
 
 }
 
+typedef int (*__compar_fn_t) (const void*, const void*);
 
 /* ========================================================================== */
 /* === gpu_reorder_descendants ============================================== */

--- a/CHOLMOD/GPU/t_cholmod_gpu.c
+++ b/CHOLMOD/GPU/t_cholmod_gpu.c
@@ -188,7 +188,9 @@ int TEMPLATE2 (CHOLMOD (gpu_init))
 
 }
 
+#if !defined(NCOMPAR_FN_T)
 typedef int (*__compar_fn_t) (const void*, const void*);
+#enfif
 
 /* ========================================================================== */
 /* === gpu_reorder_descendants ============================================== */


### PR DESCRIPTION
No  `__compar_fn_t ` defined in windows when building with msvc. 