### PR TITLE
CMake: Don't impose REQUIRED flag when importing targets

### DIFF
--- a/CHOLMOD/Config/CHOLMODConfig.cmake.in
+++ b/CHOLMOD/Config/CHOLMODConfig.cmake.in
@@ -34,22 +34,37 @@ set ( CHOLMOD_VERSION_MINOR @CHOLMOD_VERSION_MINOR@ )
 set ( CHOLMOD_VERSION_PATCH @CHOLMOD_VERSION_SUB@ )
 set ( CHOLMOD_VERSION "@CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@" )
 
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+set ( _dependencies_found ON )
+
 if ( @SUITESPARSE_CUDA@ )
     # Look for imported targets of additional dependency if CHOLMOD was built with CUDA
 
-    if ( @SUITESPARSE_IN_BUILD_TREE@ )
-        # First check in a common build tree
-        find_package ( CHOLMOD_CUDA @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@
-            PATHS ${CMAKE_SOURCE_DIR}/../CHOLMOD/build NO_DEFAULT_PATH )
-        # Then, check in the currently active CMAKE_MODULE_PATH
-        if ( NOT TARGET SuiteSparse::CHOLMOD_CUDA )
-            find_package ( CHOLMOD_CUDA @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@ REQUIRED )
+    if ( NOT CHOLMOD_CUDA_FOUND )
+        if ( @SUITESPARSE_IN_BUILD_TREE@ )
+            # First check in a common build tree
+            find_dependency ( CHOLMOD_CUDA @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@
+                PATHS ${CMAKE_SOURCE_DIR}/../CHOLMOD/build NO_DEFAULT_PATH )
+            # Then, check in the currently active CMAKE_MODULE_PATH
+            if ( NOT CHOLMOD_CUDA_FOUND )
+                find_dependency ( CHOLMOD_CUDA @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@ )
+            endif ( )
+        else ( )
+            find_dependency ( CHOLMOD_CUDA @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@ )
         endif ( )
-    else ( )
-        find_package ( CHOLMOD_CUDA @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@ REQUIRED )
+    endif ( )
+    if ( NOT CHOLMOD_CUDA_FOUND )
+        set ( _dependencies_found OFF )
     endif ( )
 endif ( )
 
+if ( NOT _dependencies_found )
+    set ( CHOLMOD_FOUND OFF )
+    return ( )
+endif ( )
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/CHOLMODTargets.cmake )
 
 # The following is only for backward compatibility with FindCHOLMOD.

--- a/CHOLMOD/Config/CHOLMOD_CUDAConfig.cmake.in
+++ b/CHOLMOD/Config/CHOLMOD_CUDAConfig.cmake.in
@@ -34,9 +34,24 @@ set ( CHOLMOD_CUDA_VERSION_MINOR @CHOLMOD_VERSION_MINOR@ )
 set ( CHOLMOD_CUDA_VERSION_PATCH @CHOLMOD_VERSION_SUB@ )
 set ( CHOLMOD_CUDA_VERSION "@CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@" )
 
-# Look for NVIDIA CUDA toolkit
-find_package ( CUDAToolkit @CUDAToolkit_VERSION_MAJOR@ REQUIRED )
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+set ( _dependencies_found ON )
 
+# Look for NVIDIA CUDA toolkit
+if ( NOT CUDAToolkit_FOUND )
+    find_dependency ( CUDAToolkit @CUDAToolkit_VERSION_MAJOR@ )
+    if ( NOT CUDAToolkit_FOUND )
+        set ( _dependencies_found OFF )
+    endif ( )
+endif ( )
+
+if ( NOT _dependencies_found )
+    set ( CHOLMOD_CUDA_FOUND OFF )
+    return ( )
+endif ( )
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/CHOLMOD_CUDATargets.cmake )
 
 # The following is only for backward compatibility with FindCHOLMOD_CUDA.

--- a/GraphBLAS/CUDA/Config/GraphBLAS_CUDAConfig.cmake.in
+++ b/GraphBLAS/CUDA/Config/GraphBLAS_CUDAConfig.cmake.in
@@ -35,9 +35,24 @@ set ( GRAPHBLAS_CUDA_VERSION_MINOR @GraphBLAS_VERSION_MINOR@ )
 set ( GRAPHBLAS_CUDA_VERSION_PATCH @GraphBLAS_VERSION_SUB@ )
 set ( GRAPHBLAS_CUDA_VERSION "@GraphBLAS_VERSION_MAJOR@.@GraphBLAS_VERSION_MINOR@.@GraphBLAS_VERSION_SUB@" )
 
-# Look for NVIDIA CUDA toolkit
-find_package ( CUDAToolkit @CUDAToolkit_VERSION_MAJOR@ REQUIRED )
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+set ( _dependencies_found ON )
 
+# Look for NVIDIA CUDA toolkit
+if ( NOT CUDAToolkit_FOUND )
+    find_dependency ( CUDAToolkit @CUDAToolkit_VERSION_MAJOR@ )
+    if ( NOT CUDAToolkit_FOUND )
+        set ( _dependencies_found OFF )
+    endif ( )
+endif ( )
+
+if ( NOT _dependencies_found )
+    set ( GraphBLAS_CUDA_FOUND OFF )
+    return ( )
+endif ( )
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/GraphBLAS_CUDATargets.cmake )
 
 # The following is only for backward compatibility with FindGraphBLAS_CUDA.

--- a/GraphBLAS/Config/GraphBLASConfig.cmake.in
+++ b/GraphBLAS/Config/GraphBLASConfig.cmake.in
@@ -35,22 +35,37 @@ set ( GRAPHBLAS_VERSION_MINOR @GraphBLAS_VERSION_MINOR@ )
 set ( GRAPHBLAS_VERSION_PATCH @GraphBLAS_VERSION_SUB@ )
 set ( GRAPHBLAS_VERSION "@GraphBLAS_VERSION_MAJOR@.@GraphBLAS_VERSION_MINOR@.@GraphBLAS_VERSION_SUB@" )
 
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+set ( _dependencies_found ON )
+
 if ( @SUITESPARSE_CUDA@ )
     # Look for imported targets of additional dependency if GraphBLAS was built with CUDA
 
-    if ( @SUITESPARSE_IN_BUILD_TREE@ )
-        # First check in a common build tree
-        find_package ( GraphBLAS_CUDA @GraphBLAS_VERSION_MAJOR@.@GraphBLAS_VERSION_MINOR@.@GraphBLAS_VERSION_SUB@
-            PATHS ${CMAKE_SOURCE_DIR}/../GraphBLAS/build/CUDA NO_DEFAULT_PATH )
-        # Then, check in the currently active CMAKE_MODULE_PATH
-        if ( NOT TARGET SuiteSparse::GraphBLAS_CUDA )
-            find_package ( GraphBLAS_CUDA @GraphBLAS_VERSION_MAJOR@.@GraphBLAS_VERSION_MINOR@.@GraphBLAS_VERSION_SUB@ REQUIRED )
+    if ( NOT GraphBLAS_CUDA_FOUND )
+        if ( @SUITESPARSE_IN_BUILD_TREE@ )
+            # First check in a common build tree
+            find_dependency ( GraphBLAS_CUDA @GraphBLAS_VERSION_MAJOR@.@GraphBLAS_VERSION_MINOR@.@GraphBLAS_VERSION_SUB@
+                PATHS ${CMAKE_SOURCE_DIR}/../GraphBLAS/build/CUDA NO_DEFAULT_PATH )
+            # Then, check in the currently active CMAKE_MODULE_PATH
+            if ( NOT GraphBLAS_CUDA_FOUND )
+                find_dependency ( GraphBLAS_CUDA @GraphBLAS_VERSION_MAJOR@.@GraphBLAS_VERSION_MINOR@.@GraphBLAS_VERSION_SUB@ )
+            endif ( )
+        else ( )
+            find_dependency ( GraphBLAS_CUDA @GraphBLAS_VERSION_MAJOR@.@GraphBLAS_VERSION_MINOR@.@GraphBLAS_VERSION_SUB@ )
         endif ( )
-    else ( )
-        find_package ( GraphBLAS_CUDA @GraphBLAS_VERSION_MAJOR@.@GraphBLAS_VERSION_MINOR@.@GraphBLAS_VERSION_SUB@ REQUIRED )
+    endif ( )
+    if ( NOT GraphBLAS_CUDA_FOUND )
+        set ( _dependencies_found OFF )
     endif ( )
 endif ( )
 
+if ( NOT _dependencies_found )
+    set ( GraphBLAS_FOUND OFF )
+    return ( )
+endif ( )
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/GraphBLASTargets.cmake )
 
 # The following is only for backward compatibility with FindGraphBLAS.

--- a/SPQR/Config/SPQRConfig.cmake.in
+++ b/SPQR/Config/SPQRConfig.cmake.in
@@ -35,22 +35,37 @@ set ( SPQR_VERSION_MINOR @SPQR_VERSION_MINOR@ )
 set ( SPQR_VERSION_PATCH @SPQR_VERSION_SUB@ )
 set ( SPQR_VERSION "@SPQR_VERSION_MAJOR@.@SPQR_VERSION_MINOR@.@SPQR_VERSION_SUB@" )
 
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+set ( _dependencies_found ON )
+
 if ( @SUITESPARSE_CUDA@ )
     # Look for imported targets of additional dependency if SPQR was built with CUDA
 
-    if ( @SUITESPARSE_IN_BUILD_TREE@ )
-        # First check in a common build tree
-         find_package ( SPQR_CUDA ${SPQR_VERSION}
-            PATHS ${CMAKE_SOURCE_DIR}/../SPQR/build NO_DEFAULT_PATH )
-        # Then, check in the currently active CMAKE_MODULE_PATH
-        if ( NOT TARGET SPQR_CUDA )
-            find_package ( SPQR_CUDA ${SPQR_VERSION} REQUIRED )
+    if ( NOT SPQR_CUDA_FOUND )
+        if ( @SUITESPARSE_IN_BUILD_TREE@ )
+            # First check in a common build tree
+            find_dependency ( SPQR_CUDA ${SPQR_VERSION}
+                PATHS ${CMAKE_SOURCE_DIR}/../SPQR/build NO_DEFAULT_PATH )
+            # Then, check in the currently active CMAKE_MODULE_PATH
+            if ( NOT SPQR_CUDA_FOUND )
+                find_dependency ( SPQR_CUDA ${SPQR_VERSION} )
+            endif ( )
+        else ( )
+            find_dependency ( SPQR_CUDA ${SPQR_VERSION} )
         endif ( )
-    else ( )
-        find_package ( SPQR_CUDA ${SPQR_VERSION} REQUIRED )
+    endif ( )
+    if ( NOT SPQR_CUDA_FOUND )
+        set ( _dependencies_found OFF )
     endif ( )
 endif ( )
 
+if ( NOT _dependencies_found )
+    set ( SPQR_FOUND OFF )
+    return ( )
+endif ( )
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/SPQRTargets.cmake )
 
 # The following is only for backward compatibility with FindSPQR.

--- a/SPQR/Config/SPQR_CUDAConfig.cmake.in
+++ b/SPQR/Config/SPQR_CUDAConfig.cmake.in
@@ -34,9 +34,24 @@ set ( SPQR_CUDA_VERSION_MINOR @SPQR_VERSION_MINOR@ )
 set ( SPQR_CUDA_VERSION_PATCH @SPQR_VERSION_SUB@ )
 set ( SPQR_CUDA_VERSION "@SPQR_VERSION_MAJOR@.@SPQR_VERSION_MINOR@.@SPQR_VERSION_SUB@" )
 
-# Look for NVIDIA CUDA toolkit
-find_package ( CUDAToolkit @CUDAToolkit_VERSION_MAJOR@ REQUIRED )
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+set ( _dependencies_found ON )
 
+# Look for NVIDIA CUDA toolkit
+if ( NOT CUDAToolkit_FOUND )
+    find_dependency ( CUDAToolkit @CUDAToolkit_VERSION_MAJOR@ )
+    if ( NOT CUDAToolkit_FOUND )
+        set ( _dependencies_found OFF )
+    endif ( )
+endif ( )
+
+if ( NOT _dependencies_found )
+    set ( SPQR_CUDA_FOUND OFF )
+    return ( )
+endif ( )
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/SPQR_CUDATargets.cmake )
 
 # The following is only for backward compatibility with FindSPQR_CUDA.


### PR DESCRIPTION
Use `find_dependency` instead of `find_package` to respect the options the user chose to find these targets (e.g., with or without `REQUIRED` flag).

This might look more complicated than it needs to be. But I'm planning to extend that at some point in the future. E.g., importing the CHOLMOD target could also import the CAMD target in case CHOLMOD was built with it. Having that structure set up now will hopefully make it more easy to build on top of that change.