### PR TITLE
CHOLMOD: Add CHOLMOD_CUDA to dependencies in .pc file if needed

### DIFF
--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -475,9 +475,12 @@ endif ( )
 # CHOLMOD_CUDA
 if ( SUITESPARSE_CUDA )
     target_link_libraries ( CHOLMOD PRIVATE CHOLMOD_CUDA ${CUDA_LIBRARIES} )
-    set ( CHOLMOD_STATIC_MODULES " ${CHOLMOD_STATIC_MODULES} CHOLMOD_CUDA" )
+    set ( CHOLMOD_STATIC_MODULES "${CHOLMOD_STATIC_MODULES} CHOLMOD_CUDA" )
+    set ( CHOLMOD_CFLAGS "${CHOLMOD_CFLAGS} -DSUITESPARSE_CUDA" )
+    target_compile_definitions ( CHOLMOD PUBLIC "SUITESPARSE_CUDA" )
     if ( NOT NSTATIC )
         target_link_libraries ( CHOLMOD_static PUBLIC CHOLMOD_CUDA_static ${CUDA_LIBRARIES} )
+        target_compile_definitions ( CHOLMOD_static PUBLIC "SUITESPARSE_CUDA" )
     endif ( )
     target_link_libraries ( CHOLMOD PRIVATE CUDA::nvrtc CUDA::cudart_static
         CUDA::nvToolsExt CUDA::cublas )

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -474,8 +474,8 @@ endif ( )
 
 # CHOLMOD_CUDA
 if ( SUITESPARSE_CUDA )
-    message ( STATUS "CHOLMOD cuda: " ${CHOLMOD_CUDA} )
     target_link_libraries ( CHOLMOD PRIVATE CHOLMOD_CUDA ${CUDA_LIBRARIES} )
+    set ( CHOLMOD_STATIC_MODULES " ${CHOLMOD_STATIC_MODULES} CHOLMOD_CUDA" )
     if ( NOT NSTATIC )
         target_link_libraries ( CHOLMOD_static PUBLIC CHOLMOD_CUDA_static ${CUDA_LIBRARIES} )
     endif ( )

--- a/CHOLMOD/Config/CHOLMOD.pc.in
+++ b/CHOLMOD/Config/CHOLMOD.pc.in
@@ -7,6 +7,8 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
+# FIXME: Which flags do we need to statically link CUDA if needed?
+
 Name: CHOLMOD
 URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Routines for factorizing sparse symmetric positive definite matrices in SuiteSparse
@@ -14,4 +16,4 @@ Version: @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@
 Requires.private: SuiteSparse_config AMD COLAMD @CHOLMOD_STATIC_MODULES@
 Libs: -L${libdir} -lcholmod
 Libs.private: @CHOLMOD_STATIC_LIBS@
-Cflags: -I${includedir}
+Cflags: -I${includedir} @CHOLMOD_CFLAGS@

--- a/CHOLMOD/Config/CHOLMOD_CUDA.pc.in
+++ b/CHOLMOD/Config/CHOLMOD_CUDA.pc.in
@@ -14,4 +14,4 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: CHOLMOD/GPU module in SuiteSparse
 Version: @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@
 Libs: -L${libdir} -lcholmod_cuda
-Cflags: -I${includedir}
+Cflags: -I${includedir} -DSUITESPARSE_CUDA

--- a/CHOLMOD/GPU/CMakeLists.txt
+++ b/CHOLMOD/GPU/CMakeLists.txt
@@ -75,13 +75,15 @@ target_include_directories ( CHOLMOD_CUDA PRIVATE
         ${CHOLMOD_CUDA_INCLUDES} )
 set_target_properties ( CHOLMOD_CUDA PROPERTIES POSITION_INDEPENDENT_CODE ON )
 set_target_properties ( CHOLMOD_CUDA PROPERTIES CUDA_SEPARABLE_COMPILATION ON )
+target_compile_definitions ( CHOLMOD_CUDA PUBLIC "SUITESPARSE_CUDA" )
 
 if ( NOT NSTATIC )
-target_include_directories ( CHOLMOD_CUDA_static PRIVATE
+    target_include_directories ( CHOLMOD_CUDA_static PRIVATE
         ${CUDAToolkit_INCLUDE_DIRS}
         ${CHOLMOD_CUDA_INCLUDES} )
-set_target_properties ( CHOLMOD_CUDA_static PROPERTIES CUDA_SEPARABLE_COMPILATION on )
-set_target_properties ( CHOLMOD_CUDA_static PROPERTIES POSITION_INDEPENDENT_CODE on )
+    set_target_properties ( CHOLMOD_CUDA_static PROPERTIES CUDA_SEPARABLE_COMPILATION on )
+    set_target_properties ( CHOLMOD_CUDA_static PROPERTIES POSITION_INDEPENDENT_CODE on )
+    target_compile_definitions ( CHOLMOD_CUDA_static PUBLIC "SUITESPARSE_CUDA" )
 endif ( )
 
 target_link_libraries ( CHOLMOD_CUDA PRIVATE CUDA::nvrtc CUDA::cudart_static


### PR DESCRIPTION
Oops.
The CHOLMOD.pc is actually missing the dependency to CHOLMOD_CUDA.
This PR should fix that.

It also removes a line that tries to display the value of a variable that no longer(?) exists.

