### PR TITLE
GraphBLAS: Fix error in SuiteSparsePolicy.cmake

### DIFF
--- a/GraphBLAS/cmake_modules/SuiteSparsePolicy.cmake
+++ b/GraphBLAS/cmake_modules/SuiteSparsePolicy.cmake
@@ -174,9 +174,8 @@ if ( INSIDE_SUITESPARSE )
     set ( CMAKE_BUILD_RPATH   ${CMAKE_BUILD_RPATH}   ${SUITESPARSE_LIBDIR} )
 endif ( )
 
-option ( SUITESPARSE_PKGFILEDIR
-    "Directory where CMake Config and pkg-config files will be installed"
-    ${SUITESPARSE_LIBDIR} )
+set ( SUITESPARSE_PKGFILEDIR ${SUITESPARSE_LIBDIR} CACHE STRING
+    "Directory where CMake Config and pkg-config files will be installed" )
 
 message ( STATUS "Install lib:      ${SUITESPARSE_LIBDIR}" )
 message ( STATUS "Install include:  ${SUITESPARSE_INCLUDEDIR}" )


### PR DESCRIPTION
Commit 42d82d857d60551fca4108cddd8e5ba018c9a1f8 accidentally contained a wrong version of that file. Synchronize it with the version in SuiteSparse_config.
