### PR TITLE
LAGraph: Link to OpenMP::OpenMP_C target

### DIFF
--- a/LAGraph/CMakeLists.txt
+++ b/LAGraph/CMakeLists.txt
@@ -127,11 +127,8 @@ find_package (GraphBLAS 7.0.1 REQUIRED MODULE)
 if ( COVERAGE )
     message ( STATUS "OpenMP disabled for test coverage" )
 else ( )
-    include ( FindOpenMP  )
-    include ( FindThreads )
-    if ( OPENMP_FOUND )
-        set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} " )
-    endif ( )
+    find_package ( OpenMP )
+    find_package ( Threads )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/LAGraph/experimental/CMakeLists.txt
+++ b/LAGraph/experimental/CMakeLists.txt
@@ -59,8 +59,8 @@ target_link_directories ( lagraphx_static BEFORE PUBLIC ${CMAKE_SOURCE_DIR}/buil
 #-------------------------------------------------------------------------------
 
 if ( OPENMP_FOUND )
-    target_link_libraries ( lagraphx PUBLIC lagraph ${OpenMP_C_LIBRARIES} )
-    target_link_libraries ( lagraphx_static PUBLIC lagraph_static ${OpenMP_C_LIBRARIES} )
+    target_link_libraries ( lagraphx PUBLIC lagraph OpenMP::OpenMP_C )
+    target_link_libraries ( lagraphx_static PUBLIC lagraph_static OpenMP::OpenMP_C )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/LAGraph/src/CMakeLists.txt
+++ b/LAGraph/src/CMakeLists.txt
@@ -65,8 +65,8 @@ target_link_directories( lagraph_static BEFORE PUBLIC ${CMAKE_SOURCE_DIR}/build 
 #-------------------------------------------------------------------------------
 
 if ( OPENMP_FOUND )
-    target_link_libraries ( lagraph PUBLIC ${OpenMP_C_LIBRARIES} )
-    target_link_libraries ( lagraph_static PUBLIC ${OpenMP_C_LIBRARIES} )
+    target_link_libraries ( lagraph PUBLIC OpenMP::OpenMP_C )
+    target_link_libraries ( lagraph_static PUBLIC OpenMP::OpenMP_C )
 endif ( )
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Building LAGraph with OpenMP currently fails if the OpenMP headers are installed in a non-default location.
E.g.: https://github.com/DrTimothyAldenDavis/SuiteSparse/actions/runs/6578211130/job/17871438146#step:7:6548
```
  [  0%] Building C object src/CMakeFiles/lagraph.dir/algorithm/LAGr_Betweenness.c.o
  In file included from /Users/runner/work/SuiteSparse/SuiteSparse/LAGraph/src/algorithm/LAGr_Betweenness.c:79:
  In file included from /Users/runner/work/SuiteSparse/SuiteSparse/LAGraph/src/utility/LG_internal.h:30:
  /Users/runner/work/SuiteSparse/SuiteSparse/LAGraph/include/LAGraph.h:51:14: fatal error: 'omp.h' file not found
      #include <omp.h>
               ^~~~~~~
  1 error generated.
```

The proposed change hopefully fixes that by linking to the imported CMake target `OpenMP::OpenMP_C` which should be providing all necessary information.

(Again, it would be easier to check whether this works if #450 was merged.)
