### PR TITLE
CMake: Use `SUITESPARSE_INCLUDEDIR` in even more places.

### DIFF
--- a/CXSparse/CMakeLists.txt
+++ b/CXSparse/CMakeLists.txt
@@ -136,8 +136,8 @@ if ( NOT NSTATIC )
     endif ( )
 
     target_include_directories ( CXSparse_static
-        INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>"
-                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>" )
+        INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
+                  $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 
 endif ( )
 

--- a/GPUQREngine/CMakeLists.txt
+++ b/GPUQREngine/CMakeLists.txt
@@ -217,8 +217,8 @@ if ( NOT NSTATIC )
     endif ( )
 
     target_include_directories ( GPUQREngine_static
-        INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>"
-                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>" )
+        INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
+                  $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/LDL/CMakeLists.txt
+++ b/LDL/CMakeLists.txt
@@ -111,8 +111,8 @@ if ( NOT NSTATIC )
     endif ( )
 
     target_include_directories ( LDL_static 
-        INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>"
-                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>" )
+        INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
+                  $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 
 endif ( )
 

--- a/RBio/CMakeLists.txt
+++ b/RBio/CMakeLists.txt
@@ -103,8 +103,8 @@ if ( NOT NSTATIC )
     endif ( )
 
     target_include_directories ( RBio_static 
-        INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>"
-                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>" )
+        INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
+                  $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 
 endif ( )
 

--- a/SuiteSparse_GPURuntime/CMakeLists.txt
+++ b/SuiteSparse_GPURuntime/CMakeLists.txt
@@ -111,7 +111,7 @@ endif ( )
 
 target_include_directories ( GPURuntime 
     INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
-              $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}> )
+              $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 
 #-------------------------------------------------------------------------------
 # static suitesparse_gpuruntime library properties

--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -116,8 +116,8 @@ if ( NOT NSTATIC )
     endif ( )
 
     target_include_directories ( SuiteSparseConfig_static
-        INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
-                  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>" )
+        INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                  $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 endif ( )
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Also, don't double quote generator expressions.

Those are some instances that I missed in #364.

I'm pretty sure that I grepped for `CMAKE_INSTALL_INCLUDEDIR` when I made those changes. But my concentration might have been low (late evening here)…