### PR TITLE
CHOLMOD: Don't include external headers in `extern "C"` block.

### DIFF
--- a/CHOLMOD/Config/cholmod.h.in
+++ b/CHOLMOD/Config/cholmod.h.in
@@ -102,11 +102,6 @@
 #define CHOLMOD_SUB_VERSION    @CHOLMOD_VERSION_MINOR@
 #define CHOLMOD_SUBSUB_VERSION @CHOLMOD_VERSION_SUB@
 
-/* make it easy for C++ programs to include CHOLMOD */
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* ========================================================================== */
 /* === Include/cholmod_io64 ================================================= */
 /* ========================================================================== */
@@ -583,6 +578,11 @@ extern "C" {
 #define CHOLMOD_SIMPLICIAL 0	/* always do simplicial */
 #define CHOLMOD_AUTO 1		/* select simpl/super depending on matrix */
 #define CHOLMOD_SUPERNODAL 2	/* always do supernodal */
+
+/* make it easy for C++ programs to include CHOLMOD */
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct cholmod_common_struct
 {
@@ -4596,6 +4596,11 @@ int cholmod_l_super_ltsolve (cholmod_factor *, cholmod_dense *, cholmod_dense *,
 
 #endif
 
+#ifdef __cplusplus
+}
+#endif
+
+
 /* ========================================================================== */
 /* === Include/cholmod_gpu.h ================================================ */
 /* ========================================================================== */
@@ -4633,6 +4638,11 @@ int cholmod_l_super_ltsolve (cholmod_factor *, cholmod_dense *, cholmod_dense *,
 #define CHOLMOD_GPU_SKIP     3    
 
 #define CHOLMOD_HANDLE_CUDA_ERROR(e,s) {if (e) {ERROR(CHOLMOD_GPU_PROBLEM,s);}}
+
+/* make it easy for C++ programs to include CHOLMOD */
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct cholmod_gpu_pointers
 {
@@ -4672,11 +4682,10 @@ void cholmod_l_gpu_end ( cholmod_common *Common ) ;
 int cholmod_gpu_allocate   ( cholmod_common *Common ) ;
 int cholmod_l_gpu_allocate ( cholmod_common *Common ) ;
 
-#endif
-
 #ifdef __cplusplus
 }
 #endif
 
 #endif
 
+#endif

--- a/CHOLMOD/Include/cholmod.h
+++ b/CHOLMOD/Include/cholmod.h
@@ -102,11 +102,6 @@
 #define CHOLMOD_SUB_VERSION    2
 #define CHOLMOD_SUBSUB_VERSION 0
 
-/* make it easy for C++ programs to include CHOLMOD */
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /* ========================================================================== */
 /* === Include/cholmod_io64 ================================================= */
 /* ========================================================================== */
@@ -583,6 +578,11 @@ extern "C" {
 #define CHOLMOD_SIMPLICIAL 0	/* always do simplicial */
 #define CHOLMOD_AUTO 1		/* select simpl/super depending on matrix */
 #define CHOLMOD_SUPERNODAL 2	/* always do supernodal */
+
+/* make it easy for C++ programs to include CHOLMOD */
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct cholmod_common_struct
 {
@@ -4596,6 +4596,11 @@ int cholmod_l_super_ltsolve (cholmod_factor *, cholmod_dense *, cholmod_dense *,
 
 #endif
 
+#ifdef __cplusplus
+}
+#endif
+
+
 /* ========================================================================== */
 /* === Include/cholmod_gpu.h ================================================ */
 /* ========================================================================== */
@@ -4633,6 +4638,11 @@ int cholmod_l_super_ltsolve (cholmod_factor *, cholmod_dense *, cholmod_dense *,
 #define CHOLMOD_GPU_SKIP     3    
 
 #define CHOLMOD_HANDLE_CUDA_ERROR(e,s) {if (e) {ERROR(CHOLMOD_GPU_PROBLEM,s);}}
+
+/* make it easy for C++ programs to include CHOLMOD */
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct cholmod_gpu_pointers
 {
@@ -4672,11 +4682,10 @@ void cholmod_l_gpu_end ( cholmod_common *Common ) ;
 int cholmod_gpu_allocate   ( cholmod_common *Common ) ;
 int cholmod_l_gpu_allocate ( cholmod_common *Common ) ;
 
-#endif
-
 #ifdef __cplusplus
 }
 #endif
 
 #endif
 
+#endif


### PR DESCRIPTION
This avoids compilation errors like the following (for older(?) versions of CUDA) when including `cholmod.h` in C++ code:
```
  In file included from /usr/include/c++/11/utility:69,
                   from /usr/include/cuda_fp16.hpp:67,
                   from /usr/include/cuda_fp16.h:3673,
                   from /usr/include/cublas_api.h:75,
                   from /usr/include/cublas_v2.h:65,
                   from /home/runner/work/SuiteSparse/SuiteSparse/include/cholmod.h:456,
                   from /home/runner/work/SuiteSparse/SuiteSparse/Example/Include/my_internal.h:17,
                   from /home/runner/work/SuiteSparse/SuiteSparse/Example/Source/my_cxx.cc:7:
  /usr/include/c++/11/bits/stl_relops.h:85:5: error: template with C linkage
     85 |     template <class _Tp>
        |     ^~~~~~~~
  In file included from /home/runner/work/SuiteSparse/SuiteSparse/Example/Include/my_internal.h:17,
                   from /home/runner/work/SuiteSparse/SuiteSparse/Example/Source/my_cxx.cc:7:
  /home/runner/work/SuiteSparse/SuiteSparse/include/cholmod.h:107:1: note: ‘extern "C"’ linkage started here
    107 | extern "C" {
        | ^~~~~~~~~~
```
```
  In file included from /usr/include/cuda_runtime.h:95,
                   from /home/runner/work/SuiteSparse/SuiteSparse/include/cholmod.h:4618,
                   from /home/runner/work/SuiteSparse/SuiteSparse/Example/Include/my_internal.h:17,
                   from /home/runner/work/SuiteSparse/SuiteSparse/Example/Source/my_cxx.cc:7:
  /usr/include/channel_descriptor.h:124:1: error: template with C linkage
    124 | template<class T> __inline__ __host__ cudaChannelFormatDesc cudaCreateChannelDesc(void)
        | ^~~~~~~~
  In file included from /home/runner/work/SuiteSparse/SuiteSparse/Example/Include/my_internal.h:17,
                   from /home/runner/work/SuiteSparse/SuiteSparse/Example/Source/my_cxx.cc:7:
  /home/runner/work/SuiteSparse/SuiteSparse/include/cholmod.h:584:1: note: ‘extern "C"’ linkage started here
    584 | extern "C" {
        | ^~~~~~~~~~
```

It would be nice if this can be included in SuiteSparse 7.2.0.
