### PR TITLE
LAGraph: Adapt for stricter implementations of the OpenMP standard.

### DIFF
--- a/LAGraph/experimental/algorithm/LAGraph_BF_full.c
+++ b/LAGraph/experimental/algorithm/LAGraph_BF_full.c
@@ -218,8 +218,9 @@ GrB_Info LAGraph_BF_full
     LG_TRY (LAGraph_GetNumThreads (&nthreads_outer, &nthreads_inner, msg)) ;
     nthreads = nthreads_outer * nthreads_inner ;
     printf ("nthreads %d\n", nthreads) ;
+    int64_t k;
     #pragma omp parallel for num_threads(nthreads) schedule(static)
-    for (GrB_Index k = 0; k < nz; k++)
+    for (k = 0; k < nz; k++)
     {
         if (w[k] == 0)             //diagonal entries
         {
@@ -292,7 +293,7 @@ GrB_Info LAGraph_BF_full
     LAGRAPH_TRY (LAGraph_Malloc ((void **) &h , nz, sizeof(GrB_Index), msg)) ;
     LAGRAPH_TRY (LAGraph_Malloc ((void **) &pi, nz, sizeof(GrB_Index), msg)) ;
 
-    for (GrB_Index k = 0; k < nz; k++)
+    for (k = 0; k < nz; k++)
     {
         w [k] = W[k].w ;
         h [k] = W[k].h ;

--- a/LAGraph/experimental/algorithm/LAGraph_BF_full1.c
+++ b/LAGraph/experimental/algorithm/LAGraph_BF_full1.c
@@ -248,8 +248,9 @@ GrB_Info LAGraph_BF_full1
     LG_TRY (LAGraph_GetNumThreads (&nthreads_outer, &nthreads_inner, msg)) ;
     nthreads = nthreads_outer * nthreads_inner ;
     printf ("nthreads %d\n", nthreads) ;
+    int64_t k;
     #pragma omp parallel for num_threads(nthreads) schedule(static)
-    for (GrB_Index k = 0; k < nz; k++)
+    for (k = 0; k < nz; k++)
     {
         W[k] = (BF1_Tuple3_struct) { .w = w[k], .h = 1, .pi = I[k] + 1 };
     }
@@ -350,7 +351,7 @@ GrB_Info LAGraph_BF_full1
 
     GRB_TRY (GrB_Vector_extractTuples_UDT (I, (void *) W, &n, d));
 
-    for (GrB_Index k = 0; k < n; k++)
+    for (k = 0; k < n; k++)
     {
         w [k] = W[k].w ;
         h [k] = W[k].h ;

--- a/LAGraph/experimental/algorithm/LAGraph_BF_full1a.c
+++ b/LAGraph/experimental/algorithm/LAGraph_BF_full1a.c
@@ -240,8 +240,9 @@ GrB_Info LAGraph_BF_full1a
     LG_TRY (LAGraph_GetNumThreads (&nthreads_outer, &nthreads_inner, msg)) ;
     nthreads = nthreads_outer * nthreads_inner ;
     printf ("nthreads %d\n", nthreads) ;
+    int64_t k;
     #pragma omp parallel for num_threads(nthreads) schedule(static)
-    for (GrB_Index k = 0; k < nz; k++)
+    for (k = 0; k < nz; k++)
     {
         W[k] = (BF_Tuple3_struct) { .w = w[k], .h = 1, .pi = I[k] + 1 };
     }
@@ -373,7 +374,7 @@ GrB_Info LAGraph_BF_full1a
 
     GRB_TRY (GrB_Vector_extractTuples_UDT (I, (void *) W, &n, d));
 
-    for (GrB_Index k = 0; k < n; k++)
+    for (k = 0; k < n; k++)
     {
         w [k] = W[k].w ;
         h [k] = W[k].h ;

--- a/LAGraph/experimental/algorithm/LAGraph_BF_full2.c
+++ b/LAGraph/experimental/algorithm/LAGraph_BF_full2.c
@@ -238,8 +238,9 @@ GrB_Info LAGraph_BF_full2
     LG_TRY (LAGraph_GetNumThreads (&nthreads_outer, &nthreads_inner, msg)) ;
     nthreads = nthreads_outer * nthreads_inner ;
     printf ("nthreads %d\n", nthreads) ;
+    int64_t k;
     #pragma omp parallel for num_threads(nthreads) schedule(static)
-    for (GrB_Index k = 0; k < nz; k++)
+    for (k = 0; k < nz; k++)
     {
         if (w[k] == 0)             //diagonal entries
         {
@@ -331,7 +332,7 @@ GrB_Info LAGraph_BF_full2
     nz = n ;
     GRB_TRY (GrB_Vector_extractTuples_UDT (I, (void *) W, &nz, d));
 
-    for (GrB_Index k = 0; k < nz; k++)
+    for (k = 0; k < nz; k++)
     {
         w [k] = W[k].w ;
         h [k] = W[k].h ;

--- a/LAGraph/experimental/algorithm/LG_CC_FastSV5.c
+++ b/LAGraph/experimental/algorithm/LG_CC_FastSV5.c
@@ -211,8 +211,9 @@ static inline int Reduce_assign32
         ht_init (ht_key, ht_val) ;
         ht_sample (index, n, HASH_SAMPLES, ht_key, ht_val, seed) ;
 
+        int tid;
         #pragma omp parallel for num_threads(nthreads) schedule(static)
-        for (int tid = 0 ; tid < nthreads ; tid++)
+        for (tid = 0 ; tid < nthreads ; tid++)
         {
             // get the thread-specific buf array of size HASH_SIZE
             // todo: buf is a bad variable name; it's not a "buffer",
@@ -260,7 +261,7 @@ static inline int Reduce_assign32
             int32_t i = ht_key [h] ;
             if (i != -1)
             {
-                for (int32_t tid = 0 ; tid < nthreads ; tid++)
+                for (tid = 0 ; tid < nthreads ; tid++)
                 {
                     w_x [i] = LAGRAPH_MIN (w_x [i], mem [tid * HASH_SIZE + h]) ;
                 }
@@ -394,8 +395,9 @@ int LG_CC_FastSV5           // SuiteSparse:GraphBLAS method, with GxB extensions
     LAGRAPH_TRY (LAGraph_Malloc ((void **) &V32, n, sizeof (uint32_t), msg)) ;
 
     // prepare vectors
+    int64_t i;
     #pragma omp parallel for num_threads(nthreads2) schedule(static)
-    for (GrB_Index i = 0 ; i < n ; i++)
+    for (i = 0 ; i < n ; i++)
     {
         I [i] = i ;
         V32 [i] = (uint32_t) i ;
@@ -487,8 +489,9 @@ int LG_CC_FastSV5           // SuiteSparse:GraphBLAS method, with GxB extensions
         // determine the number entries to be constructed in T for each thread
         //----------------------------------------------------------------------
 
+        int tid;
         #pragma omp parallel for num_threads(nthreads) schedule(static)
-        for (int tid = 0 ; tid < nthreads ; tid++)
+        for (tid = 0 ; tid < nthreads ; tid++)
         {
             for (int32_t i = range [tid] ; i < range [tid+1] ; i++)
             {
@@ -501,7 +504,7 @@ int LG_CC_FastSV5           // SuiteSparse:GraphBLAS method, with GxB extensions
         // count = cumsum (count)
         //----------------------------------------------------------------------
 
-        for (int tid = 0 ; tid < nthreads ; tid++)
+        for (tid = 0 ; tid < nthreads ; tid++)
         {
             count [tid + 1] += count [tid] ;
         }
@@ -518,7 +521,7 @@ int LG_CC_FastSV5           // SuiteSparse:GraphBLAS method, with GxB extensions
         // Note that Tx is not modified.  Only Tp and Tj are constructed.
 
         #pragma omp parallel for num_threads(nthreads) schedule(static)
-        for (int tid = 0 ; tid < nthreads ; tid++)
+        for (tid = 0 ; tid < nthreads ; tid++)
         {
             GrB_Index p = count [tid] ;
             Tp [range [tid]] = p ;
@@ -575,8 +578,9 @@ int LG_CC_FastSV5           // SuiteSparse:GraphBLAS method, with GxB extensions
             // calculate grandparent
             // fixme: NULL parameter is SS:GrB extension
             GRB_TRY (GrB_Vector_extractTuples (NULL, V32, &n, f)) ; // fixme
+            int32_t i;
             #pragma omp parallel for num_threads(nthreads2) schedule(static)
-            for (uint32_t i = 0 ; i < n ; i++)
+            for (i = 0 ; i < n ; i++)
             {
                 I [i] = (GrB_Index) V32 [i] ;
             }
@@ -630,7 +634,7 @@ int LG_CC_FastSV5           // SuiteSparse:GraphBLAS method, with GxB extensions
         // scheduled.
 
         #pragma omp parallel for num_threads(nthreads) schedule(static)
-        for (int tid = 0 ; tid < nthreads ; tid++)
+        for (tid = 0 ; tid < nthreads ; tid++)
         {
             GrB_Index ptr = Sp [range [tid]] ;
             // thread tid scans S (range [tid]:range [tid+1]-1,:),
@@ -668,7 +672,7 @@ int LG_CC_FastSV5           // SuiteSparse:GraphBLAS method, with GxB extensions
         // Compact empty space out of Tj not filled in from the above phase.
         // This is a lot of work and should be done in parallel.
         GrB_Index offset = 0 ;
-        for (int tid = 0 ; tid < nthreads ; tid++)
+        for (tid = 0 ; tid < nthreads ; tid++)
         {
             memcpy (Tj + offset, Tj + Tp [range [tid]],
                 sizeof (GrB_Index) * count [tid]) ;
@@ -678,7 +682,7 @@ int LG_CC_FastSV5           // SuiteSparse:GraphBLAS method, with GxB extensions
 
         // Compact empty space out of Tp
         #pragma omp parallel for num_threads(nthreads) schedule(static)
-        for (int tid = 0 ; tid < nthreads ; tid++)
+        for (tid = 0 ; tid < nthreads ; tid++)
         {
             GrB_Index ptr = Tp [range [tid]] ;
             for (int32_t i = range [tid] ; i < range [tid+1] ; i++)
@@ -736,8 +740,9 @@ int LG_CC_FastSV5           // SuiteSparse:GraphBLAS method, with GxB extensions
         // calculate grandparent
         // fixme: NULL parameter is SS:GrB extension
         GRB_TRY (GrB_Vector_extractTuples (NULL, V32, &n, f)) ; // fixme
+        int32_t k;
         #pragma omp parallel for num_threads(nthreads2) schedule(static)
-        for (uint32_t k = 0 ; k < n ; k++)
+        for (k = 0 ; k < n ; k++)
         {
             I [k] = (GrB_Index) V32 [k] ;
         }

--- a/LAGraph/experimental/benchmark/dnn_demo.c
+++ b/LAGraph/experimental/benchmark/dnn_demo.c
@@ -377,9 +377,10 @@ int main (int argc, char **argv)
             bool ok = true ;
 
             // assume the I/O system can handle 2-way parallelism
+            int layer;
             #pragma omp parallel for schedule(dynamic,1) reduction(&&:ok) \
                 num_threads (2)
-            for (int layer = first_layer ; layer < nlayers ; layer++)
+            for (layer = first_layer ; layer < nlayers ; layer++)
             {
                 // read the neuron layer: W [layer]
                 char my_filename [1024] ;
@@ -428,7 +429,7 @@ int main (int argc, char **argv)
             printf ("read net time %g sec\n", t) ;
 
             double nedges = 0 ;
-            for (int layer = 0 ; layer < nlayers ; layer++)
+            for (layer = 0 ; layer < nlayers ; layer++)
             {
                 GrB_Index nvals ;
                 GRB_TRY (GrB_Matrix_nvals (&nvals, W [layer])) ;

--- a/LAGraph/experimental/test/LG_check_ktruss.c
+++ b/LAGraph/experimental/test/LG_check_ktruss.c
@@ -105,10 +105,11 @@ int LG_check_ktruss
         //----------------------------------------------------------------------
 
         // masked dot-product method: C{C}=C*C' using the PLUS_ONE semiring
+        int64_t i;
         #if !defined ( COVERAGE )
         #pragma omp parallel for schedule(dynamic,1024)
         #endif
-        for (int64_t i = 0 ; i < n ; i++)
+        for (i = 0 ; i < n ; i++)
         {
             // for each entry in C(i,:)
             for (int64_t p = Cp [i] ; p < Cp [i+1] ; p++)

--- a/LAGraph/src/algorithm/LG_CC_FastSV6.c
+++ b/LAGraph/src/algorithm/LG_CC_FastSV6.c
@@ -408,7 +408,8 @@ int LG_CC_FastSV6           // SuiteSparse:GraphBLAS method, with GxB extensions
         //----------------------------------------------------------------------
 
         // thread tid works on rows range[tid]:range[tid+1]-1 of A and T
-        for (int tid = 0 ; tid <= nthreads ; tid++)
+        int tid;
+        for (tid = 0 ; tid <= nthreads ; tid++)
         {
             range [tid] = (n * tid + nthreads - 1) / nthreads ;
         }
@@ -418,7 +419,7 @@ int LG_CC_FastSV6           // SuiteSparse:GraphBLAS method, with GxB extensions
         //----------------------------------------------------------------------
 
         #pragma omp parallel for num_threads(nthreads) schedule(static)
-        for (int tid = 0 ; tid < nthreads ; tid++)
+        for (tid = 0 ; tid < nthreads ; tid++)
         {
             for (int64_t i = range [tid] ; i < range [tid+1] ; i++)
             {
@@ -431,7 +432,7 @@ int LG_CC_FastSV6           // SuiteSparse:GraphBLAS method, with GxB extensions
         // count = cumsum (count)
         //----------------------------------------------------------------------
 
-        for (int tid = 0 ; tid < nthreads ; tid++)
+        for (tid = 0 ; tid < nthreads ; tid++)
         {
             count [tid + 1] += count [tid] ;
         }
@@ -443,7 +444,7 @@ int LG_CC_FastSV6           // SuiteSparse:GraphBLAS method, with GxB extensions
         // T (i,:) consists of the first FASTSV_SAMPLES of A (i,:).
 
         #pragma omp parallel for num_threads(nthreads) schedule(static)
-        for (int tid = 0 ; tid < nthreads ; tid++)
+        for (tid = 0 ; tid < nthreads ; tid++)
         {
             GrB_Index p = count [tid] ;
             Tp [range [tid]] = p ;
@@ -553,7 +554,7 @@ int LG_CC_FastSV6           // SuiteSparse:GraphBLAS method, with GxB extensions
             &Tx_size, &T_iso, &T_jumbled, NULL)) ;
 
         #pragma omp parallel for num_threads(nthreads) schedule(static)
-        for (int tid = 0 ; tid < nthreads ; tid++)
+        for (tid = 0 ; tid < nthreads ; tid++)
         {
             GrB_Index p = Ap [range [tid]] ;
             // thread tid scans A (range [tid]:range [tid+1]-1,:),
@@ -598,7 +599,7 @@ int LG_CC_FastSV6           // SuiteSparse:GraphBLAS method, with GxB extensions
 
         // Compact empty space out of Tj not filled in from the above phase.
         nvals = 0 ;
-        for (int tid = 0 ; tid < nthreads ; tid++)
+        for (tid = 0 ; tid < nthreads ; tid++)
         {
             memcpy (Tj + nvals, Tj + Tp [range [tid]],
                 sizeof (GrB_Index) * count [tid]) ;
@@ -608,7 +609,7 @@ int LG_CC_FastSV6           // SuiteSparse:GraphBLAS method, with GxB extensions
 
         // Compact empty space out of Tp
         #pragma omp parallel for num_threads(nthreads) schedule(static)
-        for (int tid = 0 ; tid < nthreads ; tid++)
+        for (tid = 0 ; tid < nthreads ; tid++)
         {
             GrB_Index p = Tp [range [tid]] ;
             for (int64_t i = range [tid] ; i < range [tid+1] ; i++)

--- a/LAGraph/src/test/LG_check_tri.c
+++ b/LAGraph/src/test/LG_check_tri.c
@@ -85,10 +85,11 @@ int LG_check_tri        // -1 if out of memory, 0 if successful
     Ai = Aj ;       // pretend A is symmetric and in CSC format instead
 
     // masked dot-product method
+    int64_t j;
     #if !defined ( COVERAGE )
     #pragma omp parallel for reduction(+:ntriangles) schedule(dynamic,1024)
     #endif
-    for (int64_t j = 0 ; j < n ; j++)
+    for (j = 0 ; j < n ; j++)
     {
         // for each entry in the lower triangular part of A
         for (int64_t p = Ap [j] ; p < Ap [j+1] ; p++)

--- a/LAGraph/src/utility/LAGr_SortByDegree.c
+++ b/LAGraph/src/utility/LAGr_SortByDegree.c
@@ -118,8 +118,9 @@ int LAGr_SortByDegree
     // construct the pair [D,P] to sort
     //--------------------------------------------------------------------------
 
+    int64_t k;
     #pragma omp parallel for num_threads(nthreads) schedule(static)
-    for (int64_t k = 0 ; k < n ; k++)
+    for (k = 0 ; k < n ; k++)
     {
         D [k] = 0 ;
         P [k] = k ;
@@ -133,7 +134,7 @@ int LAGr_SortByDegree
     {
         // sort [D,P] in ascending order of degree, tie-breaking on P
         #pragma omp parallel for num_threads(nthreads) schedule(static)
-        for (int64_t k = 0 ; k < nvals ; k++)
+        for (k = 0 ; k < nvals ; k++)
         {
             D [W0 [k]] = W1 [k] ;
         }
@@ -142,7 +143,7 @@ int LAGr_SortByDegree
     {
         // sort [D,P] in descending order of degree, tie-breaking on P
         #pragma omp parallel for num_threads(nthreads) schedule(static)
-        for (int64_t k = 0 ; k < nvals ; k++)
+        for (k = 0 ; k < nvals ; k++)
         {
             D [W0 [k]] = -W1 [k] ;
         }

--- a/LAGraph/src/utility/LG_msort1.c
+++ b/LAGraph/src/utility/LG_msort1.c
@@ -409,7 +409,7 @@ int LG_msort1
         // already sorted with respect to each other.
 
         // this could be done in parallel if ntasks was large
-        for (int tid = 0 ; tid < ntasks ; tid += 2*nt)
+        for (tid = 0 ; tid < ntasks ; tid += 2*nt)
         {
             // create 2*nt tasks to merge two A sublists into one W sublist
             LG_msort_1b_create_merge_tasks (
@@ -438,7 +438,7 @@ int LG_msort1
         //----------------------------------------------------------------------
 
         // this could be done in parallel if ntasks was large
-        for (int tid = 0 ; tid < ntasks ; tid += 2*nt)
+        for (tid = 0 ; tid < ntasks ; tid += 2*nt)
         {
             // create 2*nt tasks to merge two W sublists into one A sublist
             LG_msort_1b_create_merge_tasks (

--- a/LAGraph/src/utility/LG_msort2.c
+++ b/LAGraph/src/utility/LG_msort2.c
@@ -427,7 +427,7 @@ int LG_msort2
         // already sorted with respect to each other.
 
         // this could be done in parallel if ntasks was large
-        for (int tid = 0 ; tid < ntasks ; tid += 2*nt)
+        for (tid = 0 ; tid < ntasks ; tid += 2*nt)
         {
             // create 2*nt tasks to merge two A sublists into one W sublist
             LG_msort_2b_create_merge_tasks (
@@ -456,7 +456,7 @@ int LG_msort2
         //----------------------------------------------------------------------
 
         // this could be done in parallel if ntasks was large
-        for (int tid = 0 ; tid < ntasks ; tid += 2*nt)
+        for (tid = 0 ; tid < ntasks ; tid += 2*nt)
         {
             // create 2*nt tasks to merge two W sublists into one A sublist
             LG_msort_2b_create_merge_tasks (

--- a/LAGraph/src/utility/LG_msort3.c
+++ b/LAGraph/src/utility/LG_msort3.c
@@ -440,7 +440,7 @@ int LG_msort3
         //----------------------------------------------------------------------
 
         // this could be done in parallel if ntasks was large
-        for (int tid = 0 ; tid < ntasks ; tid += 2*nt)
+        for (tid = 0 ; tid < ntasks ; tid += 2*nt)
         {
             // create 2*nt tasks to merge two A sublists into one W sublist
             LG_msort_3b_create_merge_tasks (
@@ -469,7 +469,7 @@ int LG_msort3
         //----------------------------------------------------------------------
 
         // this could be done in parallel if ntasks was large
-        for (int tid = 0 ; tid < ntasks ; tid += 2*nt)
+        for (tid = 0 ; tid < ntasks ; tid += 2*nt)
         {
             // create 2*nt tasks to merge two W sublists into one A sublist
             LG_msort_3b_create_merge_tasks (


### PR DESCRIPTION
IIUC, the OpenMP standard requires that the iterator of parallel for loops is a signed integer that is declared outside the scope of the parallel loop body. Some implementations seem to have relaxed that requirement (allowing unsigned integers or initialization in the for loop). But others (MSVC) seem to follow a stricter interpretation of the standard.

Adapt the source to allow for that stricter interpretation.

Fixes the second issue raised in #462.