### PR TITLE
Fix the ordering of the __thread and static specifiers

### DIFF
--- a/CHOLMOD/SuiteSparse_metis/GKlib/random.c
+++ b/CHOLMOD/SuiteSparse_metis/GKlib/random.c
@@ -71,8 +71,8 @@ GK_MKRANDOM(gk_z,   size_t, ssize_t)
 #elif defined ( HAVE_KEYWORD__THREAD )
 
     // gcc and many other compilers support the __thread keyword
-    __thread static uint64_t mt[NN];
-    __thread static int mti=NN+1;
+    static __thread uint64_t mt[NN];
+    static __thread int mti=NN+1;
 
 #elif defined ( HAVE_KEYWORD__DECLSPEC_THREAD )
 


### PR DESCRIPTION
GCC requires that the `__thread` keyword appear immediately after the storage class specifier.

ref: https://gcc.gnu.org/onlinedocs/gcc/Thread-Local.html, which says:

> The __thread specifier may be used alone, with the extern or static specifiers, but with no other storage class specifier. When used with extern or static, __thread must appear immediately after the other storage class specifier. 