### PR TITLE
KLU: Automatically check for dependencies when importing target

### DIFF
--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -275,24 +275,20 @@ if ( NOT NCHOLMOD )
     # CHOLMOD:
     # link with CHOLMOD and its dependencies, both required and optional
     # CHOLMOD without CUDA
-    target_link_libraries ( KLU PRIVATE
-        SuiteSparse::CHOLMOD )
-    target_link_libraries ( KLU_CHOLMOD PRIVATE
-        SuiteSparse::CHOLMOD )
+    target_link_libraries ( KLU_CHOLMOD PRIVATE SuiteSparse::CHOLMOD )
     if ( NOT NSTATIC )
        set ( KLU_STATIC_MODULES "${KLU_STATIC_MODULES} CHOLMOD" )
        if ( TARGET SuiteSparse::CHOLMOD_static )
-            target_link_libraries ( KLU_static PUBLIC SuiteSparse::CHOLMOD_static )
             target_link_libraries ( KLU_CHOLMOD_static PUBLIC SuiteSparse::CHOLMOD_static )
         else ( )
-            target_link_libraries ( KLU_static PUBLIC SuiteSparse::CHOLMOD )
             target_link_libraries ( KLU_CHOLMOD_static PUBLIC SuiteSparse::CHOLMOD )
         endif ( )
     endif ( )
 
     # klu:
-    target_link_libraries ( KLU_CHOLMOD PRIVATE KLU SuiteSparse::BTF )
+    target_link_libraries ( KLU_CHOLMOD PRIVATE KLU )
     if ( NOT NSTATIC )
+        target_link_libraries ( KLU_CHOLMOD_static PUBLIC KLU_static )
         if ( TARGET SuiteSparse::BTF_static )
             target_link_libraries ( KLU_CHOLMOD_static PUBLIC SuiteSparse::BTF_static )
         else ( )

--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -327,9 +327,18 @@ install ( EXPORT KLUTargets
     NAMESPACE SuiteSparse::
     DESTINATION ${SUITESPARSE_LIBDIR}/cmake/KLU )
 
+# generate config file to be used in common build tree
+set ( SUITESPARSE_IN_BUILD_TREE ON )
 configure_package_config_file (
     Config/KLUConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/KLUConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/KLUConfig.cmake )
+
+# generate config file to be installed
+set ( SUITESPARSE_IN_BUILD_TREE OFF )
+configure_package_config_file (
+    Config/KLUConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/target/KLUConfig.cmake
     INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/KLU )
 
 write_basic_package_version_file (
@@ -397,9 +406,18 @@ if ( NOT NCHOLMOD )
         NAMESPACE SuiteSparse::
         DESTINATION ${SUITESPARSE_LIBDIR}/cmake/KLU_CHOLMOD )
 
+    # generate config file to be used in common build tree
+    set ( SUITESPARSE_IN_BUILD_TREE ON )
     configure_package_config_file (
         Config/KLU_CHOLMODConfig.cmake.in
         ${CMAKE_CURRENT_BINARY_DIR}/KLU_CHOLMODConfig.cmake
+        INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/KLU_CHOLMODConfig.cmake )
+
+    # generate config file to be installed
+    set ( SUITESPARSE_IN_BUILD_TREE OFF )
+    configure_package_config_file (
+        Config/KLU_CHOLMODConfig.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/target/KLU_CHOLMODConfig.cmake
         INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/KLU_CHOLMOD )
 
     write_basic_package_version_file (

--- a/KLU/Config/KLUConfig.cmake.in
+++ b/KLU/Config/KLUConfig.cmake.in
@@ -37,6 +37,72 @@ set ( KLU_VERSION "@KLU_VERSION_MAJOR@.@KLU_VERSION_MINOR@.@KLU_VERSION_SUB@" )
 
 include ( ${CMAKE_CURRENT_LIST_DIR}/KLUTargets.cmake )
 
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+
+# Look for SuiteSparse_config, BTF, AMD and COLAMD targets
+if ( @SUITESPARSE_IN_BUILD_TREE@ )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        # First check in a common build tree
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT SuiteSparse_config_FOUND )
+            find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+
+    if ( NOT TARGET SuiteSparse::BTF )
+        # First check in a common build tree
+        find_dependency ( BTF @BTF_VERSION_MAJOR@.@BTF_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../BTF/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT BTF_FOUND )
+            find_dependency ( BTF @BTF_VERSION_MAJOR@.@BTF_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+
+    if ( NOT TARGET SuiteSparse::AMD )
+        # First check in a common build tree
+        find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../AMD/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT AMD_FOUND )
+            find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+
+    if ( NOT TARGET SuiteSparse::COLAMD )
+        # First check in a common build tree
+        find_dependency ( COLAMD @COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../COLAMD/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT COLAMD_FOUND )
+            find_dependency ( COLAMD @COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+
+else ( )
+    if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
+        find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
+    endif ( )
+    if ( NOT TARGET SuiteSparse::BTF )
+        find_dependency ( BTF @BTF_VERSION_MAJOR@.@BTF_VERSION_MINOR@ )
+    endif ( )
+    if ( NOT TARGET SuiteSparse::AMD )
+        find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@ )
+    endif ( )
+    if ( NOT TARGET SuiteSparse::COLAMD )
+        find_dependency ( COLAMD @COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@ )
+    endif ( )
+endif ( )
+
+if ( NOT SuiteSparse_config_FOUND OR NOT BTF_FOUND OR NOT AMD_FOUND OR NOT COLAMD_FOUND )
+    set ( KLU_FOUND OFF )
+    return ( )
+endif ( )
+
+
 # The following is only for backward compatibility with FindKLU.
 
 set ( _target_shared SuiteSparse::KLU )

--- a/KLU/Config/KLU_CHOLMODConfig.cmake.in
+++ b/KLU/Config/KLU_CHOLMODConfig.cmake.in
@@ -35,6 +35,46 @@ set ( KLU_CHOLMOD_VERSION_MINOR @KLU_VERSION_MINOR@ )
 set ( KLU_CHOLMOD_VERSION_PATCH @KLU_VERSION_SUB@ )
 set ( KLU_CHOLMOD_VERSION "@KLU_VERSION_MAJOR@.@KLU_VERSION_MINOR@.@KLU_VERSION_SUB@" )
 
+# Check for dependent targets
+include ( CMakeFindDependencyMacro )
+
+# Look for KLU and CHOLMOD targets
+if ( @SUITESPARSE_IN_BUILD_TREE@ )
+    if ( NOT TARGET SuiteSparse::KLU )
+        # First check in a common build tree
+        find_dependency ( KLU @KLU_VERSION_MAJOR@.@KLU_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../KLU/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT KLU_FOUND )
+            find_dependency ( KLU @KLU_VERSION_MAJOR@.@KLU_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+
+    if ( NOT TARGET SuiteSparse::CHOLMOD )
+        # First check in a common build tree
+        find_dependency ( CHOLMOD @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@
+            PATHS ${CMAKE_SOURCE_DIR}/../CHOLMOD/build NO_DEFAULT_PATH )
+        # Then, check in the currently active CMAKE_MODULE_PATH
+        if ( NOT CHOLMOD_FOUND )
+            find_dependency ( CHOLMOD @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@ )
+        endif ( )
+    endif ( )
+
+else ( )
+    if ( NOT TARGET SuiteSparse::KLU )
+        find_dependency ( KLU @KLU_VERSION_MAJOR@.@KLU_VERSION_MINOR@ )
+    endif ( )
+    if ( NOT TARGET SuiteSparse::CHOLMOD )
+        find_dependency ( CHOLMOD @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@ )
+    endif ( )
+endif ( )
+
+if ( NOT KLU_FOUND OR NOT CHOLMOD_FOUND )
+    set ( KLU_CHOLMOD_FOUND OFF )
+    return ( )
+endif ( )
+
+
 include ( ${CMAKE_CURRENT_LIST_DIR}/KLU_CHOLMODTargets.cmake )
 
 # The following is only for backward compatibility with FindKLU_CHOLMOD.


### PR DESCRIPTION
Similar to #412 and others.

Fixes that part of #409.

Additionally, clean up library dependencies of KLU and KLU_CHOLMOD to avoid overlinking.
