### PR TITLE
Don't link to CHOLMOD_CUDA explicitly

### DIFF
--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -86,14 +86,6 @@ if ( NOT NCHOLMOD )
         find_package ( CHOLMOD 4.2.0 )
     endif ( )
 
-    if ( SUITESPARSE_CUDA )
-        find_package ( CHOLMOD_CUDA 4.2.0
-            PATHS ${CMAKE_SOURCE_DIR}/../CHOLMOD/build NO_DEFAULT_PATH )
-        if ( NOT TARGET SuiteSparse::CHOLMOD_CUDA )
-            find_package ( CHOLMOD_CUDA 4.2.0 )
-        endif ( )
-    endif ( )
-
     # look for CHOLMOD's dependencies: AMD and COLAMD are required.  CAMD and
     # CCOLAMD are optional, but must be found if CHOLMOD was built with them.
     find_package ( CAMD 3.2.0

--- a/KLU/Config/KLU_CHOLMOD.pc.in
+++ b/KLU/Config/KLU_CHOLMOD.pc.in
@@ -11,6 +11,6 @@ Name: KLU_CHOLMOD
 URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Routines for sample ordering for KLU in SuiteSparse
 Version: @KLU_VERSION_MAJOR@.@KLU_VERSION_MINOR@.@KLU_VERSION_SUB@
-Requires.private: KLU BTF CHOLMOD CHOLMOD_CUDA
+Requires.private: KLU BTF CHOLMOD
 Libs: -L${libdir} -lklu_cholmod
 Cflags: -I${includedir}

--- a/UMFPACK/CMakeLists.txt
+++ b/UMFPACK/CMakeLists.txt
@@ -83,14 +83,6 @@ if ( NOT NCHOLMOD )
         find_package ( CHOLMOD 4.2.0 )
     endif ( )
 
-    if ( SUITESPARSE_CUDA )
-        find_package ( CHOLMOD_CUDA 4.2.0
-            PATHS ${CMAKE_SOURCE_DIR}/../CHOLMOD/build NO_DEFAULT_PATH )
-        if ( NOT TARGET SuiteSparse::CHOLMOD_CUDA )
-            find_package ( CHOLMOD_CUDA 4.2.0 )
-        endif ( )
-    endif ( )
-
     # look for CHOLMOD's dependencies: AMD and COLAMD are required.  CAMD and
     # CCOLAMD are optional, but must be found if CHOLMOD was built with them.
     find_package ( COLAMD 3.2.0
@@ -255,13 +247,9 @@ include_directories ( ${BLAS_INCLUDE_DIRS} )
 # CHOLMOD:
 if ( NOT NCHOLMOD )
     # link with CHOLMOD and its dependencies, both required and optional
-    message ( STATUS "CHOLMOD cuda libraries: " ${CHOLMOD_CUDA_LIBRARIES} )
-    target_link_libraries ( UMFPACK PRIVATE
-        SuiteSparse::CHOLMOD ${CHOLMOD_CUDA_LIBRARIES} )
+    target_link_libraries ( UMFPACK PRIVATE SuiteSparse::CHOLMOD )
     if ( NOT NSTATIC )
-        set ( UMFPACK_STATIC_MODULES "${UMFPACK_STATIC_MODULES} CHOLMOD CHOLMOD_CUDA" )
-        target_link_libraries ( UMFPACK_static PUBLIC
-            ${CHOLMOD_CUDA_STATIC} )
+        set ( UMFPACK_STATIC_MODULES "${UMFPACK_STATIC_MODULES} CHOLMOD" )
         if ( TARGET SuiteSparse::CHOLMOD_static )
             target_link_libraries ( UMFPACK_static PUBLIC SuiteSparse::CHOLMOD_static )
         else ( )


### PR DESCRIPTION
CHOLMOD_CUDA is automatically pulled in either by the imported CMake target `SuiteSparse::CHOLMOD` or by the pkg-config file `CHOLMOD.pc` if it is needed.
There is no need to link to it explicitly when CHOLMOD is already linked.

This fixes #392.
