### PR TITLE
CI: Add runner without OpenMP to MSVC job.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -464,10 +464,22 @@ jobs:
     # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
     runs-on: windows-latest
 
+    name: msvc (${{ matrix.openmp }} OpenMP)
+
     defaults:
       run:
         # Use bash as default shell
         shell: bash -el {0}
+
+    strategy:
+      # Allow other runners in the matrix to continue if some fail
+      fail-fast: false
+
+      matrix:
+        openmp: [with, without]
+        include:
+          - openmp: without
+            openmp-cmake-flags: "-DNOPENMP=ON"
 
     env:
       CHERE_INVOKING: 1
@@ -592,6 +604,7 @@ jobs:
                   -DCMAKE_Fortran_COMPILER_LAUNCHER=${CCACHE} \
                   -DNFORTRAN=ON \
                   -DBLA_VENDOR="All" \
+                  ${{ matrix.openmp-cmake-flags }} \
                   ..
             echo "::endgroup::"
             echo "::group::Build $lib"
@@ -630,6 +643,7 @@ jobs:
           cmake \
             -DCMAKE_PREFIX_PATH="C:/Miniconda/envs/test/Library;${GITHUB_WORKSPACE}/dependencies" \
             -DBLA_VENDOR="All" \
+            ${{ matrix.openmp-cmake-flags }} \
             ..
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Building example\n"


### PR DESCRIPTION
This adds a runner that builds without OpenMP. I chose the MSVC runner to not blow up the other matrices by another dimension. (And the macOS runners hosted by GitHub seem to be slower than the other hosted runners.)

This is mostly to demonstrate a build error. But it might make sense to add it anyway to make sure it doesn't regress once this error is fixed.
