### PR TITLE
LDL: Avoid overlinking

### DIFF
--- a/LDL/CMakeLists.txt
+++ b/LDL/CMakeLists.txt
@@ -41,16 +41,20 @@ project ( ldl
 #-------------------------------------------------------------------------------
 # find library dependencies
 #-------------------------------------------------------------------------------
+option ( DEMO "ON: Build the demo programs.  OFF (default): do not build the demo programs." OFF )
 
 find_package ( SuiteSparse_config 7.2.0
     PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
 if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
     find_package ( SuiteSparse_config 7.2.0 REQUIRED )
 endif ( )
-find_package ( AMD 3.2.0
-    PATHS ${CMAKE_SOURCE_DIR}/../AMD/build NO_DEFAULT_PATH )
-if ( NOT TARGET SuiteSparse::AMD )
-    find_package ( AMD 3.2.0 REQUIRED )
+
+if ( DEMO )
+    find_package ( AMD 3.2.0
+        PATHS ${CMAKE_SOURCE_DIR}/../AMD/build NO_DEFAULT_PATH )
+    if ( NOT TARGET SuiteSparse::AMD )
+        find_package ( AMD 3.2.0 )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -129,25 +133,13 @@ if ( NOT WIN32 )
     endif ( )
 endif ( )
 
-target_link_libraries ( LDL PRIVATE
-    SuiteSparse::AMD SuiteSparse::SuiteSparseConfig )
 target_include_directories ( LDL PUBLIC
     "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 
 if ( NOT NSTATIC )
-    if ( TARGET SuiteSparse::AMD_static )
-        target_link_libraries ( LDL_static PUBLIC SuiteSparse::AMD_static )
-    else ( )
-        target_link_libraries ( LDL_static PUBLIC SuiteSparse::AMD )
-    endif ( )
-    if ( TARGET SuiteSparse::SuiteSparseConfig_static )
-        target_link_libraries ( LDL_static PUBLIC SuiteSparse::SuiteSparseConfig_static )
-    else ( )
-        target_link_libraries ( LDL_static PUBLIC SuiteSparse::SuiteSparseConfig )
-    endif ( )
+    target_include_directories ( LDL_static PUBLIC
+        "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 endif ( )
-
-
 #-------------------------------------------------------------------------------
 # LDL installation location
 #-------------------------------------------------------------------------------
@@ -232,7 +224,6 @@ endif ( )
 # Demo library and programs
 #-------------------------------------------------------------------------------
 
-option ( DEMO "ON: Build the demo programs.  OFF (default): do not build the demo programs." off )
 if ( DEMO )
 
     #---------------------------------------------------------------------------

--- a/LDL/Config/ldl.h.in
+++ b/LDL/Config/ldl.h.in
@@ -10,11 +10,6 @@
 #ifndef LDL_H
 #define LDL_H
 
-/* make it easy for C++ programs to include LDL */
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "SuiteSparse_config.h"
 
 #ifdef LDL_LONG
@@ -45,6 +40,11 @@ extern "C" {
 #define LDL_valid_perm ldl_valid_perm
 #define LDL_valid_matrix ldl_valid_matrix
 
+#endif
+
+/* make it easy for C++ programs to include LDL */
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 /* ========================================================================== */
@@ -102,6 +102,10 @@ int64_t ldl_l_valid_perm (int64_t n, int64_t P [ ], int64_t Flag [ ]) ;
 
 int64_t ldl_l_valid_matrix ( int64_t n, int64_t Ap [ ], int64_t Ai [ ]) ;
 
+#ifdef __cplusplus
+}
+#endif
+
 /* ========================================================================== */
 /* === LDL version ========================================================== */
 /* ========================================================================== */
@@ -113,9 +117,5 @@ int64_t ldl_l_valid_matrix ( int64_t n, int64_t Ap [ ], int64_t Ai [ ]) ;
 
 #define LDL_VERSION_CODE(main,sub) ((main) * 1000 + (sub))
 #define LDL_VERSION LDL_VERSION_CODE(LDL_MAIN_VERSION,LDL_SUB_VERSION)
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/LDL/Include/ldl.h
+++ b/LDL/Include/ldl.h
@@ -10,11 +10,6 @@
 #ifndef LDL_H
 #define LDL_H
 
-/* make it easy for C++ programs to include LDL */
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "SuiteSparse_config.h"
 
 #ifdef LDL_LONG
@@ -45,6 +40,11 @@ extern "C" {
 #define LDL_valid_perm ldl_valid_perm
 #define LDL_valid_matrix ldl_valid_matrix
 
+#endif
+
+/* make it easy for C++ programs to include LDL */
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 /* ========================================================================== */
@@ -102,6 +102,10 @@ int64_t ldl_l_valid_perm (int64_t n, int64_t P [ ], int64_t Flag [ ]) ;
 
 int64_t ldl_l_valid_matrix ( int64_t n, int64_t Ap [ ], int64_t Ai [ ]) ;
 
+#ifdef __cplusplus
+}
+#endif
+
 /* ========================================================================== */
 /* === LDL version ========================================================== */
 /* ========================================================================== */
@@ -113,9 +117,5 @@ int64_t ldl_l_valid_matrix ( int64_t n, int64_t Ap [ ], int64_t Ai [ ]) ;
 
 #define LDL_VERSION_CODE(main,sub) ((main) * 1000 + (sub))
 #define LDL_VERSION LDL_VERSION_CODE(LDL_MAIN_VERSION,LDL_SUB_VERSION)
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif


### PR DESCRIPTION
The ldl library doesn't actually depend on libsuitesparseconfig or libamd. Only some of the demos do and some preprocessor definition from the SuiteSparse_config header are used in some compilation units.
Avoid overlinking that library to the libraries that it doesn't use.

Also avoid inclusion of a header inside an `extern "C"` block.