### PR TITLE
Automatically check for Suitesparse_Config when importing target

### DIFF
--- a/AMD/Config/AMDConfig.cmake.in
+++ b/AMD/Config/AMDConfig.cmake.in
@@ -35,6 +35,32 @@ set ( AMD_VERSION_MINOR @AMD_VERSION_MINOR@ )
 set ( AMD_VERSION_PATCH @AMD_VERSION_SUB@ )
 set ( AMD_VERSION "@AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@.@AMD_VERSION_SUB@" )
 
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+
+# Look for SuiteSparse_config target
+if ( @SUITESPARSE_IN_BUILD_TREE@ )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        # First check in a common build tree
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT SuiteSparse_config_FOUND )
+            find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+else ( )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+    endif ( )
+endif ( )
+if ( NOT SuiteSparse_config_FOUND )
+    set ( AMD_FOUND OFF )
+    return ( )
+endif ( )
+
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/AMDTargets.cmake )
 
 # The following is only for backward compatibility with FindAMD.

--- a/BTF/Config/BTFConfig.cmake.in
+++ b/BTF/Config/BTFConfig.cmake.in
@@ -35,6 +35,32 @@ set ( BTF_VERSION_MINOR @BTF_VERSION_MINOR@ )
 set ( BTF_VERSION_SUB @BTF_VERSION_SUB@ )
 set ( BTF_VERSION "@BTF_VERSION_MAJOR@.@BTF_VERSION_MINOR@.@BTF_VERSION_SUB@" )
 
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+
+# Look for SuiteSparse_config target
+if ( @SUITESPARSE_IN_BUILD_TREE@ )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        # First check in a common build tree
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT SuiteSparse_config_FOUND )
+            find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+else ( )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+    endif ( )
+endif ( )
+if ( NOT SuiteSparse_config_FOUND )
+    set ( BTF_FOUND OFF )
+    return ( )
+endif ( )
+
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/BTFTargets.cmake )
 
 # The following is only for backward compatibility with FindBTF.

--- a/CAMD/Config/CAMDConfig.cmake.in
+++ b/CAMD/Config/CAMDConfig.cmake.in
@@ -35,6 +35,32 @@ set ( CAMD_VERSION_MINOR @CAMD_VERSION_MINOR@ )
 set ( CAMD_VERSION_PATCH @CAMD_VERSION_SUB@ )
 set ( CAMD_VERSION "@CAMD_VERSION_MAJOR@.@CAMD_VERSION_MINOR@.@CAMD_VERSION_SUB@" )
 
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+
+# Look for SuiteSparse_config target
+if ( @SUITESPARSE_IN_BUILD_TREE@ )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        # First check in a common build tree
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT SuiteSparse_config_FOUND )
+            find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+else ( )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+    endif ( )
+endif ( )
+if ( NOT SuiteSparse_config_FOUND )
+    set ( CAMD_FOUND OFF )
+    return ( )
+endif ( )
+
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/CAMDTargets.cmake )
 
 # The following is only for backward compatibility with FindCAMD.

--- a/CCOLAMD/Config/CCOLAMDConfig.cmake.in
+++ b/CCOLAMD/Config/CCOLAMDConfig.cmake.in
@@ -35,6 +35,32 @@ set ( CCOLAMD_VERSION_MINOR @CCOLAMD_VERSION_MINOR@ )
 set ( CCOLAMD_VERSION_PATCH @CCOLAMD_VERSION_SUB@ )
 set ( CCOLAMD_VERSION "@CCOLAMD_VERSION_MAJOR@.@CCOLAMD_VERSION_MINOR@.@CCOLAMD_VERSION_SUB@" )
 
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+
+# Look for SuiteSparse_config target
+if ( @SUITESPARSE_IN_BUILD_TREE@ )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        # First check in a common build tree
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT SuiteSparse_config_FOUND )
+            find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+else ( )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+    endif ( )
+endif ( )
+if ( NOT SuiteSparse_config_FOUND )
+    set ( CCOLAMD_FOUND OFF )
+    return ( )
+endif ( )
+
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/CCOLAMDTargets.cmake )
 
 # The following is only for backward compatibility with FindCCOLAMD.

--- a/COLAMD/Config/COLAMDConfig.cmake.in
+++ b/COLAMD/Config/COLAMDConfig.cmake.in
@@ -35,6 +35,32 @@ set ( COLAMD_VERSION_MINOR @COLAMD_VERSION_MINOR@ )
 set ( COLAMD_VERSION_PATCH @COLAMD_VERSION_SUB@ )
 set ( COLAMD_VERSION "@COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@.@COLAMD_VERSION_SUB@" )
 
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+
+# Look for SuiteSparse_config target
+if ( @SUITESPARSE_IN_BUILD_TREE@ )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        # First check in a common build tree
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT SuiteSparse_config_FOUND )
+            find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+else ( )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+    endif ( )
+endif ( )
+if ( NOT SuiteSparse_config_FOUND )
+    set ( COLAMD_FOUND OFF )
+    return ( )
+endif ( )
+
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/COLAMDTargets.cmake )
 
 # The following is only for backward compatibility with FindCOLAMD.

--- a/CXSparse/Config/CXSparseConfig.cmake.in
+++ b/CXSparse/Config/CXSparseConfig.cmake.in
@@ -35,6 +35,32 @@ set ( CXSPARSE_VERSION_MINOR @CXSPARSE_VERSION_MINOR@ )
 set ( CXSPARSE_VERSION_PATCH @CXSPARSE_VERSION_SUB@ )
 set ( CXSPARSE_VERSION "@CXSPARSE_VERSION_MAJOR@.@CXSPARSE_VERSION_MINOR@.@CXSPARSE_VERSION_SUB@" )
 
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+
+# Look for SuiteSparse_config target
+if ( @SUITESPARSE_IN_BUILD_TREE@ )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        # First check in a common build tree
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT SuiteSparse_config_FOUND )
+            find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+else ( )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+    endif ( )
+endif ( )
+if ( NOT SuiteSparse_config_FOUND )
+    set ( CXSparse_FOUND OFF )
+    return ( )
+endif ( )
+
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/CXSparseTargets.cmake )
 
 # The following is only for backward compatibility with FindCXSparse.

--- a/Mongoose/Config/MongooseConfig.cmake.in
+++ b/Mongoose/Config/MongooseConfig.cmake.in
@@ -35,6 +35,32 @@ set ( MONGOOSE_VERSION_MINOR @Mongoose_VERSION_MINOR@ )
 set ( MONGOOSE_VERSION_PATCH @Mongoose_VERSION_PATCH@ )
 set ( MONGOOSE_VERSION "@Mongoose_VERSION_MAJOR@.@Mongoose_VERSION_MINOR@.@Mongoose_VERSION_PATCH@" )
 
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+
+# Look for SuiteSparse_config target
+if ( @SUITESPARSE_IN_BUILD_TREE@ )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        # First check in a common build tree
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT SuiteSparse_config_FOUND )
+            find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+else ( )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+    endif ( )
+endif ( )
+if ( NOT SuiteSparse_config_FOUND )
+    set ( Mongoose_FOUND OFF )
+    return ( )
+endif ( )
+
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/MongooseTargets.cmake )
 
 # The following is only for backward compatibility with FindMongoose.

--- a/RBio/Config/RBioConfig.cmake.in
+++ b/RBio/Config/RBioConfig.cmake.in
@@ -35,6 +35,32 @@ set ( RBIO_VERSION_MINOR @RBIO_VERSION_MINOR@ )
 set ( RBIO_VERSION_PATCH @RBIO_VERSION_SUB@ )
 set ( RBIO_VERSION "@RBIO_VERSION_MAJOR@.@RBIO_VERSION_MINOR@.@RBIO_VERSION_SUB@" )
 
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+
+# Look for SuiteSparse_config target
+if ( @SUITESPARSE_IN_BUILD_TREE@ )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        # First check in a common build tree
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT SuiteSparse_config_FOUND )
+            find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+else ( )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+    endif ( )
+endif ( )
+if ( NOT SuiteSparse_config_FOUND )
+    set ( RBio_FOUND OFF )
+    return ( )
+endif ( )
+
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/RBioTargets.cmake )
 
 # The following is only for backward compatibility with FindRBio.

--- a/SuiteSparse_GPURuntime/Config/SuiteSparse_GPURuntimeConfig.cmake.in
+++ b/SuiteSparse_GPURuntime/Config/SuiteSparse_GPURuntimeConfig.cmake.in
@@ -35,6 +35,32 @@ set ( SUITESPARSE_GPURUNTIME_VERSION_MINOR @SUITESPARSE_GPURUNTIME_VERSION_MINOR
 set ( SUITESPARSE_GPURUNTIME_VERSION_PATCH @SUITESPARSE_GPURUNTIME_VERSION_SUB@ )
 set ( SUITESPARSE_GPURUNTIME_VERSION "@SUITESPARSE_GPURUNTIME_VERSION_MAJOR@.@SUITESPARSE_GPURUNTIME_VERSION_MINOR@.@SUITESPARSE_GPURUNTIME_VERSION_SUB@" )
 
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+
+# Look for SuiteSparse_config target
+if ( @SUITESPARSE_IN_BUILD_TREE@ )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        # First check in a common build tree
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT SuiteSparse_config_FOUND )
+            find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+else ( )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+    endif ( )
+endif ( )
+if ( NOT SuiteSparse_config_FOUND )
+    set ( SuiteSparse_GPURuntime_FOUND OFF )
+    return ( )
+endif ( )
+
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/SuiteSparse_GPURuntimeTargets.cmake )
 
 # The following is only for backward compatibility with FindSuiteSparse_GPURuntime.


### PR DESCRIPTION
Similar to #404.

These are the changes for the targets that only depend on SuiteSparse_Config (and nothing else). That still leaves a couple of other targets with more dependencies.

Fixes part of #409.

