### PR TITLE
Don't generate .pc files for MSVC compatible tool chains.

### DIFF
--- a/AMD/CMakeLists.txt
+++ b/AMD/CMakeLists.txt
@@ -196,28 +196,30 @@ install ( FILES
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+if ( NOT MSVC )
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/AMD.pc.in
+        AMD.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/AMD.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/AMD.pc.in
-    AMD.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/AMD.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/BTF/CMakeLists.txt
+++ b/BTF/CMakeLists.txt
@@ -179,28 +179,30 @@ install ( FILES
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+if ( NOT MSVC )
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/BTF.pc.in
+        BTF.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/BTF.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/BTF.pc.in
-    BTF.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/BTF.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # report status

--- a/CAMD/CMakeLists.txt
+++ b/CAMD/CMakeLists.txt
@@ -181,28 +181,30 @@ install ( FILES
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+if ( NOT MSVC )
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/CAMD.pc.in
+        CAMD.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/CAMD.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/CAMD.pc.in
-    CAMD.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/CAMD.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/CCOLAMD/CMakeLists.txt
+++ b/CCOLAMD/CMakeLists.txt
@@ -178,28 +178,30 @@ install ( FILES
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+if ( NOT MSVC )
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/CCOLAMD.pc.in
+        CCOLAMD.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/CCOLAMD.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/CCOLAMD.pc.in
-    CCOLAMD.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/CCOLAMD.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -557,52 +557,53 @@ install ( FILES
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-# This might be something like:
-#   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
-# convert to -l flags for pkg-config, i.e.: "-lgomp -lpthread -lm"
-set ( CHOLMOD_STATIC_LIBS_LIST ${CHOLMOD_STATIC_LIBS} )
-set ( CHOLMOD_STATIC_LIBS "" )
-foreach ( _lib ${CHOLMOD_STATIC_LIBS_LIST} )
-    string ( FIND ${_lib} "." _pos REVERSE )
-    if ( ${_pos} EQUAL "-1" )
-        set ( CHOLMOD_STATIC_LIBS "${CHOLMOD_STATIC_LIBS} -l${_lib}" )
-        continue ()
-    endif ( )
-    foreach ( _kind IN ITEMS "IMPORT" "SHARED" "STATIC" )
-        set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
-        if ( ${_lib} MATCHES ${_regex} )
-            string ( REGEX REPLACE ${_regex} "\\2" _libname ${_lib} )
-            if ( NOT "${_libname}" STREQUAL "" )
-                set ( CHOLMOD_STATIC_LIBS "${CHOLMOD_STATIC_LIBS} -l${_libname}" )
-                break ()
-            endif ( )
+if ( NOT MSVC )
+    # This might be something like:
+    #   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
+    # convert to -l flags for pkg-config, i.e.: "-lgomp -lpthread -lm"
+    set ( CHOLMOD_STATIC_LIBS_LIST ${CHOLMOD_STATIC_LIBS} )
+    set ( CHOLMOD_STATIC_LIBS "" )
+    foreach ( _lib ${CHOLMOD_STATIC_LIBS_LIST} )
+        string ( FIND ${_lib} "." _pos REVERSE )
+        if ( ${_pos} EQUAL "-1" )
+            set ( CHOLMOD_STATIC_LIBS "${CHOLMOD_STATIC_LIBS} -l${_lib}" )
+            continue ()
         endif ( )
+        foreach ( _kind IN ITEMS "IMPORT" "SHARED" "STATIC" )
+            set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
+            if ( ${_lib} MATCHES ${_regex} )
+                string ( REGEX REPLACE ${_regex} "\\2" _libname ${_lib} )
+                if ( NOT "${_libname}" STREQUAL "" )
+                    set ( CHOLMOD_STATIC_LIBS "${CHOLMOD_STATIC_LIBS} -l${_libname}" )
+                    break ()
+                endif ( )
+            endif ( )
+        endforeach ( )
     endforeach ( )
-endforeach ( )
-message ( STATUS "CHOLMOD_STATIC_LIBS: ${CHOLMOD_STATIC_LIBS}" )
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/CHOLMOD.pc.in
+        CHOLMOD.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/CHOLMOD.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/CHOLMOD.pc.in
-    CHOLMOD.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/CHOLMOD.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/CHOLMOD/GPU/CMakeLists.txt
+++ b/CHOLMOD/GPU/CMakeLists.txt
@@ -134,26 +134,31 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/../CHOLMOD_CUDAConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CHOLMOD_CUDA )
 
+#-------------------------------------------------------------------------------
 # create pkg-config file
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+#-------------------------------------------------------------------------------
+
+if ( NOT MSVC )
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        ../Config/CHOLMOD_CUDA.pc.in
+        CHOLMOD_CUDA.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/CHOLMOD_CUDA.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    ../Config/CHOLMOD_CUDA.pc.in
-    CHOLMOD_CUDA.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/CHOLMOD_CUDA.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )

--- a/COLAMD/CMakeLists.txt
+++ b/COLAMD/CMakeLists.txt
@@ -178,28 +178,30 @@ install ( FILES
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+if ( NOT MSVC )
+  set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+  set ( exec_prefix "\${prefix}" )
+  cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+  if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+      set ( libdir "${SUITESPARSE_LIBDIR}")
+  else ( )
+      set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+  endif ( )
+  cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+  if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+      set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+  else ( )
+      set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+  endif ( )
+  configure_file (
+      Config/COLAMD.pc.in
+      COLAMD.pc
+      @ONLY
+      NEWLINE_STYLE LF )
+  install ( FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/COLAMD.pc
+      DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/COLAMD.pc.in
-    COLAMD.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/COLAMD.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/CSparse/CMakeLists.txt
+++ b/CSparse/CMakeLists.txt
@@ -130,28 +130,30 @@ endif ( )
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE CMAKE_INSTALL_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${CMAKE_INSTALL_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+if ( NOT MSVC )
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE CMAKE_INSTALL_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${CMAKE_INSTALL_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE CMAKE_INSTALL_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${CMAKE_INSTALL_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/CSparse.pc.in
+        CSparse.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    # install ( FILES
+    #     ${CMAKE_CURRENT_BINARY_DIR}/CSparse.pc
+    #     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE CMAKE_INSTALL_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${CMAKE_INSTALL_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/CSparse.pc.in
-    CSparse.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-# install ( FILES
-#     ${CMAKE_CURRENT_BINARY_DIR}/CSparse.pc
-#     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/CXSparse/CMakeLists.txt
+++ b/CXSparse/CMakeLists.txt
@@ -211,28 +211,30 @@ install ( FILES
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+if ( NOT MSVC )
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/CXSparse.pc.in
+        CXSparse.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/CXSparse.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/CXSparse.pc.in
-    CXSparse.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/CXSparse.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/GPUQREngine/CMakeLists.txt
+++ b/GPUQREngine/CMakeLists.txt
@@ -267,28 +267,30 @@ install ( FILES
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+if ( NOT MSVC )
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/GPUQREngine.pc.in
+        GPUQREngine.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/GPUQREngine.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/GPUQREngine.pc.in
-    GPUQREngine.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/GPUQREngine.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -508,52 +508,53 @@ install ( FILES
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-# This might be something like:
-#   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
-# convert to -l flags for pkg-config, i.e.: "-lgomp -lpthread -lm"
-set ( GRAPHBLAS_STATIC_LIBS_LIST ${GRAPHBLAS_STATIC_LIBS} )
-set ( GRAPHBLAS_STATIC_LIBS "" )
-foreach ( _lib ${GRAPHBLAS_STATIC_LIBS_LIST} )
-    string ( FIND ${_lib} "." _pos REVERSE )
-    if ( ${_pos} EQUAL "-1" )
-        set ( GRAPHBLAS_STATIC_LIBS "${GRAPHBLAS_STATIC_LIBS} -l${_lib}" )
-        continue ()
-    endif ( )
-    foreach ( _kind IN ITEMS "IMPORT" "SHARED" "STATIC" )
-        set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
-        if ( ${_lib} MATCHES ${_regex} )
-            string ( REGEX REPLACE ${_regex} "\\2" _libname ${_lib} )
-            if ( NOT "${_libname}" STREQUAL "" )
-                set ( GRAPHBLAS_STATIC_LIBS "${GRAPHBLAS_STATIC_LIBS} -l${_libname}" )
-                break ()
-            endif ( )
+if ( NOT MSVC )
+    # This might be something like:
+    #   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
+    # convert to -l flags for pkg-config, i.e.: "-lgomp -lpthread -lm"
+    set ( GRAPHBLAS_STATIC_LIBS_LIST ${GRAPHBLAS_STATIC_LIBS} )
+    set ( GRAPHBLAS_STATIC_LIBS "" )
+    foreach ( _lib ${GRAPHBLAS_STATIC_LIBS_LIST} )
+        string ( FIND ${_lib} "." _pos REVERSE )
+        if ( ${_pos} EQUAL "-1" )
+            set ( GRAPHBLAS_STATIC_LIBS "${GRAPHBLAS_STATIC_LIBS} -l${_lib}" )
+            continue ()
         endif ( )
+        foreach ( _kind IN ITEMS "IMPORT" "SHARED" "STATIC" )
+            set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
+            if ( ${_lib} MATCHES ${_regex} )
+                string ( REGEX REPLACE ${_regex} "\\2" _libname ${_lib} )
+                if ( NOT "${_libname}" STREQUAL "" )
+                    set ( GRAPHBLAS_STATIC_LIBS "${GRAPHBLAS_STATIC_LIBS} -l${_libname}" )
+                    break ()
+                endif ( )
+            endif ( )
+        endforeach ( )
     endforeach ( )
-endforeach ( )
-message ( STATUS "GRAPHBLAS_STATIC_LIBS: ${GRAPHBLAS_STATIC_LIBS}" )
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/GraphBLAS.pc.in
+        GraphBLAS.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/GraphBLAS.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/GraphBLAS.pc.in
-    GraphBLAS.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/GraphBLAS.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # configure the JITs

--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -371,28 +371,30 @@ install ( FILES
 # create pkg-config file for KLU
 #-------------------------------------------------------------------------------
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+if ( NOT MSVC )
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/KLU.pc.in
+        KLU.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/KLU.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/KLU.pc.in
-    KLU.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/KLU.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # KLU_CHOLMOD installation
@@ -439,28 +441,30 @@ if ( NOT NCHOLMOD )
     # create pkg-config file for KLU_CHOLMOD
     #---------------------------------------------------------------------------
 
-    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-    set ( exec_prefix "\${prefix}" )
-    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-        set ( libdir "${SUITESPARSE_LIBDIR}")
-    else ( )
-        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    if ( NOT MSVC )
+        set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+        set ( exec_prefix "\${prefix}" )
+        cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+        if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+            set ( libdir "${SUITESPARSE_LIBDIR}")
+        else ( )
+            set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+        endif ( )
+        cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+        if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+            set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+        else ( )
+            set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+        endif ( )
+        configure_file (
+            Config/KLU_CHOLMOD.pc.in
+            KLU_CHOLMOD.pc
+            @ONLY
+            NEWLINE_STYLE LF )
+        install ( FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/KLU_CHOLMOD.pc
+            DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
     endif ( )
-    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-    else ( )
-        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-    endif ( )
-    configure_file (
-        Config/KLU_CHOLMOD.pc.in
-        KLU_CHOLMOD.pc
-        @ONLY
-        NEWLINE_STYLE LF )
-    install ( FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/KLU_CHOLMOD.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/LDL/CMakeLists.txt
+++ b/LDL/CMakeLists.txt
@@ -194,28 +194,30 @@ install ( FILES
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+if ( NOT MSVC )
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/LDL.pc.in
+        LDL.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/LDL.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/LDL.pc.in
-    LDL.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/LDL.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/Mongoose/CMakeLists.txt
+++ b/Mongoose/CMakeLists.txt
@@ -492,28 +492,30 @@ install ( FILES
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+if ( NOT MSVC )
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/Mongoose.pc.in
+        Mongoose.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/Mongoose.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/Mongoose.pc.in
-    Mongoose.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/Mongoose.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # report status

--- a/RBio/CMakeLists.txt
+++ b/RBio/CMakeLists.txt
@@ -179,28 +179,30 @@ install ( FILES
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+if ( NOT MSVC )
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/RBio.pc.in
+        RBio.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/RBio.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/RBio.pc.in
-    RBio.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/RBio.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -236,52 +236,53 @@ install ( FILES
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-# This might be something like:
-#   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
-# convert to -l flags for pkg-config, i.e.: "-lgomp -lpthread -lm"
-set ( SPEX_STATIC_LIBS_LIST ${SPEX_STATIC_LIBS} )
-set ( SPEX_STATIC_LIBS "" )
-foreach ( _lib ${SPEX_STATIC_LIBS_LIST} )
-        string ( FIND ${_lib} "." _pos REVERSE )
-        if ( ${_pos} EQUAL "-1" )
-            set ( SPEX_STATIC_LIBS "${SPEX_STATIC_LIBS} -l${_lib}" )
-            continue ()
-        endif ( )
-    foreach ( _kind IN ITEMS "IMPORT" "SHARED" "STATIC" )
-        set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
-        if ( ${_lib} MATCHES ${_regex} )
-            string ( REGEX REPLACE ${_regex} "\\2" _libname ${_lib} )
-            if ( NOT "${_libname}" STREQUAL "" )
-                set ( SPEX_STATIC_LIBS "${SPEX_STATIC_LIBS} -l${_libname}" )
-                break ()
+if ( NOT MSVC )
+    # This might be something like:
+    #   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
+    # convert to -l flags for pkg-config, i.e.: "-lgomp -lpthread -lm"
+    set ( SPEX_STATIC_LIBS_LIST ${SPEX_STATIC_LIBS} )
+    set ( SPEX_STATIC_LIBS "" )
+    foreach ( _lib ${SPEX_STATIC_LIBS_LIST} )
+            string ( FIND ${_lib} "." _pos REVERSE )
+            if ( ${_pos} EQUAL "-1" )
+                set ( SPEX_STATIC_LIBS "${SPEX_STATIC_LIBS} -l${_lib}" )
+                continue ()
             endif ( )
-        endif ( )
+        foreach ( _kind IN ITEMS "IMPORT" "SHARED" "STATIC" )
+            set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
+            if ( ${_lib} MATCHES ${_regex} )
+                string ( REGEX REPLACE ${_regex} "\\2" _libname ${_lib} )
+                if ( NOT "${_libname}" STREQUAL "" )
+                    set ( SPEX_STATIC_LIBS "${SPEX_STATIC_LIBS} -l${_libname}" )
+                    break ()
+                endif ( )
+            endif ( )
+        endforeach ( )
     endforeach ( )
-endforeach ( )
-message ( STATUS "SPEX_STATIC_LIBS: ${SPEX_STATIC_LIBS}" )
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/SPEX.pc.in
+        SPEX.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/SPEX.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/SPEX.pc.in
-    SPEX.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/SPEX.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/SPQR/CMakeLists.txt
+++ b/SPQR/CMakeLists.txt
@@ -361,52 +361,53 @@ install ( FILES
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-# This might be something like:
-#   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
-# convert to -l flags for pkg-config, i.e.: "-lgomp -lpthread -lm"
-set ( SPQR_STATIC_LIBS_LIST ${SPQR_STATIC_LIBS} )
-set ( SPQR_STATIC_LIBS "" )
-foreach ( _lib ${SPQR_STATIC_LIBS_LIST} )
-    string ( FIND ${_lib} "." _pos REVERSE )
-    if ( ${_pos} EQUAL "-1" )
-        set ( SPQR_STATIC_LIBS "${SPQR_STATIC_LIBS} -l${_lib}" )
-        continue ()
-    endif ( )
-    foreach ( _kind IN ITEMS "IMPORT" "SHARED" "STATIC" )
-        set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
-        if ( ${_lib} MATCHES ${_regex} )
-            string ( REGEX REPLACE ${_regex} "\\2" _libname ${_lib} )
-            if ( NOT "${_libname}" STREQUAL "" )
-                set ( SPQR_STATIC_LIBS "${SPQR_STATIC_LIBS} -l${_libname}" )
-                break ()
-            endif ( )
+if ( NOT MSVC )
+    # This might be something like:
+    #   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
+    # convert to -l flags for pkg-config, i.e.: "-lgomp -lpthread -lm"
+    set ( SPQR_STATIC_LIBS_LIST ${SPQR_STATIC_LIBS} )
+    set ( SPQR_STATIC_LIBS "" )
+    foreach ( _lib ${SPQR_STATIC_LIBS_LIST} )
+        string ( FIND ${_lib} "." _pos REVERSE )
+        if ( ${_pos} EQUAL "-1" )
+            set ( SPQR_STATIC_LIBS "${SPQR_STATIC_LIBS} -l${_lib}" )
+            continue ()
         endif ( )
+        foreach ( _kind IN ITEMS "IMPORT" "SHARED" "STATIC" )
+            set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
+            if ( ${_lib} MATCHES ${_regex} )
+                string ( REGEX REPLACE ${_regex} "\\2" _libname ${_lib} )
+                if ( NOT "${_libname}" STREQUAL "" )
+                    set ( SPQR_STATIC_LIBS "${SPQR_STATIC_LIBS} -l${_libname}" )
+                    break ()
+                endif ( )
+            endif ( )
+        endforeach ( )
     endforeach ( )
-endforeach ( )
-message ( STATUS "SPQR_STATIC_LIBS: ${SPQR_STATIC_LIBS}" )
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/SPQR.pc.in
+        SPQR.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/SPQR.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/SPQR.pc.in
-    SPQR.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/SPQR.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs

--- a/SPQR/SPQRGPU/CMakeLists.txt
+++ b/SPQR/SPQRGPU/CMakeLists.txt
@@ -150,26 +150,31 @@ install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/../SPQR_CUDAConfigVersion.cmake
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SPQR_CUDA )
 
+#-------------------------------------------------------------------------------
 # create pkg-config file
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+#-------------------------------------------------------------------------------
+
+if ( NOT MSVC )
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        ../Config/SPQR_CUDA.pc.in
+        SPQR_CUDA.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/SPQR_CUDA.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    ../Config/SPQR_CUDA.pc.in
-    SPQR_CUDA.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/SPQR_CUDA.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )

--- a/SuiteSparse_GPURuntime/CMakeLists.txt
+++ b/SuiteSparse_GPURuntime/CMakeLists.txt
@@ -196,28 +196,30 @@ install ( FILES
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+if ( NOT MSVC )
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/SuiteSparse_GPURuntime.pc.in
+        SuiteSparse_GPURuntime.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_GPURuntime.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/SuiteSparse_GPURuntime.pc.in
-    SuiteSparse_GPURuntime.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_GPURuntime.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # report status

--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -207,28 +207,30 @@ install ( FILES
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+if ( NOT MSVC )
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/SuiteSparse_config.pc.in
+        SuiteSparse_config.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_config.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/SuiteSparse_config.pc.in
-    SuiteSparse_config.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_config.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 

--- a/UMFPACK/CMakeLists.txt
+++ b/UMFPACK/CMakeLists.txt
@@ -317,52 +317,53 @@ install ( FILES
 # create pkg-config file
 #-------------------------------------------------------------------------------
 
-# This might be something like:
-#   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
-# convert to -l flags for pkg-config, i.e.: "-lgomp -lpthread -lm"
-set ( UMFPACK_STATIC_LIBS_LIST ${UMFPACK_STATIC_LIBS} )
-set ( UMFPACK_STATIC_LIBS "" )
-foreach ( _lib ${UMFPACK_STATIC_LIBS_LIST} )
-    string ( FIND ${_lib} "." _pos REVERSE )
-    if ( ${_pos} EQUAL "-1" )
-        set ( UMFPACK_STATIC_LIBS "${UMFPACK_STATIC_LIBS} -l${_lib}" )
-        continue ()
-    endif ( )
-    foreach ( _kind IN ITEMS "IMPORT" "SHARED" "STATIC" )
-        set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
-        if ( ${_lib} MATCHES ${_regex} )
-            string ( REGEX REPLACE ${_regex} "\\2" _libname ${_lib} )
-            if ( NOT "${_libname}" STREQUAL "" )
-                set ( UMFPACK_STATIC_LIBS "${UMFPACK_STATIC_LIBS} -l${_libname}" )
-                break ()
-            endif ( )
+if ( NOT MSVC )
+    # This might be something like:
+    #   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
+    # convert to -l flags for pkg-config, i.e.: "-lgomp -lpthread -lm"
+    set ( UMFPACK_STATIC_LIBS_LIST ${UMFPACK_STATIC_LIBS} )
+    set ( UMFPACK_STATIC_LIBS "" )
+    foreach ( _lib ${UMFPACK_STATIC_LIBS_LIST} )
+        string ( FIND ${_lib} "." _pos REVERSE )
+        if ( ${_pos} EQUAL "-1" )
+            set ( UMFPACK_STATIC_LIBS "${UMFPACK_STATIC_LIBS} -l${_lib}" )
+            continue ()
         endif ( )
+        foreach ( _kind IN ITEMS "IMPORT" "SHARED" "STATIC" )
+            set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
+            if ( ${_lib} MATCHES ${_regex} )
+                string ( REGEX REPLACE ${_regex} "\\2" _libname ${_lib} )
+                if ( NOT "${_libname}" STREQUAL "" )
+                    set ( UMFPACK_STATIC_LIBS "${UMFPACK_STATIC_LIBS} -l${_libname}" )
+                    break ()
+                endif ( )
+            endif ( )
+        endforeach ( )
     endforeach ( )
-endforeach ( )
-message ( STATUS "UMFPACK_STATIC_LIBS: ${UMFPACK_STATIC_LIBS}" )
 
-set ( prefix "${CMAKE_INSTALL_PREFIX}" )
-set ( exec_prefix "\${prefix}" )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
-if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
-    set ( libdir "${SUITESPARSE_LIBDIR}")
-else ( )
-    set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    set ( prefix "${CMAKE_INSTALL_PREFIX}" )
+    set ( exec_prefix "\${prefix}" )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_LIBDIR SUITESPARSE_LIBDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_LIBDIR_IS_ABSOLUTE)
+        set ( libdir "${SUITESPARSE_LIBDIR}")
+    else ( )
+        set ( libdir "\${exec_prefix}/${SUITESPARSE_LIBDIR}")
+    endif ( )
+    cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
+    if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
+        set ( includedir "${SUITESPARSE_INCLUDEDIR}")
+    else ( )
+        set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
+    endif ( )
+    configure_file (
+        Config/UMFPACK.pc.in
+        UMFPACK.pc
+        @ONLY
+        NEWLINE_STYLE LF )
+    install ( FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/UMFPACK.pc
+        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 endif ( )
-cmake_path ( IS_ABSOLUTE SUITESPARSE_INCLUDEDIR SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE )
-if (SUITESPARSE_INCLUDEDIR_IS_ABSOLUTE)
-    set ( includedir "${SUITESPARSE_INCLUDEDIR}")
-else ( )
-    set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
-endif ( )
-configure_file (
-    Config/UMFPACK.pc.in
-    UMFPACK.pc
-    @ONLY
-    NEWLINE_STYLE LF )
-install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/UMFPACK.pc
-    DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
 
 #-------------------------------------------------------------------------------
 # Demo library and programs


### PR DESCRIPTION
The flags in the generated pkg-config files are incompatible with MSVC-compatible tool chains.
While it is very uncommon for MSVC-compatible tool chains to use .pc files at all, it would be better to not generate these files for those tool chains at all.

The proposed changes skip generating the .pc files when using a MSVC-compatible tool chain.

It would be nice if this could still be included in SuiteSparse 7.2.0.
