### PR TITLE
CMake: Import CUDA toolkit targets when importing SPQR_CUDA.

### DIFF
--- a/SPQR/Config/SPQR_CUDAConfig.cmake.in
+++ b/SPQR/Config/SPQR_CUDAConfig.cmake.in
@@ -34,6 +34,9 @@ set ( SPQR_CUDA_VERSION_MINOR @SPQR_VERSION_MINOR@ )
 set ( SPQR_CUDA_VERSION_PATCH @SPQR_VERSION_SUB@ )
 set ( SPQR_CUDA_VERSION "@SPQR_VERSION_MAJOR@.@SPQR_VERSION_MINOR@.@SPQR_VERSION_SUB@" )
 
+# Look for NVIDIA CUDA toolkit
+find_package ( CUDAToolkit @CUDAToolkit_VERSION_MAJOR@ REQUIRED )
+
 include ( ${CMAKE_CURRENT_LIST_DIR}/SPQR_CUDATargets.cmake )
 
 # The following is only for backward compatibility with FindSPQR_CUDA.


### PR DESCRIPTION
That is similar to what was done in #358 for CHOLMOD_CUDA. But this can be done unconditionally because SPQR_CUDA is only built if `SUITESPARSE_CUDA` is true. So, no need to guard on it like in CHOLMOD_CUDA.
