### PR TITLE
CHOLMOD: Automatically check for dependencies when importing target

### DIFF
--- a/CHOLMOD/Config/CHOLMODConfig.cmake.in
+++ b/CHOLMOD/Config/CHOLMODConfig.cmake.in
@@ -61,34 +61,46 @@ endif ( )
 
 # Look for SuiteSparse_config, COLAMD, and AMD targets
 if ( @SUITESPARSE_IN_BUILD_TREE@ )
-    # First check in a common build tree
-    find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@
-        PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
-    # Then, check in the currently active CMAKE_MODULE_PATH
-    if ( NOT SuiteSparse_config_FOUND )
-        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        # First check in a common build tree
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT SuiteSparse_config_FOUND )
+            find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+        endif ( )
     endif ( )
 
-    # First check in a common build tree
-    find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@
-        PATHS ${CMAKE_SOURCE_DIR}/../AMD/build NO_DEFAULT_PATH )
-    # Then, check in the currently active CMAKE_MODULE_PATH
-    if ( NOT AMD_FOUND )
-        find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@ )
+    if ( NOT TARGET SuiteSparse::AMD )
+        # First check in a common build tree
+        find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../AMD/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT AMD_FOUND )
+            find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@ )
+        endif ( )
     endif ( )
 
-    # First check in a common build tree
-    find_dependency ( COLAMD @COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@
-        PATHS ${CMAKE_SOURCE_DIR}/../COLAMD/build NO_DEFAULT_PATH )
-    # Then, check in the currently active CMAKE_MODULE_PATH
-    if ( NOT COLAMD_FOUND )
-        find_dependency ( COLAMD @COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@ )
+    if ( NOT TARGET SuiteSparse::COLAMD )
+        # First check in a common build tree
+        find_dependency ( COLAMD @COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../COLAMD/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT COLAMD_FOUND )
+            find_dependency ( COLAMD @COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@ )
+        endif ( )
     endif ( )
 
 else ( )
-    find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
-    find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@ )
-    find_dependency ( COLAMD @COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@ )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+    endif ( )
+    if ( NOT TARGET SuiteSparse::AMD )
+        find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@ )
+    endif ( )
+    if ( NOT TARGET SuiteSparse::COLAMD )
+        find_dependency ( COLAMD @COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@ )
+    endif ( )
 endif ( )
 if ( NOT SuiteSparse_config_FOUND OR NOT AMD_FOUND OR NOT COLAMD_FOUND )
     set ( _dependencies_found OFF )
@@ -98,24 +110,32 @@ if ( NOT @NCAMD@ )
     # If CHOLMOD was built with CAMD and CCOLAMD, look for their targets
 
     if ( @SUITESPARSE_IN_BUILD_TREE@ )
-        # First check in a common build tree
-        find_dependency ( CAMD @CAMD_VERSION_MAJOR@.@CAMD_VERSION_MINOR@
-            PATHS ${CMAKE_SOURCE_DIR}/../CAMD/build NO_DEFAULT_PATH )
-        # Then, check in the currently active CMAKE_MODULE_PATH
-        if ( NOT CAMD_FOUND )
-            find_dependency ( CAMD @CAMD_VERSION_MAJOR@.@CAMD_VERSION_MINOR@ )
+        if ( NOT TARGET SuiteSparse::CAMD )
+            # First check in a common build tree
+            find_dependency ( CAMD @CAMD_VERSION_MAJOR@.@CAMD_VERSION_MINOR@
+                PATHS ${CMAKE_SOURCE_DIR}/../CAMD/build NO_DEFAULT_PATH )
+            # Then, check in the currently active CMAKE_MODULE_PATH
+            if ( NOT CAMD_FOUND )
+                find_dependency ( CAMD @CAMD_VERSION_MAJOR@.@CAMD_VERSION_MINOR@ )
+            endif ( )
         endif ( )
 
-        # First check in a common build tree
-        find_dependency ( CCOLAMD @CCOLAMD_VERSION_MAJOR@.@CCOLAMD_VERSION_MINOR@
-            PATHS ${CMAKE_SOURCE_DIR}/../CCOLAMD/build NO_DEFAULT_PATH )
-        # Then, check in the currently active CMAKE_MODULE_PATH
-        if ( NOT CCOLAMD_FOUND )
-            find_dependency ( CCOLAMD @CCOLAMD_VERSION_MAJOR@.@CCOLAMD_VERSION_MINOR@ )
+        if ( NOT TARGET SuiteSparse::CCOLAMD )
+            # First check in a common build tree
+            find_dependency ( CCOLAMD @CCOLAMD_VERSION_MAJOR@.@CCOLAMD_VERSION_MINOR@
+                PATHS ${CMAKE_SOURCE_DIR}/../CCOLAMD/build NO_DEFAULT_PATH )
+            # Then, check in the currently active CMAKE_MODULE_PATH
+            if ( NOT CCOLAMD_FOUND )
+                find_dependency ( CCOLAMD @CCOLAMD_VERSION_MAJOR@.@CCOLAMD_VERSION_MINOR@ )
+            endif ( )
         endif ( )
     else ( )
-        find_dependency ( CAMD @CAMD_VERSION_MAJOR@.@CAMD_VERSION_MINOR@ )
-        find_dependency ( CCOLAMD @CCOLAMD_VERSION_MAJOR@.@CCOLAMD_VERSION_MINOR@ )
+        if ( NOT TARGET SuiteSparse::CAMD )
+            find_dependency ( CAMD @CAMD_VERSION_MAJOR@.@CAMD_VERSION_MINOR@ )
+        endif ( )
+        if ( NOT TARGET SuiteSparse::CCOLAMD )
+            find_dependency ( CCOLAMD @CCOLAMD_VERSION_MAJOR@.@CCOLAMD_VERSION_MINOR@ )
+        endif ( )
     endif ( )
     if ( NOT CAMD_FOUND OR NOT CCOLAMD_FOUND )
        set ( _dependencies_found OFF )

--- a/CHOLMOD/Config/CHOLMODConfig.cmake.in
+++ b/CHOLMOD/Config/CHOLMODConfig.cmake.in
@@ -59,10 +59,74 @@ if ( @SUITESPARSE_CUDA@ )
     endif ( )
 endif ( )
 
+# Look for SuiteSparse_config, COLAMD, and AMD targets
+if ( @SUITESPARSE_IN_BUILD_TREE@ )
+    # First check in a common build tree
+    find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@
+        PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
+    # Then, check in the currently active CMAKE_MODULE_PATH
+    if ( NOT SuiteSparse_config_FOUND )
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+    endif ( )
+
+    # First check in a common build tree
+    find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@
+        PATHS ${CMAKE_SOURCE_DIR}/../AMD/build NO_DEFAULT_PATH )
+    # Then, check in the currently active CMAKE_MODULE_PATH
+    if ( NOT AMD_FOUND )
+        find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@ )
+    endif ( )
+
+    # First check in a common build tree
+    find_dependency ( COLAMD @COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@
+        PATHS ${CMAKE_SOURCE_DIR}/../COLAMD/build NO_DEFAULT_PATH )
+    # Then, check in the currently active CMAKE_MODULE_PATH
+    if ( NOT COLAMD_FOUND )
+        find_dependency ( COLAMD @COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@ )
+    endif ( )
+
+else ( )
+    find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+    find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@ )
+    find_dependency ( COLAMD @COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@ )
+endif ( )
+if ( NOT SuiteSparse_config_FOUND OR NOT AMD_FOUND OR NOT COLAMD_FOUND )
+    set ( _dependencies_found OFF )
+endif ( )
+
+if ( NOT @NCAMD@ )
+    # If CHOLMOD was built with CAMD and CCOLAMD, look for their targets
+
+    if ( @SUITESPARSE_IN_BUILD_TREE@ )
+        # First check in a common build tree
+        find_dependency ( CAMD @CAMD_VERSION_MAJOR@.@CAMD_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../CAMD/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT CAMD_FOUND )
+            find_dependency ( CAMD @CAMD_VERSION_MAJOR@.@CAMD_VERSION_MINOR@ )
+        endif ( )
+
+        # First check in a common build tree
+        find_dependency ( CCOLAMD @CCOLAMD_VERSION_MAJOR@.@CCOLAMD_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../CCOLAMD/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT CCOLAMD_FOUND )
+            find_dependency ( CCOLAMD @CCOLAMD_VERSION_MAJOR@.@CCOLAMD_VERSION_MINOR@ )
+        endif ( )
+    else ( )
+        find_dependency ( CAMD @CAMD_VERSION_MAJOR@.@CAMD_VERSION_MINOR@ )
+        find_dependency ( CCOLAMD @CCOLAMD_VERSION_MAJOR@.@CCOLAMD_VERSION_MINOR@ )
+    endif ( )
+    if ( NOT CAMD_FOUND OR NOT CCOLAMD_FOUND )
+       set ( _dependencies_found OFF )
+    endif ( )
+endif ( )
+
 if ( NOT _dependencies_found )
     set ( CHOLMOD_FOUND OFF )
     return ( )
 endif ( )
+
 
 # Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/CHOLMODTargets.cmake )

--- a/GPUQREngine/CMakeLists.txt
+++ b/GPUQREngine/CMakeLists.txt
@@ -73,45 +73,14 @@ set ( DEMO_OK false )
 
 if ( DEMO AND DEMO_OK )
     # for the demo only:
-    find_package ( AMD 3.2.0
-        PATHS ${CMAKE_SOURCE_DIR}/../AMD/build NO_DEFAULT_PATH )
-    if ( NOT TARGET SuiteSparse::AMD )
-        find_package ( AMD 3.2.0 )
-    endif ( )
-
-    find_package ( COLAMD 3.2.0
-        PATHS ${CMAKE_SOURCE_DIR}/../COLAMD/build NO_DEFAULT_PATH )
-    if ( NOT TARGET SuiteSparse::COLAMD )
-        find_package ( COLAMD 3.2.0 )
-    endif ( )
-
-    find_package ( CAMD 3.2.0
-        PATHS ${CMAKE_SOURCE_DIR}/../CAMD/build NO_DEFAULT_PATH )
-    if ( NOT TARGET SuiteSparse::CAMD )
-        find_package ( CAMD 3.2.0 )
-    endif ( )
-
-    find_package ( CCOLAMD 3.2.0
-        PATHS ${CMAKE_SOURCE_DIR}/../CCOLAMD/build NO_DEFAULT_PATH )
-    if ( NOT TARGET SuiteSparse::CCOLAMD )
-        find_package ( CCOLAMD 3.2.0 )
-    endif ( )
-
     find_package ( CHOLMOD 4.2.0
         PATHS ${CMAKE_SOURCE_DIR}/../CHOLMOD/build NO_DEFAULT_PATH )
     if ( NOT TARGET SuiteSparse::CHOLMOD )
         find_package ( CHOLMOD 4.2.0 )
     endif ( )
-
-    find_package ( CHOLMOD_CUDA 4.2.0
-        PATHS ${CMAKE_SOURCE_DIR}/../CHOLMOD/build NO_DEFAULT_PATH )
-    if ( NOT TARGET SuiteSparse::CHOLMOD_CUDA )
-        find_package ( CHOLMOD_CUDA 4.2.0 )
-    endif ( )
 endif ( )
 
-if ( SUITESPARSE_CUDA AND CHOLMOD_FOUND AND AMD_FOUND AND COLAMD_FOUND AND 
-    CAMD_FOUND AND CCOLAMD_FOUND )
+if ( SUITESPARSE_CUDA AND CHOLMOD_FOUND )
     set ( DEMO_OK true )
 else ( )
     set ( DEMO_OK false )

--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -86,21 +86,7 @@ if ( NOT NCHOLMOD )
         find_package ( CHOLMOD 4.2.0 )
     endif ( )
 
-    # look for CHOLMOD's dependencies: AMD and COLAMD are required.  CAMD and
-    # CCOLAMD are optional, but must be found if CHOLMOD was built with them.
-    find_package ( CAMD 3.2.0
-        PATHS ${CMAKE_SOURCE_DIR}/../CAMD/build NO_DEFAULT_PATH )
-    if ( NOT TARGET SuiteSparse::CAMD )
-        find_package ( CAMD 3.2.0 )
-    endif ( )
-
-    find_package ( CCOLAMD 3.2.0
-        PATHS ${CMAKE_SOURCE_DIR}/../CCOLAMD/build NO_DEFAULT_PATH )
-    if ( NOT TARGET SuiteSparse::CCOLAMD )
-        find_package ( CCOLAMD 3.2.0 )
-    endif ( )
-
-    if ( NOT CHOLMOD_FOUND OR NOT AMD_FOUND OR NOT COLAMD_FOUND )
+    if ( NOT CHOLMOD_FOUND )
         # CHOLMOD not found so disable it
         set ( NCHOLMOD true )
     endif ( )

--- a/SPQR/CMakeLists.txt
+++ b/SPQR/CMakeLists.txt
@@ -60,38 +60,10 @@ if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
     find_package ( SuiteSparse_config 7.2.0 REQUIRED )
 endif ( )
 
-find_package ( AMD 3.2.0
-    PATHS ${CMAKE_SOURCE_DIR}/../AMD/build NO_DEFAULT_PATH )
-if ( NOT TARGET SuiteSparse::AMD )
-    find_package ( AMD 3.2.0 REQUIRED )
-endif ( )
-
-find_package ( COLAMD 3.2.0
-    PATHS ${CMAKE_SOURCE_DIR}/../COLAMD/build NO_DEFAULT_PATH )
-if ( NOT TARGET SuiteSparse::COLAMD )
-    find_package ( COLAMD 3.2.0 REQUIRED )
-endif ( )
-
-# It would be nice if just checking for CHOLMOD would automatically pull in
-# the targets for its dependencies.
 find_package ( CHOLMOD 4.2.0
     PATHS ${CMAKE_SOURCE_DIR}/../CHOLMOD/build NO_DEFAULT_PATH )
 if ( NOT TARGET SuiteSparse::CHOLMOD )
     find_package ( CHOLMOD 4.2.0 REQUIRED )
-endif ( )
-
-# look for CHOLMOD's dependencies: AMD and COLAMD are required.  CAMD and
-# CCOLAMD are optional, but must be found if CHOLMOD was built with them.
-find_package ( CAMD 3.2.0
-    PATHS ${CMAKE_SOURCE_DIR}/../CAMD/build NO_DEFAULT_PATH )
-if ( NOT TARGET SuiteSparse::CAMD )
-    find_package ( CAMD 3.2.0 )
-endif ( )
-
-find_package ( CCOLAMD 3.2.0
-    PATHS ${CMAKE_SOURCE_DIR}/../CCOLAMD/build NO_DEFAULT_PATH )
-if ( NOT TARGET SuiteSparse::CCOLAMD )
-    find_package ( CCOLAMD 3.2.0 )
 endif ( )
 
 if ( SUITESPARSE_CUDA )

--- a/UMFPACK/CMakeLists.txt
+++ b/UMFPACK/CMakeLists.txt
@@ -83,27 +83,7 @@ if ( NOT NCHOLMOD )
         find_package ( CHOLMOD 4.2.0 )
     endif ( )
 
-    # look for CHOLMOD's dependencies: AMD and COLAMD are required.  CAMD and
-    # CCOLAMD are optional, but must be found if CHOLMOD was built with them.
-    find_package ( COLAMD 3.2.0
-        PATHS ${CMAKE_SOURCE_DIR}/../COLAMD/build NO_DEFAULT_PATH )
-    if ( NOT TARGET SuiteSparse::COLAMD )
-        find_package ( COLAMD 3.2.0 )
-    endif ( )
-
-    find_package ( CAMD 3.2.0
-        PATHS ${CMAKE_SOURCE_DIR}/../CAMD/build NO_DEFAULT_PATH )
-    if ( NOT TARGET SuiteSparse::CAMD )
-        find_package ( CAMD 3.2.0 )
-    endif ( )
-
-    find_package ( CCOLAMD 3.2.0
-        PATHS ${CMAKE_SOURCE_DIR}/../CCOLAMD/build NO_DEFAULT_PATH )
-    if ( NOT TARGET SuiteSparse::CCOLAMD )
-        find_package ( CCOLAMD 3.2.0 )
-    endif ( )
-
-    if ( NOT CHOLMOD_FOUND OR NOT AMD_FOUND OR NOT COLAMD_FOUND )
+    if ( NOT CHOLMOD_FOUND )
         # CHOLMOD not found so disable it
         set ( NCHOLMOD true )
     endif ( )


### PR DESCRIPTION
Users don't really need to know that CHOLMOD depends on AMD and COLAMD (and likely also on CAMD and CCOLAMD).

With the proposed changes, it should be enough for a user to just import the CHOLMOD target and link their own CMake target to it. The transitive dependencies should be resolved automatically  by CMake.

That is done for the SuiteSparse libraries that depend on CHOLMOD.
