### PR TITLE
LAGraph: Re-run failing tests with more verbose output and continue.

### DIFF
--- a/LAGraph/Makefile
+++ b/LAGraph/Makefile
@@ -63,7 +63,7 @@ debug:
 all: library
 
 test: library
-	( cd build && ctest . )
+	( cd build && ctest . || ctest . --rerun-failed --output-on-failure || true )
 
 # target used in CI
 demos: test


### PR DESCRIPTION
Re-run failing tests with `--rerun-failed --output-on-failure` to get more verbose output that might help in tracking down the issue on 32-bit platforms.

Also continue even if ctest fails to make it behave more similar to the other projects.
