### PR TITLE
SPEX: Automatically check for dependencies when importing target

### DIFF
--- a/Example/CMakeLists.txt
+++ b/Example/CMakeLists.txt
@@ -89,8 +89,7 @@ endif ( )
 
 # look for all external libaries:
 find_package ( OpenMP REQUIRED )
-find_package ( GMP 6.1.2 REQUIRED )
-find_package ( MPFR 4.0.2 REQUIRED )
+
 include ( SuiteSparseBLAS )
 
 #-------------------------------------------------------------------------------

--- a/SPEX/Config/SPEXConfig.cmake.in
+++ b/SPEX/Config/SPEXConfig.cmake.in
@@ -35,6 +35,69 @@ set ( SPEX_VERSION_MINOR @SPEX_VERSION_MINOR@ )
 set ( SPEX_VERSION_PATCH @SPEX_VERSION_SUB@ )
 set ( SPEX_VERSION "@SPEX_VERSION_MAJOR@.@SPEX_VERSION_MINOR@.@SPEX_VERSION_SUB@" )
 
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+
+# Look for SuiteSparse_config, AMD and COLAMD targets
+if ( @SUITESPARSE_IN_BUILD_TREE@ )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        # First check in a common build tree
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT SuiteSparse_config_FOUND )
+            find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+
+    if ( NOT TARGET SuiteSparse::AMD )
+        # First check in a common build tree
+        find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../AMD/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT AMD_FOUND )
+            find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+
+    if ( NOT TARGET SuiteSparse::COLAMD )
+        # First check in a common build tree
+        find_dependency ( COLAMD @COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../COLAMD/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT COLAMD_FOUND )
+            find_dependency ( COLAMD @COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+
+else ( )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+    endif ( )
+    if ( NOT TARGET SuiteSparse::AMD )
+        find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@ )
+    endif ( )
+    if ( NOT TARGET SuiteSparse::COLAMD )
+        find_dependency ( COLAMD @COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@ )
+    endif ( )
+endif ( )
+
+# Look for GMP and MPFR modules
+if ( NOT GMP_FOUND )
+    find_dependency ( GMP 6.1.2 )
+endif ( )
+if ( NOT MPFR_FOUND )
+    find_dependency ( MPFR 4.0.2 )
+endif ( )
+
+if ( NOT SuiteSparse_config_FOUND OR NOT AMD_FOUND OR NOT COLAMD_FOUND
+        OR NOT GMP_FOUND OR NOT MPFR_FOUND)
+    set ( SPEX_FOUND OFF )
+    return ( )
+endif ( )
+
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/SPEXTargets.cmake )
 
 # The following is only for backward compatibility with FindSPEX.


### PR DESCRIPTION
Similar to #404.

Additionally, simplify build rules for example by no longer importing the modules for GMP and MPFR explicitly.

Fixes part of #409.
