### PR TITLE
GPURuntime: Don't add include dir for SuiteSparse_Config to interface

### DIFF
--- a/SuiteSparse_GPURuntime/CMakeLists.txt
+++ b/SuiteSparse_GPURuntime/CMakeLists.txt
@@ -99,10 +99,8 @@ set_target_properties ( GPURuntime PROPERTIES
 
 target_include_directories ( GPURuntime PRIVATE
     ${CUDAToolkit_INCLUDE_DIRS}
-    ${SUITESPARSE_GPURUNTIME_INCLUDES} )
-
-target_include_directories ( GPURuntime PUBLIC
-    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
+    ${SUITESPARSE_GPURUNTIME_INCLUDES}
+    $<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES> )
 
 if ( SUITESPARSE_CUDA )
     set_target_properties ( GPURuntime PROPERTIES POSITION_INDEPENDENT_CODE ON )
@@ -136,10 +134,8 @@ if ( NOT NSTATIC )
 
     target_include_directories ( GPURuntime_static PRIVATE
         ${CUDAToolkit_INCLUDE_DIRS}
-        ${SUITESPARSE_GPURUNTIME_INCLUDES} )
-
-    target_include_directories ( GPURuntime_static PUBLIC
-        "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
+        ${SUITESPARSE_GPURUNTIME_INCLUDES}
+        $<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES> )
 
     if ( SUITESPARSE_CUDA )
         set_target_properties ( GPURuntime_static PROPERTIES CUDA_SEPARABLE_COMPILATION on )


### PR DESCRIPTION
There is no reason I can see why projects that link to this library would need to add the include directory of SuiteSparse_Config to the preprocessor flags.
This will probably also remove the confusing output in the configuration summary.
