### PR TITLE
ParU: First pass for CMake build rules

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -9,9 +9,9 @@ concurrency: ci-arch-emu-${{ github.ref }}
 
 env:
   # string with name of libraries to be built
-  BUILD_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:RBio:SPQR:SPEX:ParU"
+  BUILD_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:ParU:RBio:SPQR:SPEX"
   # string with name of libraries to be checked
-  CHECK_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:RBio:SPQR:SPEX"
+  CHECK_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:ParU:RBio:SPQR:SPEX"
 
 
 jobs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,9 +10,9 @@ concurrency: ci-${{ github.ref }}
 
 env:
   # string with name of libraries to be built
-  BUILD_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:RBio:SPQR:GraphBLAS:SPEX:LAGraph:ParU"
+  BUILD_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:ParU:RBio:SPQR:GraphBLAS:SPEX:LAGraph"
   # string with name of libraries to be checked
-  CHECK_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:RBio:SPQR:GraphBLAS:SPEX"
+  CHECK_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:ParU:RBio:SPQR:GraphBLAS:SPEX"
 
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ library:
 	( cd LDL && $(MAKE) )
 	( cd KLU && $(MAKE) )
 	( cd UMFPACK && $(MAKE) )
+	( cd ParU && $(MAKE) )
 	( cd RBio && $(MAKE) )
 	( cd SPQR && $(MAKE) )
 	( cd GraphBLAS && $(MAKE) )
@@ -55,6 +56,7 @@ local:
 	( cd LDL && $(MAKE) local )
 	( cd KLU && $(MAKE) local )
 	( cd UMFPACK && $(MAKE) local )
+	( cd ParU && $(MAKE) local )
 	( cd RBio && $(MAKE) local )
 	( cd SPQR && $(MAKE) local )
 	( cd GraphBLAS && $(MAKE) local )
@@ -76,6 +78,7 @@ global:
 	( cd LDL && $(MAKE) global )
 	( cd KLU && $(MAKE) global )
 	( cd UMFPACK && $(MAKE) global )
+	( cd ParU && $(MAKE) global )
 	( cd RBio && $(MAKE) global )
 	( cd SPQR && $(MAKE) global )
 	( cd GraphBLAS && $(MAKE) global )
@@ -95,6 +98,7 @@ install:
 	( cd LDL && $(MAKE) install )
 	( cd KLU && $(MAKE) install )
 	( cd UMFPACK && $(MAKE) install )
+	( cd ParU && $(MAKE) install )
 	( cd RBio && $(MAKE) install )
 	( cd SPQR && $(MAKE) install )
 	( cd GraphBLAS && $(MAKE) install )
@@ -111,6 +115,7 @@ uninstall:
 	( cd KLU && $(MAKE) uninstall )
 	( cd LDL && $(MAKE) uninstall )
 	( cd CCOLAMD && $(MAKE) uninstall )
+	( cd ParU && $(MAKE) uninstall )
 	( cd UMFPACK && $(MAKE) uninstall )
 	( cd CHOLMOD && $(MAKE) uninstall )
 	( cd CXSparse && $(MAKE) uninstall )
@@ -144,6 +149,7 @@ purge:
 	- $(RM) -r Example/build/*
 	- ( cd GraphBLAS && $(MAKE) purge )
 	- ( cd SPEX && $(MAKE) purge )
+	- ( cd ParU && $(MAKE) purge )
 	- $(RM) -r include/* bin/* lib/*
 
 clean: purge
@@ -167,6 +173,7 @@ demos:
 	- ( cd SPQR && $(MAKE) demos )
 	- ( cd GraphBLAS && $(MAKE) demos )
 	- ( cd SPEX && $(MAKE) demos )
+	- ( cd ParU && $(MAKE) demos )
 
 # Create the PDF documentation
 docs:
@@ -178,6 +185,7 @@ docs:
 	( cd LDL && $(MAKE) docs )
 	( cd UMFPACK && $(MAKE) docs )
 	( cd CHOLMOD && $(MAKE) docs )
+	( cd ParU && $(MAKE) docs )
 	( cd SPQR && $(MAKE) docs )
 	( cd SPEX && $(MAKE) docs )
 
@@ -211,6 +219,7 @@ debug:
 	( cd LDL && $(MAKE) debug )
 	( cd KLU && $(MAKE) debug )
 	( cd UMFPACK && $(MAKE) debug )
+	( cd ParU && $(MAKE) debug )
 	( cd RBio && $(MAKE) debug )
 	( cd SPQR && $(MAKE) debug )
 	( cd GraphBLAS && $(MAKE) cdebug )

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -53,8 +53,8 @@ project ( paru
 # find library dependencies
 #-------------------------------------------------------------------------------
 
-enable_language ( C CXX Fortran )
-message ( STATUS "Fortran: ${CMAKE_Fortran_COMPILER_ID} ") 
+enable_language ( C CXX )
+
 find_package ( OpenMP )
 
 find_package ( SuiteSparse_config 7.2.0

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -29,14 +29,7 @@ message ( STATUS "Building PARU version: v"
 
 set ( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
     ${CMAKE_SOURCE_DIR}/cmake_modules
-    ${CMAKE_SOURCE_DIR}/../AMD/cmake_modules
-    ${CMAKE_SOURCE_DIR}/../CAMD/cmake_modules
-    ${CMAKE_SOURCE_DIR}/../COLAMD/cmake_modules
-    ${CMAKE_SOURCE_DIR}/../CCOLAMD/cmake_modules
-    ${CMAKE_SOURCE_DIR}/../CHOLMOD/cmake_modules
-    ${CMAKE_SOURCE_DIR}/../UMFPACK/cmake_modules
     ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/cmake_modules
-    ${CMAKE_SOURCE_DIR}/../SuiteSparse/SuiteSparse_config/cmake_modules
     )
 
 include ( SuiteSparsePolicy )
@@ -95,13 +88,7 @@ configure_file ( "Config/paru_version.tex.in"
 # include directories
 #-------------------------------------------------------------------------------
 
-include_directories ( Source Include ${SUITESPARSE_CONFIG_INCLUDE_DIR}
-    ${AMD_INCLUDE_DIR}
-    ${CAMD_INCLUDE_DIR}
-    ${COLAMD_INCLUDE_DIR}
-    ${CCOLAMD_INCLUDE_DIR}
-    ${CHOLMOD_INCLUDE_DIR}
-    ${UMFPACK_INCLUDE_DIR}
+include_directories ( Source Include
     ${CMAKE_SOURCE_DIR}/../UMFPACK/Source
     ${CMAKE_SOURCE_DIR}/../UMFPACK/Include
     ${CMAKE_SOURCE_DIR}/../CHOLMOD/Include
@@ -142,9 +129,15 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 # suitesparseconfig:
-target_link_libraries ( paru PRIVATE ${SUITESPARSE_CONFIG_LIBRARIES} )
+target_link_libraries ( paru PRIVATE SuiteSparse::SuiteSparseConfig )
+target_include_directories ( paru PUBLIC
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( NOT NSTATIC )
-    target_link_libraries ( paru_static PUBLIC ${SUITESPARSE_CONFIG_STATIC} )
+    if ( TARGET SuiteSparse::SuiteSparseConfig_static )
+        target_link_libraries ( paru_static PUBLIC SuiteSparse::SuiteSparseConfig_static )
+    else ( )
+        target_link_libraries ( paru_static PUBLIC SuiteSparse::SuiteSparseConfig )
+    endif ( )
 endif ( )
 
 # OpenMP:
@@ -166,34 +159,16 @@ if ( NOT MSVC )
     endif ( )
 endif ( )
 
-# amd
-target_link_libraries ( paru PRIVATE ${AMD_LIBRARIES} )
-if ( NOT NSTATIC )
-    target_link_libraries ( paru_static PUBLIC ${AMD_STATIC} )
-endif ( )
-
-# camd:
-target_link_libraries ( paru PRIVATE ${CAMD_LIBRARIES} )
-if ( NOT NSTATIC )
-target_link_libraries ( paru_static PUBLIC ${CAMD_STATIC} )
-endif ( )
-
-# colamd:
-target_link_libraries ( paru PRIVATE ${COLAMD_LIBRARIES} )
-if ( NOT NSTATIC )
-    target_link_libraries ( paru_static PUBLIC ${COLAMD_STATIC} )
-endif ( )
-
-# ccolamd:
-target_link_libraries ( paru PRIVATE ${CCOLAMD_LIBRARIES} )
-if ( NOT NSTATIC )
-    target_link_libraries ( paru_static PUBLIC ${CCOLAMD_STATIC} )
-endif ( )
-
 # umfpack:
-target_link_libraries ( paru PRIVATE ${UMFPACK_LIBRARIES} )
+target_link_libraries ( paru PRIVATE SuiteSparse::UMFPACK )
+target_include_directories ( paru PUBLIC
+    "$<TARGET_PROPERTY:SuiteSparse::UMFPACK,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( NOT NSTATIC )
-    target_link_libraries ( paru_static PUBLIC ${UMFPACK_STATIC} )
+    if ( TARGET SuiteSparse::UMFPACK_static )
+        target_link_libraries ( paru_static PUBLIC SuiteSparse::UMFPACK_static )
+    else ( )
+        target_link_libraries ( paru_static PUBLIC SuiteSparse::UMFPACK )
+    endif ( )
 endif ( )
 
 # BLAS:
@@ -206,9 +181,15 @@ if ( NOT NSTATIC )
 endif ( )
 
 # cholmod:
-target_link_libraries ( paru PRIVATE ${CHOLMOD_LIBRARIES} )
+target_link_libraries ( paru PRIVATE SuiteSparse::CHOLMOD )
+target_include_directories ( paru PUBLIC
+    "$<TARGET_PROPERTY:SuiteSparse::CHOLMOD,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( NOT NSTATIC )
-    target_link_libraries ( paru_static PUBLIC ${CHOLMOD_STATIC} )
+    if ( TARGET SuiteSparse::CHOLMOD_static )
+        target_link_libraries ( paru_static PUBLIC SuiteSparse::CHOLMOD_static )
+    else ( )
+        target_link_libraries ( paru_static PUBLIC SuiteSparse::CHOLMOD )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -275,10 +256,14 @@ if ( DEMO )
     add_executable ( paru_simplec "Demo/paru_simplec.c"  )
 
     # Libraries required for Demo programs
-    target_link_libraries ( paru_demo    PUBLIC paru OpenMP::OpenMP_CXX )
-    target_link_libraries ( paru_democ   PUBLIC paru OpenMP::OpenMP_C )
-    target_link_libraries ( paru_simple  PUBLIC paru )
-    target_link_libraries ( paru_simplec PUBLIC paru )
+    target_link_libraries ( paru_demo
+        PUBLIC paru SuiteSparse::CHOLMOD SuiteSparse::UMFPACK OpenMP::OpenMP_CXX )
+    target_link_libraries ( paru_democ
+        PUBLIC paru SuiteSparse::CHOLMOD SuiteSparse::UMFPACK OpenMP::OpenMP_C )
+    target_link_libraries ( paru_simple
+        PUBLIC paru SuiteSparse::CHOLMOD )
+    target_link_libraries ( paru_simplec
+        PUBLIC paru SuiteSparse::CHOLMOD )
 
 else ( )
 

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -114,7 +114,8 @@ set_target_properties ( paru PROPERTIES
     VERSION ${PARU_VERSION_MAJOR}.${PARU_VERSION_MINOR}.${PARU_VERSION_UPDATE}
     CXX_STANDARD 11
     CXX_STANDARD_REQUIRED ON
-    SOVERSION ${PARU_VERSION_MAJOR} )
+    SOVERSION ${PARU_VERSION_MAJOR}
+    WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
 #-------------------------------------------------------------------------------
 # static paru library properties
@@ -128,7 +129,8 @@ if ( NOT NSTATIC )
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED ON
         OUTPUT_NAME paru
-        SOVERSION ${PARU_VERSION_MAJOR} )
+        SOVERSION ${PARU_VERSION_MAJOR}
+        WINDOWS_EXPORT_ALL_SYMBOLS ON )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -133,6 +133,11 @@ if ( NOT NSTATIC )
         SOVERSION ${PARU_VERSION_MAJOR}
         PUBLIC_HEADER "Include/ParU.hpp;Include/ParU_C.h;Include/ParU_definitions.h"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
+
+    if ( MSVC )
+        set_target_properties ( paru_static PROPERTIES
+            OUTPUT_NAME paru_static )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -115,6 +115,7 @@ set_target_properties ( paru PROPERTIES
     CXX_STANDARD 11
     CXX_STANDARD_REQUIRED ON
     SOVERSION ${PARU_VERSION_MAJOR}
+    PUBLIC_HEADER "Include/ParU.hpp;Include/ParU_C.h;Include/ParU_definitions.h"
     WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
 #-------------------------------------------------------------------------------
@@ -130,6 +131,7 @@ if ( NOT NSTATIC )
         CXX_STANDARD_REQUIRED ON
         OUTPUT_NAME paru
         SOVERSION ${PARU_VERSION_MAJOR}
+        PUBLIC_HEADER "Include/ParU.hpp;Include/ParU_C.h;Include/ParU_definitions.h"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
 endif ( )
 
@@ -205,42 +207,19 @@ endif ( )
 # PARU installation location
 #-------------------------------------------------------------------------------
 
-if ( GLOBAL_INSTALL )
-    # install in /usr/local/lib and /usr/local/include.
-    # requires "sudo make install"
-    message ( STATUS "Installation will be system-wide (requires 'sudo make install')" )
-    install ( TARGETS paru
-        LIBRARY       DESTINATION ${CMAKE_INSTALL_LIBDIR} )
-    install ( FILES ${CMAKE_SOURCE_DIR}/cmake_modules/FindParU.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/SuiteSparse 
-        COMPONENT Development )
-    if ( NOT NSTATIC )
-    install ( TARGETS paru_static
-        ARCHIVE       DESTINATION ${CMAKE_INSTALL_LIBDIR} )
-    endif ( )
-    install ( FILES "Include/ParU_C.h"
-        "Include/ParU_definitions.h"
-        "Include/ParU.hpp" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} )
-endif ( )
+install ( TARGETS paru
+    LIBRARY DESTINATION ${SUITESPARSE_LIBDIR}
+    ARCHIVE DESTINATION ${SUITESPARSE_LIBDIR}
+    RUNTIME DESTINATION ${SUITESPARSE_BINDIR}
+    PUBLIC_HEADER DESTINATION ${SUITESPARSE_INCLUDEDIR} )
 
-if ( INSIDE_SUITESPARSE )
-    # also install in SuiteSparse/lib and SuiteSparse/include;
-    # does not require "sudo make install", just "make install"
-    message ( STATUS "Installation in ../lib and ../include only," )
-    message ( STATUS "  with 'make install'. No 'sudo' required." )
-    install ( TARGETS paru
-        LIBRARY       DESTINATION ${SUITESPARSE_LIBDIR}
-        PUBLIC_HEADER DESTINATION ${SUITESPARSE_INCLUDEDIR} )
-    install ( FILES ${CMAKE_SOURCE_DIR}/cmake_modules/FindParU.cmake
-        DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SuiteSparse 
-        COMPONENT Development )
-    if ( NOT NSTATIC )
+install ( FILES ${CMAKE_SOURCE_DIR}/cmake_modules/FindParU.cmake
+    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SuiteSparse 
+    COMPONENT Development )
+
+if ( NOT NSTATIC )
     install ( TARGETS paru_static
         ARCHIVE       DESTINATION ${SUITESPARSE_LIBDIR} )
-    endif ( )
-    install ( FILES "Include/ParU_C.h"
-        "Include/ParU_definitions.h"
-        "Include/ParU.hpp" DESTINATION ${SUITESPARSE_INCLUDEDIR} )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -142,9 +142,9 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 # suitesparseconfig:
-target_link_libraries ( paru PUBLIC ${SUITESPARSE_CONFIG_LIBRARIES} )
+target_link_libraries ( paru PRIVATE ${SUITESPARSE_CONFIG_LIBRARIES} )
 if ( NOT NSTATIC )
-target_link_libraries ( paru_static PUBLIC ${SUITESPARSE_CONFIG_STATIC} )
+    target_link_libraries ( paru_static PUBLIC ${SUITESPARSE_CONFIG_STATIC} )
 endif ( )
 
 # OpenMP:
@@ -160,55 +160,55 @@ endif ( )
 
 # libm:
 if ( NOT MSVC )
-    target_link_libraries ( paru PUBLIC m )
+    target_link_libraries ( paru PRIVATE m )
     if ( NOT NSTATIC )
-    target_link_libraries ( paru_static PUBLIC m )
+        target_link_libraries ( paru_static PUBLIC m )
     endif ( )
 endif ( )
 
 # amd
-target_link_libraries ( paru PUBLIC ${AMD_LIBRARIES} )
+target_link_libraries ( paru PRIVATE ${AMD_LIBRARIES} )
 if ( NOT NSTATIC )
-target_link_libraries ( paru_static PUBLIC ${AMD_STATIC} )
+    target_link_libraries ( paru_static PUBLIC ${AMD_STATIC} )
 endif ( )
 
 # camd:
-target_link_libraries ( paru PUBLIC ${CAMD_LIBRARIES} )
+target_link_libraries ( paru PRIVATE ${CAMD_LIBRARIES} )
 if ( NOT NSTATIC )
 target_link_libraries ( paru_static PUBLIC ${CAMD_STATIC} )
 endif ( )
 
 # colamd:
-target_link_libraries ( paru PUBLIC ${COLAMD_LIBRARIES} )
+target_link_libraries ( paru PRIVATE ${COLAMD_LIBRARIES} )
 if ( NOT NSTATIC )
-target_link_libraries ( paru_static PUBLIC ${COLAMD_STATIC} )
+    target_link_libraries ( paru_static PUBLIC ${COLAMD_STATIC} )
 endif ( )
 
 # ccolamd:
-target_link_libraries ( paru PUBLIC ${CCOLAMD_LIBRARIES} )
+target_link_libraries ( paru PRIVATE ${CCOLAMD_LIBRARIES} )
 if ( NOT NSTATIC )
-target_link_libraries ( paru_static PUBLIC ${CCOLAMD_STATIC} )
+    target_link_libraries ( paru_static PUBLIC ${CCOLAMD_STATIC} )
 endif ( )
 
 # umfpack:
-target_link_libraries ( paru PUBLIC ${UMFPACK_LIBRARIES} )
+target_link_libraries ( paru PRIVATE ${UMFPACK_LIBRARIES} )
 if ( NOT NSTATIC )
-target_link_libraries ( paru_static PUBLIC ${UMFPACK_STATIC} )
+    target_link_libraries ( paru_static PUBLIC ${UMFPACK_STATIC} )
 endif ( )
 
 # BLAS:
 message ( STATUS "BLAS libraries:      ${BLAS_LIBRARIES} ")
 message ( STATUS "BLAS linker flags:   ${BLAS_LINKER_FLAGS} ")
-target_link_libraries ( paru PUBLIC ${BLAS_LIBRARIES} )
+target_link_libraries ( paru PRIVATE ${BLAS_LIBRARIES} )
 if ( NOT NSTATIC )
-target_link_libraries ( paru_static PUBLIC ${BLAS_LIBRARIES} )
-include_directories ( ${BLAS_INCLUDE_DIRS} )
+    target_link_libraries ( paru_static PUBLIC ${BLAS_LIBRARIES} )
+    include_directories ( ${BLAS_INCLUDE_DIRS} )
 endif ( )
 
 # cholmod:
-target_link_libraries ( paru PUBLIC ${CHOLMOD_LIBRARIES} )
+target_link_libraries ( paru PRIVATE ${CHOLMOD_LIBRARIES} )
 if ( NOT NSTATIC )
-target_link_libraries ( paru_static PUBLIC ${CHOLMOD_STATIC} )
+    target_link_libraries ( paru_static PUBLIC ${CHOLMOD_STATIC} )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -85,9 +85,11 @@ include ( SuiteSparseBLAS )     # requires cmake 3.22
 #-------------------------------------------------------------------------------
 
 configure_file ( "Config/ParU_definitions.h.in"
-    "${PROJECT_SOURCE_DIR}/Include/ParU_definitions.h" )
+    "${PROJECT_SOURCE_DIR}/Include/ParU_definitions.h"
+    NEWLINE_STYLE LF )
 configure_file ( "Config/paru_version.tex.in"
-    "${PROJECT_SOURCE_DIR}/Doc/paru_version.tex" )
+    "${PROJECT_SOURCE_DIR}/Doc/paru_version.tex"
+    NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
 # include directories

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -88,11 +88,11 @@ configure_file ( "Config/paru_version.tex.in"
 # include directories
 #-------------------------------------------------------------------------------
 
+# FIXME: "paru_internal.hpp" includes "umf_internal.h" which is not installed.
+#        That means the two libraries are interdependent and ParU cannot be
+#        built as a stand-alone project outside a common build tree.
 include_directories ( Source Include
     ${CMAKE_SOURCE_DIR}/../UMFPACK/Source
-    ${CMAKE_SOURCE_DIR}/../UMFPACK/Include
-    ${CMAKE_SOURCE_DIR}/../CHOLMOD/Include
-    ${CMAKE_SOURCE_DIR}/../AMD/Include
     )
 
 #-------------------------------------------------------------------------------

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SuiteSparse/ParU/CMakeLists.txt:  cmake for ParU
 #-------------------------------------------------------------------------------
 
-# ParU, Copyright (c) 2022, Mohsen Aznaveh and Timothy A. Davis,
+# ParU, Copyright (c) 2022-2023, Mohsen Aznaveh and Timothy A. Davis,
 # All Rights Reserved.
 # SPDX-License-Identifier: GNU GPL 3.0
 
@@ -113,8 +113,8 @@ add_library ( paru SHARED ${PARU_SOURCES} )
 
 set_target_properties ( paru PROPERTIES
     VERSION ${PARU_VERSION_MAJOR}.${PARU_VERSION_MINOR}.${PARU_VERSION_UPDATE}
-    C_STANDARD_REQUIRED 11
-    CXX_STANDARD_REQUIRED 11
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED ON
     SOVERSION ${PARU_VERSION_MAJOR} )
 
 #-------------------------------------------------------------------------------
@@ -122,14 +122,14 @@ set_target_properties ( paru PROPERTIES
 #-------------------------------------------------------------------------------
 
 if ( NOT NSTATIC )
-add_library ( paru_static STATIC ${PARU_SOURCES} )
+    add_library ( paru_static STATIC ${PARU_SOURCES} )
 
-set_target_properties ( paru_static PROPERTIES
-    VERSION ${PARU_VERSION_MAJOR}.${PARU_VERSION_MINOR}.${PARU_VERSION_UPDATE}
-    C_STANDARD_REQUIRED 11
-    CXX_STANDARD_REQUIRED 11
-    OUTPUT_NAME paru
-    SOVERSION ${PARU_VERSION_MAJOR} )
+    set_target_properties ( paru_static PROPERTIES
+        VERSION ${PARU_VERSION_MAJOR}.${PARU_VERSION_MINOR}.${PARU_VERSION_UPDATE}
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED ON
+        OUTPUT_NAME paru
+        SOVERSION ${PARU_VERSION_MAJOR} )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -211,7 +211,7 @@ endif ( )
 
 #-------------------------------------------------------------------------------
 # PARU installation location
-#---------------------------------------------------------------Z--------------
+#-------------------------------------------------------------------------------
 
 if ( GLOBAL_INSTALL )
     # install in /usr/local/lib and /usr/local/include.

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -148,17 +148,14 @@ target_link_libraries ( paru_static PUBLIC ${SUITESPARSE_CONFIG_STATIC} )
 endif ( )
 
 # OpenMP:
-if ( OPENMP_FOUND )
-    message ( STATUS "OpenMP C libraries:      ${OpenMP_C_LIBRARIES} ")
-    message ( STATUS "OpenMP C include:        ${OpenMP_C_INCLUDE_DIRS} ")
-    message ( STATUS "OpenMP C flags:          ${OpenMP_C_FLAGS} ")
-    target_link_libraries ( paru PUBLIC ${OpenMP_C_LIBRARIES} )
+if ( OPENMP_CXX_FOUND )
+    message ( STATUS "OpenMP C++ libraries:    ${OpenMP_CXX_LIBRARIES} ")
+    message ( STATUS "OpenMP C++ include:      ${OpenMP_CXX_INCLUDE_DIRS} ")
+    message ( STATUS "OpenMP C++ flags:        ${OpenMP_CXX_FLAGS} ")
+    target_link_libraries ( paru PRIVATE OpenMP::OpenMP_CXX )
     if ( NOT NSTATIC )
-    target_link_libraries ( paru_static PUBLIC ${OpenMP_C_LIBRARIES} )
+        target_link_libraries ( paru_static PUBLIC OpenMP::OpenMP_CXX )
     endif ( )
-    set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} " )
-    set ( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} " )
-    include_directories ( ${OpenMP_C_INCLUDE_DIRS} )
 endif ( )
 
 # libm:
@@ -278,8 +275,8 @@ if ( DEMO )
     add_executable ( paru_simplec "Demo/paru_simplec.c"  )
 
     # Libraries required for Demo programs
-    target_link_libraries ( paru_demo    PUBLIC paru )
-    target_link_libraries ( paru_democ   PUBLIC paru )
+    target_link_libraries ( paru_demo    PUBLIC paru OpenMP::OpenMP_CXX )
+    target_link_libraries ( paru_democ   PUBLIC paru OpenMP::OpenMP_C )
     target_link_libraries ( paru_simple  PUBLIC paru )
     target_link_libraries ( paru_simplec PUBLIC paru )
 

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -46,14 +46,17 @@ include ( SuiteSparsePolicy )
 #-------------------------------------------------------------------------------
 
 project ( paru
-    VERSION "${PARU_VERSION_MAJOR}.${PARU_VERSION_MINOR}.${PARU_VERSION_UPDATE}"
-    LANGUAGES C CXX )
+    VERSION "${PARU_VERSION_MAJOR}.${PARU_VERSION_MINOR}.${PARU_VERSION_UPDATE}" )
 
 #-------------------------------------------------------------------------------
 # find library dependencies
 #-------------------------------------------------------------------------------
 
-enable_language ( C CXX )
+enable_language ( CXX )
+
+if ( DEMO )
+    enable_language ( C )
+endif ( )
 
 find_package ( OpenMP )
 

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -51,7 +51,14 @@ if ( DEMO )
     enable_language ( C )
 endif ( )
 
-find_package ( OpenMP )
+option ( NOPENMP "ON: do not use OpenMP.  OFF (default): use OpenMP" OFF )
+if ( NOPENMP )
+    # OpenMP has been disabled
+    set ( OPENMP_CXX_FOUND OFF )
+    set ( OPENMP_C_FOUND OFF )
+else ( )
+    find_package ( OpenMP )
+endif ( )
 
 find_package ( SuiteSparse_config 7.2.0
     PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
@@ -250,18 +257,23 @@ if ( DEMO )
     # Demo programs
     #---------------------------------------------------------------------------
 
-    add_executable ( paru_demo    "Demo/paru_demo.cpp"   )
-    add_executable ( paru_democ   "Demo/paru_democ.c"    )
-    add_executable ( paru_simple  "Demo/paru_simple.cpp" )
-    add_executable ( paru_simplec "Demo/paru_simplec.c"  )
+    if ( OPENMP_CXX_FOUND )
+        add_executable ( paru_demo    "Demo/paru_demo.cpp"   )
+        target_link_libraries ( paru_demo
+            PUBLIC paru SuiteSparse::CHOLMOD SuiteSparse::UMFPACK OpenMP::OpenMP_CXX )
+    endif ( )
 
-    # Libraries required for Demo programs
-    target_link_libraries ( paru_demo
-        PUBLIC paru SuiteSparse::CHOLMOD SuiteSparse::UMFPACK OpenMP::OpenMP_CXX )
-    target_link_libraries ( paru_democ
-        PUBLIC paru SuiteSparse::CHOLMOD SuiteSparse::UMFPACK OpenMP::OpenMP_C )
+    if ( OPENMP_C_FOUND )
+        add_executable ( paru_democ   "Demo/paru_democ.c"    )
+        target_link_libraries ( paru_democ
+            PUBLIC paru SuiteSparse::CHOLMOD SuiteSparse::UMFPACK OpenMP::OpenMP_C )
+    endif ( )
+
+    add_executable ( paru_simple  "Demo/paru_simple.cpp" )
     target_link_libraries ( paru_simple
         PUBLIC paru SuiteSparse::CHOLMOD )
+
+    add_executable ( paru_simplec "Demo/paru_simplec.c"  )
     target_link_libraries ( paru_simplec
         PUBLIC paru SuiteSparse::CHOLMOD )
 

--- a/ParU/Include/ParU_C.h
+++ b/ParU/Include/ParU_C.h
@@ -11,10 +11,6 @@
 #ifndef PARU_C_H
 #define PARU_C_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif 
-
 #include <stdint.h>
 #include "ParU_definitions.h"
 
@@ -78,6 +74,10 @@ typedef struct ParU_C_Numeric_struct
     double *Rs ;
     void *num_handle;
 } ParU_C_Numeric;
+
+#ifdef __cplusplus
+extern "C" {
+#endif 
 
 //------------------------------------------------------------------------------
 // ParU_Version: 

--- a/ParU/Makefile
+++ b/ParU/Makefile
@@ -56,10 +56,10 @@ all: library
 
 demos: library
 	( cd build && cmake $(CMAKE_OPTIONS) -DDEMO=1 .. && cmake --build . --config Release -j${JOBS} )
-	( cd build && ./paru_simplec < ../Matrix/b1_ss.mtx)
-	( cd build && ./paru_simple < ../Matrix/west0067.mtx )
-	( cd build && ./paru_democ < ../Matrix/west0067.mtx)
-	( cd build && ./paru_demo < ../Matrix/xenon1.mtx )
+	( cd build && ./paru_simplec$(EXEEXT) < ../Matrix/b1_ss.mtx )
+	( cd build && ./paru_simple$(EXEEXT) < ../Matrix/west0067.mtx )
+	( cd build && [ -f paru_democ$(EXEEXT) ] && ./paru_democ$(EXEEXT) < ../Matrix/west0067.mtx || true )
+	( cd build && [ -f paru_demo$(EXEEXT) ] && ./paru_demo$(EXEEXT) < ../Matrix/xenon1.mtx || true )
 
 cov:
 	( cd Tcov && $(MAKE) )

--- a/ParU/Makefile
+++ b/ParU/Makefile
@@ -35,27 +35,27 @@ JOBS ?= 8
 default: library
 
 library:
-	( cd build && cmake $(CMAKE_OPTIONS) .. && $(MAKE) --jobs=${JOBS} )
+	( cd build && cmake $(CMAKE_OPTIONS) .. && cmake --build . --config Release -j${JOBS} )
 
 # install only in SuiteSparse/lib and SuiteSparse/include
 local:
-	( cd build && cmake $(CMAKE_OPTIONS) -DGLOBAL_INSTALL=0 -DLOCAL_INSTALL=1 .. && $(MAKE) --jobs=${JOBS} )
+	( cd build && cmake $(CMAKE_OPTIONS) -DGLOBAL_INSTALL=0 -DLOCAL_INSTALL=1 .. && cmake --build . --config Release -j${JOBS} )
 
 # install only in /usr/local (default)
 global:
-	( cd build && cmake $(CMAKE_OPTIONS) -DGLOBAL_INSTALL=1 -DLOCAL_INSTALL=0 .. && $(MAKE) --jobs=${JOBS} )
+	( cd build && cmake $(CMAKE_OPTIONS) -DGLOBAL_INSTALL=1 -DLOCAL_INSTALL=0 .. && cmake --build . --config Release -j${JOBS} )
 
 # install in SuiteSparse/lib both and SuiteSparse/include and /usr/local
 both:
-	( cd build && cmake $(CMAKE_OPTIONS) -DGLOBAL_INSTALL=1 -DLOCAL_INSTALL=1 .. && $(MAKE) --jobs=${JOBS} )
+	( cd build && cmake $(CMAKE_OPTIONS) -DGLOBAL_INSTALL=1 -DLOCAL_INSTALL=1 .. && cmake --build . --config Release -j${JOBS} )
 
 debug:
-	( cd build && cmake $(CMAKE_OPTIONS) -DCMAKE_BUILD_TYPE=Debug .. && $(MAKE) --jobs=${JOBS} )
+	( cd build && cmake $(CMAKE_OPTIONS) -DCMAKE_BUILD_TYPE=Debug .. && cmake --build . --config Release -j${JOBS} )
 
 all: library
 
 demos: library
-	( cd build && cmake $(CMAKE_OPTIONS) -DDEMO=1 .. && $(MAKE) --jobs=${JOBS} )
+	( cd build && cmake $(CMAKE_OPTIONS) -DDEMO=1 .. && cmake --build . --config Release -j${JOBS} )
 	( cd build && ./paru_simplec < ../Matrix/b1_ss.mtx)
 	( cd build && ./paru_simple < ../Matrix/west0067.mtx )
 	( cd build && ./paru_democ < ../Matrix/west0067.mtx)
@@ -66,14 +66,14 @@ cov:
 
 # just compile after running cmake; do not run cmake again
 remake:
-	( cd build && $(MAKE) --jobs=${JOBS} )
+	( cd build && cmake --build . --config Release -j${JOBS} )
 
 # just run cmake to set things up
 setup:
 	( cd build && cmake $(CMAKE_OPTIONS) .. )
 
 install:
-	( cd build && $(MAKE) install )
+	( cd build && cmake --install . )
 
 # remove any installed libraries and #include files
 uninstall:


### PR DESCRIPTION
It is building now in most of the configurations of the CI. 
It's only still failing for MSVC with OpenMP. Maybe, we need some additional flags for that? But it's getting late here. And the current state might be enough to share.

This library also seems to include a header that isn't installed: `umf_internal.h` which in turn includes `amd_internal.h`. Should these be copied again? (I don't really like that workaround...)