### PR TITLE
LDL: Automatically check for dependencies when importing target

### DIFF
--- a/LDL/Config/LDLConfig.cmake.in
+++ b/LDL/Config/LDLConfig.cmake.in
@@ -35,6 +35,51 @@ set ( LDL_VERSION_MINOR @LDL_VERSION_MINOR@ )
 set ( LDL_VERSION_PATCH @LDL_VERSION_SUB@ )
 set ( LDL_VERSION "@LDL_VERSION_MAJOR@.@LDL_VERSION_MINOR@.@LDL_VERSION_SUB@" )
 
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+set ( _dependencies_found ON )
+
+# Look for SuiteSparse_config and AMD targets
+if ( @SUITESPARSE_IN_BUILD_TREE@ )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        # First check in a common build tree
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT SuiteSparse_config_FOUND )
+            find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+
+    if ( NOT TARGET SuiteSparse::AMD )
+        # First check in a common build tree
+        find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../AMD/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT AMD_FOUND )
+            find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+
+else ( )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+    endif ( )
+    if ( NOT TARGET SuiteSparse::AMD )
+        find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@ )
+    endif ( )
+endif ( )
+if ( NOT SuiteSparse_config_FOUND OR NOT AMD_FOUND )
+    set ( _dependencies_found OFF )
+endif ( )
+
+if ( NOT _dependencies_found )
+    set ( LDL_FOUND OFF )
+    return ( )
+endif ( )
+
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/LDLTargets.cmake )
 
 # The following is only for backward compatibility with FindLDL.


### PR DESCRIPTION
Similar to #404.

Fixes part of #409.
