### PR TITLE
Set preprocessor macro SUITESPARSE_CUDA on a per-target level

### DIFF
--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -2,7 +2,7 @@
 # GraphBLAS/CMakeLists.txt:  cmake script for GraphBLAS
 #-------------------------------------------------------------------------------
 
-# SuiteSparse:GraphBLAS, Timothy A. Davis, (c) 2017-2022, All Rights Reserved.
+# SuiteSparse:GraphBLAS, Timothy A. Davis, (c) 2017-2023, All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # See the User Guide for details on how to compile SuiteSparse:GraphBLAS.
@@ -246,6 +246,7 @@ target_include_directories ( GraphBLAS
 if ( SUITESPARSE_CUDA )
     add_dependencies ( GraphBLAS GraphBLAS_CUDA )
 #   add_dependencies ( GraphBLAS rmm_wrap )
+    target_compile_definitions ( GraphBLAS PRIVATE "SUITESPARSE_CUDA" )
 endif ( )
 
 if ( WIN32 )
@@ -281,6 +282,7 @@ if ( NOT NSTATIC )
         add_dependencies ( GraphBLAS_static GraphBLAS_CUDA )
         set ( GRAPHBLAS_STATIC_MODULES "${GRAPHBLAS_STATIC_MODULES} GraphBLAS_CUDA" )
 #       add_dependencies ( GraphBLAS_static rmm_wrap )
+        target_compile_definitions ( GraphBLAS_static PRIVATE "SUITESPARSE_CUDA" )
     endif ( )
 endif ( )
 

--- a/GraphBLAS/cmake_modules/SuiteSparsePolicy.cmake
+++ b/GraphBLAS/cmake_modules/SuiteSparsePolicy.cmake
@@ -261,7 +261,6 @@ endif ( )
 
 if ( SUITESPARSE_CUDA )
     message ( STATUS "CUDA: enabled" )
-    add_compile_definitions ( SUITESPARSE_CUDA )
     set ( SUITESPARSE_CUDA_ARCHITECTURES "52;75;80" CACHE STRING "CUDA architectures" )
     set ( CMAKE_CUDA_ARCHITECTURES ${SUITESPARSE_CUDA_ARCHITECTURES} )
 else ( )

--- a/SPQR/GPUQREngine/CMakeLists.txt
+++ b/SPQR/GPUQREngine/CMakeLists.txt
@@ -111,6 +111,7 @@ set_target_properties ( GPUQREngine PROPERTIES POSITION_INDEPENDENT_CODE ON )
 set_target_properties ( GPUQREngine PROPERTIES CUDA_SEPARABLE_COMPILATION ON )
 target_link_libraries ( GPUQREngine PRIVATE
     CUDA::nvrtc CUDA::cudart_static CUDA::nvToolsExt CUDA::cublas )
+target_compile_definitions ( GPUQREngine PRIVATE "SUITESPARSE_CUDA" )
 
 target_include_directories ( GPUQREngine
     INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
@@ -140,15 +141,14 @@ if ( NOT NSTATIC )
         ${GPUQRENGINE_INCLUDES}
         "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 
-    if ( SUITESPARSE_CUDA )
-        target_include_directories ( GPUQREngine_static PRIVATE
-            "$<TARGET_PROPERTY:GPURuntime,INTERFACE_INCLUDE_DIRECTORIES>" )
+    target_include_directories ( GPUQREngine_static PRIVATE
+        "$<TARGET_PROPERTY:GPURuntime,INTERFACE_INCLUDE_DIRECTORIES>" )
 
-        set_target_properties ( GPUQREngine_static PROPERTIES CUDA_SEPARABLE_COMPILATION on )
-        set_target_properties ( GPUQREngine_static PROPERTIES POSITION_INDEPENDENT_CODE on )
-        target_link_libraries ( GPUQREngine_static PUBLIC
-            CUDA::nvrtc CUDA::cudart_static CUDA::nvToolsExt CUDA::cublas )
-    endif ( )
+    set_target_properties ( GPUQREngine_static PROPERTIES CUDA_SEPARABLE_COMPILATION ON )
+    set_target_properties ( GPUQREngine_static PROPERTIES POSITION_INDEPENDENT_CODE ON )
+    target_link_libraries ( GPUQREngine_static PUBLIC
+        CUDA::nvrtc CUDA::cudart_static CUDA::nvToolsExt CUDA::cublas )
+    target_compile_definitions ( GPUQREngine_static PRIVATE "SUITESPARSE_CUDA" )
 
     target_include_directories ( GPUQREngine_static
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>

--- a/SPQR/GPURuntime/CMakeLists.txt
+++ b/SPQR/GPURuntime/CMakeLists.txt
@@ -65,8 +65,7 @@ configure_file ( "Config/SuiteSparse_GPURuntime.hpp.in"
 
 #-------------------------------------------------------------------------------
 
-set ( CMAKE_CUDA_FLAGS "-cudart=static -lineinfo -DSUITESPARSE_CUDA" )
-set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSUITESPARSE_CUDA" )
+set ( CMAKE_CUDA_FLAGS "-cudart=static -lineinfo" )
 message ( STATUS "C++ flags for CUDA:  ${CMAKE_CXX_FLAGS}" )
 message ( STATUS "nvcc flags for CUDA: ${CMAKE_CUDA_FLAGS}" )
 
@@ -100,6 +99,7 @@ set_target_properties ( GPURuntime PROPERTIES POSITION_INDEPENDENT_CODE ON )
 set_target_properties ( GPURuntime PROPERTIES CUDA_SEPARABLE_COMPILATION ON )
 target_link_libraries ( GPURuntime PRIVATE
     CUDA::nvrtc CUDA::cudart_static CUDA::nvToolsExt CUDA::cublas )
+target_compile_definitions ( GPURuntime PRIVATE "SUITESPARSE_CUDA" )
 
 target_include_directories ( GPURuntime 
     INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
@@ -129,10 +129,11 @@ if ( NOT NSTATIC )
         ${SUITESPARSE_GPURUNTIME_INCLUDES}
         $<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES> )
 
-    set_target_properties ( GPURuntime_static PROPERTIES CUDA_SEPARABLE_COMPILATION on )
-    set_target_properties ( GPURuntime_static PROPERTIES POSITION_INDEPENDENT_CODE on )
+    set_target_properties ( GPURuntime_static PROPERTIES CUDA_SEPARABLE_COMPILATION ON )
+    set_target_properties ( GPURuntime_static PROPERTIES POSITION_INDEPENDENT_CODE ON )
     target_link_libraries ( GPURuntime_static PUBLIC
         CUDA::nvrtc CUDA::cudart_static CUDA::nvToolsExt CUDA::cublas )
+    target_compile_definitions ( GPURuntime_static PRIVATE "SUITESPARSE_CUDA" )
 
     target_include_directories ( GPURuntime_static 
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>

--- a/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
+++ b/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
@@ -261,7 +261,6 @@ endif ( )
 
 if ( SUITESPARSE_CUDA )
     message ( STATUS "CUDA: enabled" )
-    add_compile_definitions ( SUITESPARSE_CUDA )
     set ( SUITESPARSE_CUDA_ARCHITECTURES "52;75;80" CACHE STRING "CUDA architectures" )
     set ( CMAKE_CUDA_ARCHITECTURES ${SUITESPARSE_CUDA_ARCHITECTURES} )
 else ( )


### PR DESCRIPTION
Instead of setting the preprocessor definition `SUITESPARSE_CUDA` globally, set it on a per-target level.

This avoids some issues when trying to build everything with a root CMakeLists.txt (in particular GraphBLAS which currently needs to deviate from the global setting).
