### PR TITLE
LAGraph: Relax check for negative-weight cycle by floating point precision

### DIFF
--- a/LAGraph/experimental/algorithm/LAGraph_BF_pure_c_double.c
+++ b/LAGraph/experimental/algorithm/LAGraph_BF_pure_c_double.c
@@ -44,6 +44,8 @@
     LAGraph_Free ((void**) &pi, NULL) ;     \
 }
 
+#include <float.h>
+
 #include "LG_internal.h"
 #include <LAGraphX.h>
 
@@ -122,7 +124,7 @@ GrB_Info LAGraph_BF_pure_c_double
         {
             i = I[k];
             j = J[k];
-            if (d[j] > d[i] + W[k])
+            if (d[j] > d[i] + W[k] + DBL_EPSILON*d[j])
             {
                 LG_FREE_ALL ;
                 return (GrB_NO_VALUE) ;


### PR DESCRIPTION
Comparisons between floating point numbers can be "dangerous" at times because small errors could accumulate because of their limited precision.
If I understand the condition that checks for negative-weight cycles correctly, it shouldn't trigger if the compared numbers are equal.
This change allows them to be equal to double floating point precision.

This fixes part of #461.
