### PR TITLE
Support installing package configuration files at different location

### DIFF
--- a/AMD/CMakeLists.txt
+++ b/AMD/CMakeLists.txt
@@ -171,7 +171,7 @@ export ( EXPORT AMDTargets
 # install export target, config and version files for find_package
 install ( EXPORT AMDTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/AMD )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/AMD )
 
 # generate config file to be used in common build tree
 set ( SUITESPARSE_IN_BUILD_TREE ON )
@@ -185,7 +185,7 @@ set ( SUITESPARSE_IN_BUILD_TREE OFF )
 configure_package_config_file (
     Config/AMDConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/target/AMDConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/AMD )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/AMD )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/AMDConfigVersion.cmake
@@ -194,7 +194,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/AMDConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/AMDConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/AMD )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/AMD )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -222,7 +222,7 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/AMD.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/BTF/CMakeLists.txt
+++ b/BTF/CMakeLists.txt
@@ -159,7 +159,7 @@ export ( EXPORT BTFTargets
 # install export target, config and version files for find_package
 install ( EXPORT BTFTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/BTF )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/BTF )
 
 # generate config file to be used in common build tree
 set ( SUITESPARSE_IN_BUILD_TREE ON )
@@ -173,7 +173,7 @@ set ( SUITESPARSE_IN_BUILD_TREE OFF )
 configure_package_config_file (
     Config/BTFConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/target/BTFConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/BTF )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/BTF )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/BTFConfigVersion.cmake
@@ -182,7 +182,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/BTFConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/BTFConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/BTF )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/BTF )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -210,7 +210,7 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/BTF.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/CAMD/CMakeLists.txt
+++ b/CAMD/CMakeLists.txt
@@ -161,7 +161,7 @@ export ( EXPORT CAMDTargets
 # install export target, config and version files for find_package
 install ( EXPORT CAMDTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CAMD )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CAMD )
 
 # generate config file to be used in common build tree
 set ( SUITESPARSE_IN_BUILD_TREE ON )
@@ -175,7 +175,7 @@ set ( SUITESPARSE_IN_BUILD_TREE OFF )
 configure_package_config_file (
     Config/CAMDConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/target/CAMDConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CAMD )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CAMD )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/CAMDConfigVersion.cmake
@@ -184,7 +184,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/CAMDConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/CAMDConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CAMD )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CAMD )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -212,7 +212,7 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/CAMD.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/CCOLAMD/CMakeLists.txt
+++ b/CCOLAMD/CMakeLists.txt
@@ -158,7 +158,7 @@ export ( EXPORT CCOLAMDTargets
 # install export target, config and version files for find_package
 install ( EXPORT CCOLAMDTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CCOLAMD )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CCOLAMD )
 
 # generate config file to be used in common build tree
 set ( SUITESPARSE_IN_BUILD_TREE ON )
@@ -172,7 +172,7 @@ set ( SUITESPARSE_IN_BUILD_TREE OFF )
 configure_package_config_file (
     Config/CCOLAMDConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/target/CCOLAMDConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CCOLAMD )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CCOLAMD )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/CCOLAMDConfigVersion.cmake
@@ -181,7 +181,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/CCOLAMDConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/CCOLAMDConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CCOLAMD )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CCOLAMD )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -209,7 +209,7 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/CCOLAMD.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -531,7 +531,7 @@ export ( EXPORT CHOLMODTargets
 # install export target, config and version files for find_package
 install ( EXPORT CHOLMODTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CHOLMOD )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CHOLMOD )
 
 # generate config file to be used in common build tree
 set ( SUITESPARSE_IN_BUILD_TREE on )
@@ -545,7 +545,7 @@ set ( SUITESPARSE_IN_BUILD_TREE off )
 configure_package_config_file (
     Config/CHOLMODConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/target/CHOLMODConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CHOLMOD )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CHOLMOD )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/CHOLMODConfigVersion.cmake
@@ -554,7 +554,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/target/CHOLMODConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/CHOLMODConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CHOLMOD )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CHOLMOD )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -609,7 +609,7 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/CHOLMOD.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/CHOLMOD/GPU/CMakeLists.txt
+++ b/CHOLMOD/GPU/CMakeLists.txt
@@ -120,12 +120,12 @@ export ( EXPORT CHOLMOD_CUDATargets
 # install export target, config and version files for find_package
 install ( EXPORT CHOLMOD_CUDATargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CHOLMOD_CUDA )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CHOLMOD_CUDA )
 
 configure_package_config_file (
     ../Config/CHOLMOD_CUDAConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/../CHOLMOD_CUDAConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CHOLMOD_CUDA )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CHOLMOD_CUDA )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/../CHOLMOD_CUDAConfigVersion.cmake
@@ -134,7 +134,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/../CHOLMOD_CUDAConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/../CHOLMOD_CUDAConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CHOLMOD_CUDA )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CHOLMOD_CUDA )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -162,5 +162,5 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/CHOLMOD_CUDA.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )

--- a/COLAMD/CMakeLists.txt
+++ b/COLAMD/CMakeLists.txt
@@ -158,7 +158,7 @@ export ( EXPORT COLAMDTargets
 # install export target, config and version files for find_package
 install ( EXPORT COLAMDTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/COLAMD )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/COLAMD )
 
 # generate config file to be used in common build tree
 set ( SUITESPARSE_IN_BUILD_TREE ON )
@@ -172,7 +172,7 @@ set ( SUITESPARSE_IN_BUILD_TREE OFF )
 configure_package_config_file (
     Config/COLAMDConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/target/COLAMDConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/COLAMD )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/COLAMD )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/COLAMDConfigVersion.cmake
@@ -181,7 +181,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/COLAMDConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/COLAMDConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/COLAMD )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/COLAMD )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -209,7 +209,7 @@ if ( NOT MSVC )
       NEWLINE_STYLE LF )
   install ( FILES
       ${CMAKE_CURRENT_BINARY_DIR}/COLAMD.pc
-      DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+      DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/CXSparse/CMakeLists.txt
+++ b/CXSparse/CMakeLists.txt
@@ -191,7 +191,7 @@ export ( EXPORT CXSparseTargets
 # install export target, config and version files for find_package
 install ( EXPORT CXSparseTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CXSparse )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CXSparse )
 
 # generate config file to be used in common build tree
 set ( SUITESPARSE_IN_BUILD_TREE ON )
@@ -205,7 +205,7 @@ set ( SUITESPARSE_IN_BUILD_TREE OFF )
 configure_package_config_file (
     Config/CXSparseConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/target/CXSparseConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CXSparse )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CXSparse )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/CXSparseConfigVersion.cmake
@@ -214,7 +214,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/CXSparseConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/CXSparseConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/CXSparse )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CXSparse )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -242,7 +242,7 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/CXSparse.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -491,7 +491,7 @@ export ( EXPORT GraphBLASTargets
 # install export target and config for find_package
 install ( EXPORT GraphBLASTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/GraphBLAS )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/GraphBLAS )
 
 # generate config file to be used in common build tree
 set ( SUITESPARSE_IN_BUILD_TREE ON )
@@ -505,7 +505,7 @@ set ( SUITESPARSE_IN_BUILD_TREE OFF )
 configure_package_config_file (
     Config/GraphBLASConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/target/GraphBLASConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/GraphBLAS )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/GraphBLAS )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/GraphBLASConfigVersion.cmake
@@ -514,7 +514,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/GraphBLASConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/GraphBLASConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/GraphBLAS )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/GraphBLAS )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -569,7 +569,7 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/GraphBLAS.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/GraphBLAS/CUDA/CMakeLists.txt
+++ b/GraphBLAS/CUDA/CMakeLists.txt
@@ -100,12 +100,12 @@ export ( EXPORT GraphBLAS_CUDATargets
 # install export target and config for find_package
 install ( EXPORT GraphBLAS_CUDATargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/GraphBLAS )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/GraphBLAS )
 
 configure_package_config_file (
     Config/GraphBLAS_CUDAConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/GraphBLAS_CUDAConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/GraphBLAS )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/GraphBLAS )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/GraphBLAS_CUDAConfigVersion.cmake
@@ -114,7 +114,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/GraphBLAS_CUDAConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/GraphBLAS_CUDAConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/GraphBLAS )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/GraphBLAS )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -142,7 +142,7 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/GraphBLAS_CUDA.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/GraphBLAS/cmake_modules/SuiteSparsePolicy.cmake
+++ b/GraphBLAS/cmake_modules/SuiteSparsePolicy.cmake
@@ -174,11 +174,16 @@ if ( INSIDE_SUITESPARSE )
     set ( CMAKE_BUILD_RPATH   ${CMAKE_BUILD_RPATH}   ${SUITESPARSE_LIBDIR} )
 endif ( )
 
-message ( STATUS "Install lib:     ${SUITESPARSE_LIBDIR}" )
-message ( STATUS "Install include: ${SUITESPARSE_INCLUDEDIR}" )
-message ( STATUS "Install bin:     ${SUITESPARSE_BINDIR}" )
-message ( STATUS "Install rpath:   ${CMAKE_INSTALL_RPATH}" )
-message ( STATUS "Build   rpath:   ${CMAKE_BUILD_RPATH}" )
+option ( SUITESPARSE_PKGFILEDIR
+    "Directory where CMake Config and pkg-config files will be installed"
+    ${SUITESPARSE_LIBDIR} )
+
+message ( STATUS "Install lib:      ${SUITESPARSE_LIBDIR}" )
+message ( STATUS "Install include:  ${SUITESPARSE_INCLUDEDIR}" )
+message ( STATUS "Install bin:      ${SUITESPARSE_BINDIR}" )
+message ( STATUS "Install pkg-file: ${SUITESPARSE_PKGFILEDIR}" )
+message ( STATUS "Install rpath:    ${CMAKE_INSTALL_RPATH}" )
+message ( STATUS "Build   rpath:    ${CMAKE_BUILD_RPATH}" )
 
 if ( NOT CMAKE_BUILD_TYPE )
     set ( CMAKE_BUILD_TYPE Release )

--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -325,7 +325,7 @@ export ( EXPORT KLUTargets
 # install export target, config and version files for find_package
 install ( EXPORT KLUTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/KLU )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/KLU )
 
 # generate config file to be used in common build tree
 set ( SUITESPARSE_IN_BUILD_TREE ON )
@@ -339,7 +339,7 @@ set ( SUITESPARSE_IN_BUILD_TREE OFF )
 configure_package_config_file (
     Config/KLUConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/target/KLUConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/KLU )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/KLU )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/KLUConfigVersion.cmake
@@ -348,7 +348,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/KLUConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/KLUConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/KLU )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/KLU )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file for KLU
@@ -376,7 +376,7 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/KLU.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -404,7 +404,7 @@ if ( NOT NCHOLMOD )
     # install export target, config and version files for find_package
     install ( EXPORT KLU_CHOLMODTargets
         NAMESPACE SuiteSparse::
-        DESTINATION ${SUITESPARSE_LIBDIR}/cmake/KLU_CHOLMOD )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/KLU_CHOLMOD )
 
     # generate config file to be used in common build tree
     set ( SUITESPARSE_IN_BUILD_TREE ON )
@@ -418,7 +418,7 @@ if ( NOT NCHOLMOD )
     configure_package_config_file (
         Config/KLU_CHOLMODConfig.cmake.in
         ${CMAKE_CURRENT_BINARY_DIR}/target/KLU_CHOLMODConfig.cmake
-        INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/KLU_CHOLMOD )
+        INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/KLU_CHOLMOD )
 
     write_basic_package_version_file (
         ${CMAKE_CURRENT_BINARY_DIR}/KLU_CHOLMODConfigVersion.cmake
@@ -427,7 +427,7 @@ if ( NOT NCHOLMOD )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/KLU_CHOLMODConfig.cmake
         ${CMAKE_CURRENT_BINARY_DIR}/KLU_CHOLMODConfigVersion.cmake
-        DESTINATION ${SUITESPARSE_LIBDIR}/cmake/KLU_CHOLMOD )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/KLU_CHOLMOD )
 
     #---------------------------------------------------------------------------
     # create pkg-config file for KLU_CHOLMOD
@@ -455,7 +455,7 @@ if ( NOT NCHOLMOD )
             NEWLINE_STYLE LF )
         install ( FILES
             ${CMAKE_CURRENT_BINARY_DIR}/KLU_CHOLMOD.pc
-            DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+            DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
     endif ( )
 endif ( )
 

--- a/LDL/CMakeLists.txt
+++ b/LDL/CMakeLists.txt
@@ -174,7 +174,7 @@ export ( EXPORT LDLTargets
 # install export target, config and version files for find_package
 install ( EXPORT LDLTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/LDL )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/LDL )
 
 # generate config file to be used in common build tree
 set ( SUITESPARSE_IN_BUILD_TREE ON )
@@ -188,7 +188,7 @@ set ( SUITESPARSE_IN_BUILD_TREE OFF )
 configure_package_config_file (
     Config/LDLConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/target/LDLConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/LDL )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/LDL )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/LDLConfigVersion.cmake
@@ -197,7 +197,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/LDLConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/LDLConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/LDL )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/LDL )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -225,7 +225,7 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/LDL.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/Mongoose/CMakeLists.txt
+++ b/Mongoose/CMakeLists.txt
@@ -497,7 +497,7 @@ export ( EXPORT MongooseTargets
 # install export target, config and version files for find_package
 install ( EXPORT MongooseTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/Mongoose )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/Mongoose )
 
 # generate config file to be used in common build tree
 set ( SUITESPARSE_IN_BUILD_TREE ON )
@@ -511,7 +511,7 @@ set ( SUITESPARSE_IN_BUILD_TREE OFF )
 configure_package_config_file (
     Config/MongooseConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/target/MongooseConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/Mongoose )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/Mongoose )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/MongooseConfigVersion.cmake
@@ -520,7 +520,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/MongooseConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/MongooseConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/Mongoose )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/Mongoose )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -548,7 +548,7 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/Mongoose.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/RBio/CMakeLists.txt
+++ b/RBio/CMakeLists.txt
@@ -159,7 +159,7 @@ export ( EXPORT RBioTargets
 # install export target, config and version files for find_package
 install ( EXPORT RBioTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/RBio )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/RBio )
 
 # generate config file to be used in common build tree
 set ( SUITESPARSE_IN_BUILD_TREE ON )
@@ -173,7 +173,7 @@ set ( SUITESPARSE_IN_BUILD_TREE OFF )
 configure_package_config_file (
     Config/RBioConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/target/RBioConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/RBio )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/RBio )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/RBioConfigVersion.cmake
@@ -182,7 +182,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/RBioConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/RBioConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/RBio )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/RBio )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -210,7 +210,7 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/RBio.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -216,7 +216,7 @@ export ( EXPORT SPEXTargets
 # install export target, config and version files for find_package
 install ( EXPORT SPEXTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SPEX )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/SPEX )
 
 # generate config file to be used in common build tree
 set ( SUITESPARSE_IN_BUILD_TREE ON )
@@ -230,7 +230,7 @@ set ( SUITESPARSE_IN_BUILD_TREE OFF )
 configure_package_config_file (
     Config/SPEXConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/target/SPEXConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SPEX )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/SPEX )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/SPEXConfigVersion.cmake
@@ -239,7 +239,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/SPEXConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/SPEXConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SPEX )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/SPEX )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -294,7 +294,7 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/SPEX.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/SPQR/CMakeLists.txt
+++ b/SPQR/CMakeLists.txt
@@ -261,7 +261,7 @@ export ( EXPORT SPQRTargets
 # install export target, config and version files for find_package
 install ( EXPORT SPQRTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SPQR )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/SPQR )
 
 # generate config file to be used in common build tree
 set ( SUITESPARSE_IN_BUILD_TREE ON )
@@ -275,7 +275,7 @@ set ( SUITESPARSE_IN_BUILD_TREE OFF )
 configure_package_config_file (
     Config/SPQRConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/target/SPQRConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SPQR )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/SPQR )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/SPQRConfigVersion.cmake
@@ -284,7 +284,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/target/SPQRConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/SPQRConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SPQR )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/SPQR )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -339,7 +339,7 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/SPQR.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/SPQR/GPUQREngine/CMakeLists.txt
+++ b/SPQR/GPUQREngine/CMakeLists.txt
@@ -181,12 +181,12 @@ export ( EXPORT GPUQREngineTargets
 # install export target, config and version files for find_package
 install ( EXPORT GPUQREngineTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/GPUQREngine )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/GPUQREngine )
 
 configure_package_config_file (
     Config/GPUQREngineConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/GPUQREngineConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/GPUQREngine )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/GPUQREngine )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/GPUQREngineConfigVersion.cmake
@@ -195,7 +195,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/GPUQREngineConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/GPUQREngineConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/GPUQREngine )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/GPUQREngine )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -223,7 +223,7 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/GPUQREngine.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/SPQR/GPURuntime/CMakeLists.txt
+++ b/SPQR/GPURuntime/CMakeLists.txt
@@ -167,12 +167,12 @@ export ( EXPORT SuiteSparse_GPURuntimeTargets
 # install export target, config and version files for find_package
 install ( EXPORT SuiteSparse_GPURuntimeTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SuiteSparse_GPURuntime )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/SuiteSparse_GPURuntime )
 
 configure_package_config_file (
     Config/SuiteSparse_GPURuntimeConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_GPURuntimeConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SuiteSparse_GPURuntime )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/SuiteSparse_GPURuntime )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_GPURuntimeConfigVersion.cmake
@@ -181,7 +181,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_GPURuntimeConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_GPURuntimeConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SuiteSparse_GPURuntime )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/SuiteSparse_GPURuntime )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -209,5 +209,5 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_GPURuntime.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )

--- a/SPQR/SPQRGPU/CMakeLists.txt
+++ b/SPQR/SPQRGPU/CMakeLists.txt
@@ -125,7 +125,7 @@ export ( EXPORT SPQR_CUDATargets
 # install export target, config and version files for find_package
 install ( EXPORT SPQR_CUDATargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SPQR_CUDA )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/SPQR_CUDA )
 
 # generate config file to be used in common build tree
 set ( SUITESPARSE_IN_BUILD_TREE ON )
@@ -139,7 +139,7 @@ set ( SUITESPARSE_IN_BUILD_TREE OFF )
 configure_package_config_file (
     ../Config/SPQR_CUDAConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/../target/SPQR_CUDAConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SPQR_CUDA )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/SPQR_CUDA )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/../SPQR_CUDAConfigVersion.cmake
@@ -148,7 +148,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/../SPQR_CUDAConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/../SPQR_CUDAConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SPQR_CUDA )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/SPQR_CUDA )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -176,5 +176,5 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/SPQR_CUDA.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )

--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -171,7 +171,7 @@ install ( TARGETS SuiteSparseConfig
     PUBLIC_HEADER DESTINATION ${SUITESPARSE_INCLUDEDIR} )
 install ( FILES
     ${SUITESPARSE_CMAKE_MODULES}
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SuiteSparse
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/SuiteSparse
     COMPONENT Development )
 if ( NOT NSTATIC )
     install ( TARGETS SuiteSparseConfig_static
@@ -187,12 +187,12 @@ export ( EXPORT SuiteSparse_configTargets
 # install export target and config for find_package
 install ( EXPORT SuiteSparse_configTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SuiteSparse_config )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/SuiteSparse_config )
 
 configure_package_config_file (
     Config/SuiteSparse_configConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_configConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SuiteSparse_config )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/SuiteSparse_config )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_configConfigVersion.cmake
@@ -201,7 +201,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_configConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_configConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/SuiteSparse_config )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/SuiteSparse_config )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -229,7 +229,7 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_config.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
+++ b/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
@@ -174,11 +174,15 @@ if ( INSIDE_SUITESPARSE )
     set ( CMAKE_BUILD_RPATH   ${CMAKE_BUILD_RPATH}   ${SUITESPARSE_LIBDIR} )
 endif ( )
 
-message ( STATUS "Install lib:     ${SUITESPARSE_LIBDIR}" )
-message ( STATUS "Install include: ${SUITESPARSE_INCLUDEDIR}" )
-message ( STATUS "Install bin:     ${SUITESPARSE_BINDIR}" )
-message ( STATUS "Install rpath:   ${CMAKE_INSTALL_RPATH}" )
-message ( STATUS "Build   rpath:   ${CMAKE_BUILD_RPATH}" )
+set ( SUITESPARSE_PKGFILEDIR ${SUITESPARSE_LIBDIR} CACHE STRING
+    "Directory where CMake Config and pkg-config files will be installed" )
+
+message ( STATUS "Install lib:      ${SUITESPARSE_LIBDIR}" )
+message ( STATUS "Install include:  ${SUITESPARSE_INCLUDEDIR}" )
+message ( STATUS "Install bin:      ${SUITESPARSE_BINDIR}" )
+message ( STATUS "Install pkg-file: ${SUITESPARSE_PKGFILEDIR}" )
+message ( STATUS "Install rpath:    ${CMAKE_INSTALL_RPATH}" )
+message ( STATUS "Build   rpath:    ${CMAKE_BUILD_RPATH}" )
 
 if ( NOT CMAKE_BUILD_TYPE )
     set ( CMAKE_BUILD_TYPE Release )

--- a/UMFPACK/CMakeLists.txt
+++ b/UMFPACK/CMakeLists.txt
@@ -265,7 +265,7 @@ export ( EXPORT UMFPACKTargets
 # install export target, config and version files for find_package
 install ( EXPORT UMFPACKTargets
     NAMESPACE SuiteSparse::
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/UMFPACK )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/UMFPACK )
 
 # generate config file to be used in common build tree
 set ( SUITESPARSE_IN_BUILD_TREE ON )
@@ -279,7 +279,7 @@ set ( SUITESPARSE_IN_BUILD_TREE OFF )
 configure_package_config_file (
     Config/UMFPACKConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/target/UMFPACKConfig.cmake
-    INSTALL_DESTINATION ${SUITESPARSE_LIBDIR}/cmake/UMFPACK )
+    INSTALL_DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/UMFPACK )
 
 write_basic_package_version_file (
     ${CMAKE_CURRENT_BINARY_DIR}/UMFPACKConfigVersion.cmake
@@ -288,7 +288,7 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/UMFPACKConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/UMFPACKConfigVersion.cmake
-    DESTINATION ${SUITESPARSE_LIBDIR}/cmake/UMFPACK )
+    DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/UMFPACK )
 
 #-------------------------------------------------------------------------------
 # create pkg-config file
@@ -343,7 +343,7 @@ if ( NOT MSVC )
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/UMFPACK.pc
-        DESTINATION ${SUITESPARSE_LIBDIR}/pkgconfig )
+        DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )
 endif ( )
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This change allows the user to define a location for the CMake and pkg-config configuration files while installing the libraries, e.g., at a "default" location.

This will hopefully help for the use case described in #425.

@opoplawski: Would that work for your use-case?
You could, e.g., configure with 
```
cmake -DSUITESPARSE_INCLUDEDIR=include/suitesparse64 -DSUITESPARSE_PKGFILEDIR=lib/suitesparse64 -DCMAKE_RELEASE_POSTFIX=64 [other flags for that configuration] ..
```
That would allow to install the headers to a separate location like you already proposed in #425. Additionally, it would allow to install the CMake package configuration files and the .pc files in a location that differs from the "usual" one.
However, the libraries themselves would still be installed at the default location (with the SUFFIX that you were using). So, no RPATH or LD_PRELOAD shenanigans would be needed.

When building projects that rely on the "non-default" variants, users would need to set one of the following (depending on their choice of build system):
```
cmake -DCMAKE_PREFIX_PATH=/usr/lib/suitesparse64/cmake
PKG_CONFIG_PATH=/usr/lib/suitesparse64/pkgconfig
```

What do you think?
