### PR TITLE
Support None cmake build type

### DIFF
--- a/AMD/Config/AMDConfig.cmake.in
+++ b/AMD/Config/AMDConfig.cmake.in
@@ -60,7 +60,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/BTF/Config/BTFConfig.cmake.in
+++ b/BTF/Config/BTFConfig.cmake.in
@@ -60,7 +60,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/CAMD/Config/CAMDConfig.cmake.in
+++ b/CAMD/Config/CAMDConfig.cmake.in
@@ -60,7 +60,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/CCOLAMD/Config/CCOLAMDConfig.cmake.in
+++ b/CCOLAMD/Config/CCOLAMDConfig.cmake.in
@@ -60,7 +60,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/CHOLMOD/Config/CHOLMODConfig.cmake.in
+++ b/CHOLMOD/Config/CHOLMODConfig.cmake.in
@@ -90,7 +90,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/CHOLMOD/Config/CHOLMOD_CUDAConfig.cmake.in
+++ b/CHOLMOD/Config/CHOLMOD_CUDAConfig.cmake.in
@@ -77,7 +77,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/COLAMD/Config/COLAMDConfig.cmake.in
+++ b/COLAMD/Config/COLAMDConfig.cmake.in
@@ -60,7 +60,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/CXSparse/Config/CXSparseConfig.cmake.in
+++ b/CXSparse/Config/CXSparseConfig.cmake.in
@@ -60,7 +60,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/GPUQREngine/Config/GPUQREngineConfig.cmake.in
+++ b/GPUQREngine/Config/GPUQREngineConfig.cmake.in
@@ -60,7 +60,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/GraphBLAS/CUDA/Config/GraphBLAS_CUDAConfig.cmake.in
+++ b/GraphBLAS/CUDA/Config/GraphBLAS_CUDAConfig.cmake.in
@@ -78,7 +78,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/GraphBLAS/Config/GraphBLASConfig.cmake.in
+++ b/GraphBLAS/Config/GraphBLASConfig.cmake.in
@@ -91,7 +91,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/KLU/Config/KLUConfig.cmake.in
+++ b/KLU/Config/KLUConfig.cmake.in
@@ -60,7 +60,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/KLU/Config/KLU_CHOLMODConfig.cmake.in
+++ b/KLU/Config/KLU_CHOLMODConfig.cmake.in
@@ -60,7 +60,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/LDL/Config/LDLConfig.cmake.in
+++ b/LDL/Config/LDLConfig.cmake.in
@@ -60,7 +60,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/Mongoose/Config/MongooseConfig.cmake.in
+++ b/Mongoose/Config/MongooseConfig.cmake.in
@@ -60,7 +60,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/RBio/Config/RBioConfig.cmake.in
+++ b/RBio/Config/RBioConfig.cmake.in
@@ -60,7 +60,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/SPEX/Config/SPEXConfig.cmake.in
+++ b/SPEX/Config/SPEXConfig.cmake.in
@@ -60,7 +60,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/SPQR/Config/SPQRConfig.cmake.in
+++ b/SPQR/Config/SPQRConfig.cmake.in
@@ -91,7 +91,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/SPQR/Config/SPQR_CUDAConfig.cmake.in
+++ b/SPQR/Config/SPQR_CUDAConfig.cmake.in
@@ -77,7 +77,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/SuiteSparse_GPURuntime/Config/SuiteSparse_GPURuntimeConfig.cmake.in
+++ b/SuiteSparse_GPURuntime/Config/SuiteSparse_GPURuntimeConfig.cmake.in
@@ -60,7 +60,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/SuiteSparse_config/Config/SuiteSparse_configConfig.cmake.in
+++ b/SuiteSparse_config/Config/SuiteSparse_configConfig.cmake.in
@@ -60,7 +60,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )

--- a/UMFPACK/Config/UMFPACKConfig.cmake.in
+++ b/UMFPACK/Config/UMFPACKConfig.cmake.in
@@ -60,7 +60,7 @@ if ( TARGET ${_target_static} )
 endif ( )
 
 # Check for most common build types
-set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" )
+set ( _config_types "Debug" "Release" "RelWithDebInfo" "MinSizeRel" "None" )
 
 get_property ( _isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG )
 if ( _isMultiConfig )


### PR DESCRIPTION
"None" is the default build type in cmake, and used to build packages in Arch Linux.

No pull request can be accepted unless you first sign the Contributor License Agreement [ CONTRIBUTOR-LICENSE.txt ].  Print it as a PDF and email me a signed PDF (digital signature OK).  Submit all PRs to the dev2 branch only.
