### PR TITLE
CI: Make sure that "with" doesn't match "without" in ccache key

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,7 +86,7 @@ jobs:
           # Prefer caches from the same branch. Fall back to caches from the dev branch.
           restore-keys: |
             ccache:ubuntu:${{ matrix.compiler }}:${{ matrix.cuda }}:${{ github.ref }}
-            ccache:ubuntu:${{ matrix.compiler }}:${{ matrix.cuda }}
+            ccache:ubuntu:${{ matrix.compiler }}:${{ matrix.cuda }}:
 
       - name: create empty libraries
         # This is to work around a bug in nvlink.
@@ -573,7 +573,7 @@ jobs:
           # Prefer caches from the same branch. Fall back to caches from the dev branch.
           restore-keys: |
             ccache:msvc:${{ matrix.openmp }}:${{ github.ref }}
-            ccache:msvc:${{ matrix.openmp }}
+            ccache:msvc:${{ matrix.openmp }}:
 
       - name: configure ccache
         # Limit the maximum size and switch on compression to avoid exceeding the total disk or cache quota.


### PR DESCRIPTION
I was wondering why some runners took exceptionally long compared to others sometimes.
Turns out that is because "with" can match "without" in the restore key for the GitHub cache that's used for ccache. (Didn't think of that 😖)

Make sure that doesn't happen by adding ":" to the affected restore keys.

This is a low-impact change that shouldn't affect the release process.
