### PR TITLE
CHOLMOD: Don't build libcholmod_cuda when building without CUDA.

### DIFF
--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -265,9 +265,9 @@ endif ( )
 # find CUDA
 #-------------------------------------------------------------------------------
 
-add_subdirectory ( GPU )
 if ( SUITESPARSE_CUDA )
     # with CUDA
+    add_subdirectory ( GPU )
     message ( STATUS "CUDA libraries: " ${CUDA_LIBRARIES} )
     include_directories ( GPU ${CUDAToolkit_INCLUDE_DIRS} )
     link_directories ( "GPU" "${CUDA_LIBRARIES}" "/usr/local/cuda/lib64/stubs" "/usr/local/cuda/lib64" )
@@ -626,9 +626,18 @@ if ( DEMO )
     endif ( )
 
     # Libraries required for Demo programs
-    target_link_libraries ( cholmod_demo   PUBLIC CHOLMOD CHOLMOD_CUDA SuiteSparse::SuiteSparseConfig )
-    target_link_libraries ( cholmod_l_demo PUBLIC CHOLMOD CHOLMOD_CUDA SuiteSparse::SuiteSparseConfig )
-    target_link_libraries ( cholmod_simple PUBLIC CHOLMOD CHOLMOD_CUDA )
+    target_link_libraries ( cholmod_demo PUBLIC CHOLMOD SuiteSparse::SuiteSparseConfig )
+    if ( SUITESPARSE_CUDA )
+        target_link_libraries ( cholmod_demo PUBLIC CHOLMOD_CUDA )
+    endif ( )
+    target_link_libraries ( cholmod_l_demo PUBLIC CHOLMOD SuiteSparse::SuiteSparseConfig )
+    if ( SUITESPARSE_CUDA )
+        target_link_libraries ( cholmod_l_demo PUBLIC CHOLMOD_CUDA )
+    endif ( )
+    target_link_libraries ( cholmod_simple PUBLIC CHOLMOD )
+    if ( SUITESPARSE_CUDA )
+        target_link_libraries ( cholmod_simple PUBLIC CHOLMOD_CUDA )
+    endif ( )
 
 else ( )
 

--- a/CHOLMOD/Config/CHOLMOD_CUDAConfig.cmake.in
+++ b/CHOLMOD/Config/CHOLMOD_CUDAConfig.cmake.in
@@ -34,11 +34,8 @@ set ( CHOLMOD_CUDA_VERSION_MINOR @CHOLMOD_VERSION_MINOR@ )
 set ( CHOLMOD_CUDA_VERSION_PATCH @CHOLMOD_VERSION_SUB@ )
 set ( CHOLMOD_CUDA_VERSION "@CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@" )
 
-if ( @SUITESPARSE_CUDA@ )
-    # Look for NVIDIA CUDA toolkit if CHOLMOD_CUDA was built as a non-empty library.
-    # FindCUDAToolkit ( @CUDAToolkit_VERSION_MAJOR@ REQUIRED )
-    find_package ( CUDAToolkit @CUDAToolkit_VERSION_MAJOR@ REQUIRED )
-endif ( )
+# Look for NVIDIA CUDA toolkit
+find_package ( CUDAToolkit @CUDAToolkit_VERSION_MAJOR@ REQUIRED )
 
 include ( ${CMAKE_CURRENT_LIST_DIR}/CHOLMOD_CUDATargets.cmake )
 

--- a/CHOLMOD/GPU/CMakeLists.txt
+++ b/CHOLMOD/GPU/CMakeLists.txt
@@ -11,7 +11,7 @@
 #-------------------------------------------------------------------------------
 
 # cmake 3.22 is required to find the BLAS/LAPACK
-cmake_minimum_required ( VERSION 3.19 )
+cmake_minimum_required ( VERSION 3.20 )
 
 message ( STATUS "Building CHOLMOD_CUDA version: v"
     ${CHOLMOD_VERSION_MAJOR}.
@@ -20,22 +20,15 @@ message ( STATUS "Building CHOLMOD_CUDA version: v"
 
 include ( SuiteSparsePolicy )
 
-if ( SUITESPARSE_CUDA )
-    project ( cholmod_cuda
-        VERSION "${CHOLMOD_VERSION_MAJOR}.${CHOLMOD_VERSION_MINOR}.${CHOLMOD_VERSION_SUB}"
-        LANGUAGES C CXX CUDA )
-    set ( CMAKE_CUDA_FLAGS "-cudart=static -lineinfo -DSUITESPARSE_CUDA" )
-    set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSUITESPARSE_CUDA" )
-    message ( STATUS "C++ flags for CUDA:  ${CMAKE_CXX_FLAGS}" )
-    message ( STATUS "nvcc flags for CUDA: ${CMAKE_CUDA_FLAGS}" )
-    file ( GLOB CHOLMOD_CUDA_SOURCES "cholmod_gpu.c" "cholmod_l_gpu.c"
-        "cholmod_gpu_kernels.cu" )
-else ( )
-    project ( cholmod_cuda
-        VERSION "${CHOLMOD_VERSION_MAJOR}.${CHOLMOD_VERSION_MINOR}.${CHOLMOD_VERSION_SUB}"
-        LANGUAGES C CXX )
-    file ( GLOB CHOLMOD_CUDA_SOURCES "cholmod_gpu.c" "cholmod_l_gpu.c" )
-endif ( )
+project ( cholmod_cuda
+    VERSION "${CHOLMOD_VERSION_MAJOR}.${CHOLMOD_VERSION_MINOR}.${CHOLMOD_VERSION_SUB}"
+    LANGUAGES C CXX CUDA )
+set ( CMAKE_CUDA_FLAGS "-cudart=static -lineinfo -DSUITESPARSE_CUDA" )
+set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSUITESPARSE_CUDA" )
+message ( STATUS "C++ flags for CUDA:  ${CMAKE_CXX_FLAGS}" )
+message ( STATUS "nvcc flags for CUDA: ${CMAKE_CUDA_FLAGS}" )
+file ( GLOB CHOLMOD_CUDA_SOURCES "cholmod_gpu.c" "cholmod_l_gpu.c"
+    "cholmod_gpu_kernels.cu" )
 
 add_library ( CHOLMOD_CUDA SHARED ${CHOLMOD_CUDA_SOURCES} )
 
@@ -91,13 +84,11 @@ set_target_properties ( CHOLMOD_CUDA_static PROPERTIES CUDA_SEPARABLE_COMPILATIO
 set_target_properties ( CHOLMOD_CUDA_static PROPERTIES POSITION_INDEPENDENT_CODE on )
 endif ( )
 
-if ( SUITESPARSE_CUDA )
-    target_link_libraries ( CHOLMOD_CUDA PRIVATE CUDA::nvrtc CUDA::cudart_static
+target_link_libraries ( CHOLMOD_CUDA PRIVATE CUDA::nvrtc CUDA::cudart_static
+    CUDA::nvToolsExt CUDA::cublas )
+if ( NOT NSTATIC )
+    target_link_libraries ( CHOLMOD_CUDA_static PUBLIC CUDA::nvrtc CUDA::cudart_static
         CUDA::nvToolsExt CUDA::cublas )
-    if ( NOT NSTATIC )
-        target_link_libraries ( CHOLMOD_CUDA_static PUBLIC CUDA::nvrtc CUDA::cudart_static
-            CUDA::nvToolsExt CUDA::cublas )
-    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This is similar to what was done for SPQR_CUDA.
It fixes #285 and #308 afaict.
