### PR TITLE
SPEX: Install CMake modules that are used in CMake Config file.

### DIFF
--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -239,6 +239,8 @@ write_basic_package_version_file (
 install ( FILES
     ${CMAKE_CURRENT_BINARY_DIR}/SPEXConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/SPEXConfigVersion.cmake
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/FindGMP.cmake
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/FindMPFR.cmake
     DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/SPEX )
 
 #-------------------------------------------------------------------------------

--- a/SPEX/Config/SPEXConfig.cmake.in
+++ b/SPEX/Config/SPEXConfig.cmake.in
@@ -83,6 +83,7 @@ else ( )
 endif ( )
 
 # Look for GMP and MPFR modules
+list ( PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR} )
 if ( NOT GMP_FOUND )
     find_dependency ( GMP 6.1.2 )
 endif ( )


### PR DESCRIPTION
The CMake Config file of SPEX includes logic to find all its dependencies automatically when a user adds `find_package ( SPEX )` in their CMake project. That includes GMP and MPFR. However, the CMake modules needed to detect these two libraries haven't been installed.

Install them to the same location as the Config file to avoid errors when users include `find_package ( SPEX )` in their projects.

