### PR TITLE
ParU: Don't include headers in `extern "C"` block.

### DIFF
--- a/ParU/Config/ParU_definitions.h.in
+++ b/ParU/Config/ParU_definitions.h.in
@@ -9,10 +9,6 @@
 #ifndef PARU_DEFINITIONS_H
 #define PARU_DEFINITIONS_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif 
-
 
 #include "SuiteSparse_config.h"
 #include "cholmod.h"
@@ -26,10 +22,6 @@ typedef enum ParU_Ret
     PARU_SINGULAR = -3,
     PARU_TOO_LARGE = -4
 } ParU_Ret;
-
-#ifdef __cplusplus
-}
-#endif 
 
 #define PARU_MEM_CHUNK (1024*1024)
 

--- a/ParU/Include/ParU_definitions.h
+++ b/ParU/Include/ParU_definitions.h
@@ -9,10 +9,6 @@
 #ifndef PARU_DEFINITIONS_H
 #define PARU_DEFINITIONS_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif 
-
 
 #include "SuiteSparse_config.h"
 #include "cholmod.h"
@@ -26,10 +22,6 @@ typedef enum ParU_Ret
     PARU_SINGULAR = -3,
     PARU_TOO_LARGE = -4
 } ParU_Ret;
-
-#ifdef __cplusplus
-}
-#endif 
 
 #define PARU_MEM_CHUNK (1024*1024)
 


### PR DESCRIPTION
Building ParU with a CHOLMOD library that was built with CUDA currently fails with this error:
```
  [  1%] Building CXX object CMakeFiles/paru.dir/Source/paru_Diag_update.cpp.o
  In file included from /usr/include/c++/11/utility:69,
                   from /usr/include/cuda_fp16.hpp:67,
                   from /usr/include/cuda_fp16.h:3673,
                   from /usr/include/cublas_api.h:75,
                   from /usr/include/cublas_v2.h:65,
                   from /home/runner/work/SuiteSparse/SuiteSparse/CHOLMOD/Include/cholmod.h:451,
                   from /home/runner/work/SuiteSparse/SuiteSparse/ParU/Include/ParU_definitions.h:18,
                   from /home/runner/work/SuiteSparse/SuiteSparse/ParU/Include/ParU.hpp:42,
                   from /home/runner/work/SuiteSparse/SuiteSparse/ParU/Source/paru_internal.hpp:17,
                   from /home/runner/work/SuiteSparse/SuiteSparse/ParU/Source/paru_Diag_update.cpp:20:
  /usr/include/c++/11/bits/stl_relops.h:85:5: error: template with C linkage
     85 |     template <class _Tp>
        |     ^~~~~~~~
  In file included from /home/runner/work/SuiteSparse/SuiteSparse/ParU/Include/ParU.hpp:42,
                   from /home/runner/work/SuiteSparse/SuiteSparse/ParU/Source/paru_internal.hpp:17,
                   from /home/runner/work/SuiteSparse/SuiteSparse/ParU/Source/paru_Diag_update.cpp:20:
  /home/runner/work/SuiteSparse/SuiteSparse/ParU/Include/ParU_definitions.h:13:1: note: ‘extern "C"’ linkage started here
     13 | extern "C" {
        | ^~~~~~~~~~
```
(e.g.: https://github.com/DrTimothyAldenDavis/SuiteSparse/actions/runs/6578211130/job/17871436856#step:8:7567 )

The proposed change should be avoiding that error by not including headers inside an `extern "C"` block. (It would be easier to check whether this actually works if #450 was merged.)
Afaict, there is no difference in `typedef enum [...]` between C and C++. So, remove the `extern "C"` block entirely for simplicity.
