### PR TITLE
AMD: Don't force-disable Fortran on Windows

### DIFF
--- a/AMD/CMakeLists.txt
+++ b/AMD/CMakeLists.txt
@@ -35,11 +35,6 @@ include ( SuiteSparsePolicy )
 # define the project
 #-------------------------------------------------------------------------------
 
-if ( WIN32 )
-    # disable Fortran in AMD when compiling on Windows
-    set ( NFORTRAN true )
-endif ( )
-
 if ( NOT NFORTRAN )
     # Fortan is available and enabled
     project ( amd


### PR DESCRIPTION
I don't know the original motivation why Fortran was deactivated for AMD on Windows unconditionally. But it is working for me now. 
So, remove the logic that deactivates Fortran for AMD on Windows.
