### PR TITLE
GraphBLAS: Export CMake target for GraphBLAS_CUDA.

### DIFF
--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -63,7 +63,7 @@ if ( SUITESPARSE_CUDA )
     # with CUDA and RMM
     set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DSUITESPARSE_CUDA" )
     add_subdirectory ( CUDA )
-    set ( GB_CUDA graphblascuda  ${CUDA_LIBRARIES} )
+    set ( GB_CUDA GraphBLAS_CUDA  ${CUDA_LIBRARIES} )
     set ( GB_RMM rmm_wrap ${CUDA_LIBRARIES} )
     add_subdirectory ( rmm_wrap )
     include_directories ( "rmm_wrap" ${CUDA_INCLUDE_DIRS}
@@ -245,7 +245,7 @@ target_include_directories ( GraphBLAS
               $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 
 if ( SUITESPARSE_CUDA )
-    add_dependencies ( GraphBLAS graphblascuda )
+    add_dependencies ( GraphBLAS GraphBLAS_CUDA )
 #   add_dependencies ( GraphBLAS rmm_wrap )
 endif ( )
 
@@ -279,7 +279,7 @@ if ( NOT NSTATIC )
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 
     if ( SUITESPARSE_CUDA )
-        add_dependencies ( GraphBLAS_static graphblascuda )
+        add_dependencies ( GraphBLAS_static GraphBLAS_CUDA )
 #       add_dependencies ( GraphBLAS_static rmm_wrap )
     endif ( )
 endif ( )

--- a/GraphBLAS/CUDA/CMakeLists.txt
+++ b/GraphBLAS/CUDA/CMakeLists.txt
@@ -34,9 +34,9 @@ message ( STATUS "C++ flags for CUDA: ${CMAKE_CXX_FLAGS}" )
 
 file ( GLOB GRAPHBLAS_CUDA_SOURCES "*.cu" "*.c" "*.cpp" )
 
-add_library ( graphblascuda SHARED ${GRAPHBLAS_CUDA_SOURCES} )
+add_library ( GraphBLAS_CUDA SHARED ${GRAPHBLAS_CUDA_SOURCES} )
 
-set_target_properties ( graphblascuda PROPERTIES
+set_target_properties ( GraphBLAS_CUDA PROPERTIES
     VERSION ${GraphBLAS_VERSION_MAJOR}.${GraphBLAS_VERSION_MINOR}.${GraphBLAS_VERSION_SUB}
     SOVERSION ${GraphBLAS_VERSION_MAJOR}
     C_STANDARD 11
@@ -59,28 +59,59 @@ set ( GRAPHBLAS_CUDA_INCLUDES
 message ( STATUS "GraphBLAS CUDA includes: ${GRAPHBLAS_CUDA_INCLUDES}" )
 
 #-------------------------------------------------------------------------------
-# graphblascuda properties
+# GraphBLAS_CUDA properties
 #-------------------------------------------------------------------------------
 
-target_include_directories(graphblascuda PUBLIC
+target_include_directories(GraphBLAS_CUDA PRIVATE
         ${CUDAToolkit_INCLUDE_DIRS}
         ${GRAPHBLAS_CUDA_INCLUDES})
-set_target_properties(graphblascuda PROPERTIES POSITION_INDEPENDENT_CODE ON)
-set_target_properties(graphblascuda PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+set_target_properties(GraphBLAS_CUDA PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(GraphBLAS_CUDA PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 # FIXME: use SUITESPARSE_CUDA_ARCHITECTURES
-set_target_properties(graphblascuda PROPERTIES CUDA_ARCHITECTURES "52;75;80" )
+set_target_properties(GraphBLAS_CUDA PROPERTIES CUDA_ARCHITECTURES "52;75;80" )
 
-target_link_libraries(graphblascuda CUDA::nvrtc CUDA::cudart_static CUDA::cuda_driver CUDA::nvToolsExt )
+target_link_libraries(GraphBLAS_CUDA CUDA::nvrtc CUDA::cudart_static CUDA::cuda_driver CUDA::nvToolsExt )
+
+target_include_directories ( GraphBLAS_CUDA
+    INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+              $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 
 #-------------------------------------------------------------------------------
 # installation location
 #-------------------------------------------------------------------------------
 
-install ( TARGETS graphblascuda
+include ( CMakePackageConfigHelpers )
+
+install ( TARGETS GraphBLAS_CUDA
+    EXPORT GraphBLAS_CUDATargets
     LIBRARY DESTINATION ${SUITESPARSE_LIBDIR}
     ARCHIVE DESTINATION ${SUITESPARSE_LIBDIR}
     RUNTIME DESTINATION ${SUITESPARSE_BINDIR}
     PUBLIC_HEADER DESTINATION ${SUITESPARSE_INCLUDEDIR} )
+
+# create (temporary) export target file during build
+export ( EXPORT GraphBLAS_CUDATargets
+    NAMESPACE SuiteSparse::
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/GraphBLAS_CUDATargets.cmake )
+
+# install export target and config for find_package
+install ( EXPORT GraphBLAS_CUDATargets
+    NAMESPACE SuiteSparse::
+    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/GraphBLAS )
+
+configure_package_config_file (
+    Config/GraphBLAS_CUDAConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/GraphBLAS_CUDAConfig.cmake
+    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/GraphBLAS )
+
+write_basic_package_version_file (
+    ${CMAKE_CURRENT_BINARY_DIR}/GraphBLAS_CUDAConfigVersion.cmake
+    COMPATIBILITY SameMajorVersion )
+
+install ( FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/GraphBLAS_CUDAConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/GraphBLAS_CUDAConfigVersion.cmake
+    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/GraphBLAS )
 
 #-------------------------------------------------------------------------------
 # test suite for the CUDA kernels
@@ -181,14 +212,14 @@ set_target_properties(graphblascuda_test PROPERTIES CUDA_ARCHITECTURES "52;75;80
 include(GoogleTest)
 
 add_dependencies(graphblascuda_test GraphBLAS)
-add_dependencies(graphblascuda_test graphblascuda)
+add_dependencies(graphblascuda_test GraphBLAS_CUDA)
 add_dependencies(graphblascuda_test gtest_main)
 add_dependencies(graphblascuda_test rmm_wrap)
 
 target_link_libraries(graphblascuda_test
         PUBLIC
         GraphBLAS
-        graphblascuda
+        GraphBLAS_CUDA
         rmm_wrap
         CUDA::cudart_static
         CUDA::nvrtc

--- a/GraphBLAS/CUDA/Config/GraphBLAS_CUDAConfig.cmake.in
+++ b/GraphBLAS/CUDA/Config/GraphBLAS_CUDAConfig.cmake.in
@@ -1,0 +1,121 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/GraphBLAS/cmake_modules/GraphBLASConfig.cmake
+#-------------------------------------------------------------------------------
+
+# The following copyright and license applies to just this file only, not to
+# the library itself:
+# GraphBLASConfig.cmake, Copyright (c) 2023, Timothy A. Davis.  All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+#-------------------------------------------------------------------------------
+
+# Finds the GraphBLAS_CUDA include file and compiled library.
+# The following targets are defined:
+#   SuiteSparse::GRAPHBLAS_CUDA           - for the shared library (if available)
+#   SuiteSparse::GRAPHBLAS_CUDA_static    - for the static library (if available)
+
+# For backward compatibility the following variables are set:
+
+# GRAPHBLAS_CUDA_INCLUDE_DIR - where to find GraphBLAS.h, etc.
+# GRAPHBLAS_CUDA_LIBRARY     - dynamic GraphBLAS library
+# GRAPHBLAS_CUDA_STATIC      - static GraphBLAS library
+# GRAPHBLAS_CUDA_LIBRARIES   - libraries when using GraphBLAS
+# GRAPHBLAS_CUDA_FOUND       - true if GraphBLAS found
+
+# Set ``CMAKE_MODULE_PATH`` to the parent folder where this module file is
+# installed.
+
+#-------------------------------------------------------------------------------
+
+@PACKAGE_INIT@
+
+set ( GRAPHBLAS_CUDA_DATE "@GraphBLAS_DATE@" )
+set ( GRAPHBLAS_CUDA_VERSION_MAJOR @GraphBLAS_VERSION_MAJOR@ )
+set ( GRAPHBLAS_CUDA_VERSION_MINOR @GraphBLAS_VERSION_MINOR@ )
+set ( GRAPHBLAS_CUDA_VERSION_PATCH @GraphBLAS_VERSION_SUB@ )
+set ( GRAPHBLAS_CUDA_VERSION "@GraphBLAS_VERSION_MAJOR@.@GraphBLAS_VERSION_MINOR@.@GraphBLAS_VERSION_SUB@" )
+
+include ( ${CMAKE_CURRENT_LIST_DIR}/GraphBLAS_CUDATargets.cmake )
+
+# The following is only for backward compatibility with FindGraphBLAS_CUDA.
+
+set ( _target_shared SuiteSparse::GraphBLAS_CUDA )
+set ( _target_static SuiteSparse::GraphBLAS_CUDA_static )
+set ( _var_prefix "GRAPHBLAS_CUDA" )
+
+get_target_property ( ${_var_prefix}_INCLUDE_DIR ${_target_shared} INTERFACE_INCLUDE_DIRECTORIES )
+if ( ${_var_prefix}_INCLUDE_DIR )
+    # First item in SuiteSparse targets contains the "main" header directory.
+    list ( GET ${_var_prefix}_INCLUDE_DIR 0 ${_var_prefix}_INCLUDE_DIR )
+endif ( )
+get_target_property ( ${_var_prefix}_LIBRARY ${_target_shared} IMPORTED_IMPLIB )
+if ( NOT ${_var_prefix}_LIBRARY )
+    get_target_property ( _library_chk ${_target_shared} IMPORTED_LOCATION )
+    if ( EXISTS ${_library_chk} )
+        set ( ${_var_prefix}_LIBRARY ${_library_chk} )
+    endif ( )
+endif ( )
+if ( TARGET ${_target_static} )
+    get_target_property ( ${_var_prefix}_STATIC ${_target_static} IMPORTED_LOCATION )
+endif ( )
+
+# Check for most common build types
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+
+get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
+if ( _isMultiConfig )
+    # For multi-configuration generators (e.g., Visual Studio), prefer those
+    # configurations.
+    list ( PREPEND _config_types ${CMAKE_CONFIGURATION_TYPES} )
+else ( )
+    # For single-configuration generators, prefer the current configuration.
+    list ( PREPEND _config_types ${CMAKE_BUILD_TYPE} )
+endif ( )
+
+list ( REMOVE_DUPLICATES _config_types )
+
+foreach ( _config ${_config_types} )
+    string ( TOUPPER ${_config} _uc_config )
+    if ( NOT ${_var_prefix}_LIBRARY )
+        get_target_property ( _library_chk ${_target_shared}
+            IMPORTED_IMPLIB_${_uc_config} )
+        if ( EXISTS ${_library_chk} )
+            set ( ${_var_prefix}_LIBRARY ${_library_chk} )
+        endif ( )
+    endif ( )
+    if ( NOT ${_var_prefix}_LIBRARY )
+        get_target_property ( _library_chk ${_target_shared}
+            IMPORTED_LOCATION_${_uc_config} )
+        if ( EXISTS ${_library_chk} )
+            set ( ${_var_prefix}_LIBRARY ${_library_chk} )
+        endif ( )
+    endif ( )
+    if ( TARGET ${_target_static} AND NOT ${_var_prefix}_STATIC )
+        get_target_property ( _library_chk ${_target_static}
+            IMPORTED_LOCATION_${_uc_config} )
+        if ( EXISTS ${_library_chk} )
+            set ( ${_var_prefix}_STATIC ${_library_chk} )
+        endif ( )
+    endif ( )
+endforeach ( )
+
+set ( GRAPHBLAS_CUDA_LIBRARIES ${GRAPHBLAS_CUDA_LIBRARY} )
+
+macro ( suitesparse_check_exist _var _files )
+  # ignore generator expressions
+  string ( GENEX_STRIP "${_files}" _files2 )
+
+  foreach ( _file ${_files2} )
+    if ( NOT EXISTS "${_file}" )
+      message ( FATAL_ERROR "File or directory ${_file} referenced by variable ${_var} does not exist!" )
+    endif ( )
+  endforeach ()
+endmacro ( )
+
+suitesparse_check_exist ( GRAPHBLAS_CUDA_INCLUDE_DIR ${GRAPHBLAS_CUDA_INCLUDE_DIR} )
+suitesparse_check_exist ( GRAPHBLAS_CUDA_LIBRARY ${GRAPHBLAS_CUDA_LIBRARY} )
+
+message ( STATUS "GraphBLAS_CUDA version: ${GRAPHBLAS_CUDA_VERSION}" )
+message ( STATUS "GraphBLAS_CUDA include: ${GRAPHBLAS_CUDA_INCLUDE_DIR}" )
+message ( STATUS "GraphBLAS_CUDA library: ${GRAPHBLAS_CUDA_LIBRARY}" )
+message ( STATUS "GraphBLAS_CUDA static:  ${GRAPHBLAS_CUDA_STATIC}" )


### PR DESCRIPTION
This PR renames the CMake target `graphblascuda` to `GraphBLAS_CUDA` and exports it as `SuiteSparse::GraphBLAS_CUDA`.

There was no `FindGraphBLAS_CUDA`. So, there might not actually be a reason to define variables like `GRAPHBLAS_CUDA_INCLUDE_DIR` when importing the target. But that way, it is pretty similar to the other targets.

I haven't tested yet. And iiuc, the CI won't test it either because CUDA is hard disabled in the build rules for GraphBLAS.

Might be fixing #396.
