### PR TITLE
Install CMake Config files that are meant for installation

### DIFF
--- a/AMD/CMakeLists.txt
+++ b/AMD/CMakeLists.txt
@@ -192,7 +192,7 @@ write_basic_package_version_file (
     COMPATIBILITY SameMajorVersion )
 
 install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/AMDConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/target/AMDConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/AMDConfigVersion.cmake
     DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/AMD )
 

--- a/BTF/CMakeLists.txt
+++ b/BTF/CMakeLists.txt
@@ -180,7 +180,7 @@ write_basic_package_version_file (
     COMPATIBILITY SameMajorVersion )
 
 install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/BTFConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/target/BTFConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/BTFConfigVersion.cmake
     DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/BTF )
 

--- a/CAMD/CMakeLists.txt
+++ b/CAMD/CMakeLists.txt
@@ -182,7 +182,7 @@ write_basic_package_version_file (
     COMPATIBILITY SameMajorVersion )
 
 install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/CAMDConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/target/CAMDConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/CAMDConfigVersion.cmake
     DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CAMD )
 

--- a/CCOLAMD/CMakeLists.txt
+++ b/CCOLAMD/CMakeLists.txt
@@ -179,7 +179,7 @@ write_basic_package_version_file (
     COMPATIBILITY SameMajorVersion )
 
 install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/CCOLAMDConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/target/CCOLAMDConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/CCOLAMDConfigVersion.cmake
     DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CCOLAMD )
 

--- a/COLAMD/CMakeLists.txt
+++ b/COLAMD/CMakeLists.txt
@@ -179,7 +179,7 @@ write_basic_package_version_file (
     COMPATIBILITY SameMajorVersion )
 
 install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/COLAMDConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/target/COLAMDConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/COLAMDConfigVersion.cmake
     DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/COLAMD )
 

--- a/CXSparse/CMakeLists.txt
+++ b/CXSparse/CMakeLists.txt
@@ -212,7 +212,7 @@ write_basic_package_version_file (
     COMPATIBILITY SameMajorVersion )
 
 install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/CXSparseConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/target/CXSparseConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/CXSparseConfigVersion.cmake
     DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/CXSparse )
 

--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -512,7 +512,7 @@ write_basic_package_version_file (
     COMPATIBILITY SameMajorVersion )
 
 install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/GraphBLASConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/target/GraphBLASConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/GraphBLASConfigVersion.cmake
     DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/GraphBLAS )
 

--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -346,7 +346,7 @@ write_basic_package_version_file (
     COMPATIBILITY SameMajorVersion )
 
 install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/KLUConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/target/KLUConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/KLUConfigVersion.cmake
     DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/KLU )
 

--- a/LDL/CMakeLists.txt
+++ b/LDL/CMakeLists.txt
@@ -187,7 +187,7 @@ write_basic_package_version_file (
     COMPATIBILITY SameMajorVersion )
 
 install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/LDLConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/target/LDLConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/LDLConfigVersion.cmake
     DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/LDL )
 

--- a/Mongoose/CMakeLists.txt
+++ b/Mongoose/CMakeLists.txt
@@ -518,7 +518,7 @@ write_basic_package_version_file (
     COMPATIBILITY SameMajorVersion )
 
 install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/MongooseConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/target/MongooseConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/MongooseConfigVersion.cmake
     DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/Mongoose )
 

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -279,7 +279,7 @@ write_basic_package_version_file (
     COMPATIBILITY SameMajorVersion )
 
 install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/ParUConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/target/ParUConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/ParUConfigVersion.cmake
     DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/ParU )
 

--- a/RBio/CMakeLists.txt
+++ b/RBio/CMakeLists.txt
@@ -180,7 +180,7 @@ write_basic_package_version_file (
     COMPATIBILITY SameMajorVersion )
 
 install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/RBioConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/target/RBioConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/RBioConfigVersion.cmake
     DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/RBio )
 

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -237,7 +237,7 @@ write_basic_package_version_file (
     COMPATIBILITY SameMajorVersion )
 
 install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/SPEXConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/target/SPEXConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/SPEXConfigVersion.cmake
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/FindGMP.cmake
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/FindMPFR.cmake

--- a/UMFPACK/CMakeLists.txt
+++ b/UMFPACK/CMakeLists.txt
@@ -286,7 +286,7 @@ write_basic_package_version_file (
     COMPATIBILITY SameMajorVersion )
 
 install ( FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/UMFPACKConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/target/UMFPACKConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/UMFPACKConfigVersion.cmake
     DESTINATION ${SUITESPARSE_PKGFILEDIR}/cmake/UMFPACK )
 


### PR DESCRIPTION
In #445 I added rules to generate separate CMake Config files that are meant for installation. But I missed the part that actually installed them. D'oh.

Should be fixed with this change.
