### PR TITLE
CSparse: Don't install pkg-config file.

### DIFF
--- a/CSparse/CMakeLists.txt
+++ b/CSparse/CMakeLists.txt
@@ -149,9 +149,9 @@ configure_file (
     CSparse.pc
     @ONLY
     NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/CSparse.pc
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
+# install ( FILES
+#     ${CMAKE_CURRENT_BINARY_DIR}/CSparse.pc
+#     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs


### PR DESCRIPTION
Nothing else is installed for CSparse. So, don't install the pkg-config file either.

Should it be built at all with the default rules in the root Makefile if it doesn't get installed anyway?

