### PR TITLE
SPQR_CUDA: Don't configure target SPQR_CUDA_static if it isn't built

### DIFF
--- a/SPQR/SPQRGPU/CMakeLists.txt
+++ b/SPQR/SPQRGPU/CMakeLists.txt
@@ -61,40 +61,41 @@ set ( SPQR_CUDA_INCLUDES ../Include )
 target_include_directories ( SPQR_CUDA PRIVATE
     "$<TARGET_PROPERTY:GPUQREngine,INTERFACE_INCLUDE_DIRECTORIES>"
     "$<TARGET_PROPERTY:GPURuntime,INTERFACE_INCLUDE_DIRECTORIES>" )
-target_include_directories ( SPQR_CUDA_static PRIVATE
-    "$<TARGET_PROPERTY:GPUQREngine,INTERFACE_INCLUDE_DIRECTORIES>"
-    "$<TARGET_PROPERTY:GPURuntime,INTERFACE_INCLUDE_DIRECTORIES>" )
 
 target_include_directories ( SPQR_CUDA PRIVATE
-        ${CUDAToolkit_INCLUDE_DIRS}
-        ${SPQR_CUDA_INCLUDES}
-        "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
+    ${CUDAToolkit_INCLUDE_DIRS}
+    ${SPQR_CUDA_INCLUDES}
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
+
 set_target_properties ( SPQR_CUDA PROPERTIES POSITION_INDEPENDENT_CODE ON )
 set_target_properties ( SPQR_CUDA PROPERTIES CUDA_SEPARABLE_COMPILATION ON )
 target_compile_definitions ( SPQR_CUDA PRIVATE "SUITESPARSE_CUDA" )
 
+target_link_libraries ( SPQR_CUDA PRIVATE SuiteSparse::CHOLMOD )
+
+target_link_libraries ( SPQR_CUDA PRIVATE CUDA::nvrtc CUDA::cudart_static
+    CUDA::nvToolsExt CUDA::cublas )
+
 if ( NOT NSTATIC )
+    target_include_directories ( SPQR_CUDA_static PRIVATE
+        "$<TARGET_PROPERTY:GPUQREngine,INTERFACE_INCLUDE_DIRECTORIES>"
+        "$<TARGET_PROPERTY:GPURuntime,INTERFACE_INCLUDE_DIRECTORIES>" )
+
     target_include_directories ( SPQR_CUDA_static PRIVATE
         ${CUDAToolkit_INCLUDE_DIRS}
         ${SPQR_CUDA_INCLUDES}
         "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
+
     set_target_properties ( SPQR_CUDA_static PROPERTIES CUDA_SEPARABLE_COMPILATION ON )
     set_target_properties ( SPQR_CUDA_static PROPERTIES POSITION_INDEPENDENT_CODE ON )
     target_compile_definitions ( SPQR_CUDA_static PRIVATE "SUITESPARSE_CUDA" )
-
 
     if ( TARGET SuiteSparse::CHOLMOD_static )
         target_link_libraries ( SPQR_CUDA_static PUBLIC SuiteSparse::CHOLMOD_static )
     else ( )
         target_link_libraries ( SPQR_CUDA_static PUBLIC SuiteSparse::CHOLMOD )
     endif ( )
-endif ( )
 
-target_link_libraries ( SPQR_CUDA PRIVATE SuiteSparse::CHOLMOD )
-
-target_link_libraries ( SPQR_CUDA PRIVATE CUDA::nvrtc CUDA::cudart_static
-    CUDA::nvToolsExt CUDA::cublas )
-if ( NOT NSTATIC )
     target_link_libraries ( SPQR_CUDA_static PUBLIC CUDA::nvrtc CUDA::cudart_static
         CUDA::nvToolsExt CUDA::cublas )
 endif ( )
@@ -112,9 +113,9 @@ install ( TARGETS SPQR_CUDA
     RUNTIME DESTINATION ${SUITESPARSE_BINDIR} )
 
 if ( NOT NSTATIC )
-install ( TARGETS SPQR_CUDA_static
-    EXPORT SPQR_CUDATargets
-    ARCHIVE DESTINATION ${SUITESPARSE_LIBDIR} )
+    install ( TARGETS SPQR_CUDA_static
+        EXPORT SPQR_CUDATargets
+        ARCHIVE DESTINATION ${SUITESPARSE_LIBDIR} )
 endif ( )
 
 # create (temporary) export target file during build


### PR DESCRIPTION
Do not call `target_include_directories` on `SPQR_CUDA_static` if that target isn't built.

Take the opportunity to re-order settings for the targets `SPQR_CUDA` and `SPQR_CUDA_static` for readability.