### PR TITLE
CXSparse: Avoid overlinking

### DIFF
--- a/CXSparse/CMakeLists.txt
+++ b/CXSparse/CMakeLists.txt
@@ -145,15 +145,11 @@ endif ( )
 # add the library dependencies
 #-------------------------------------------------------------------------------
 
-target_link_libraries ( CXSparse PRIVATE SuiteSparse::SuiteSparseConfig )
 target_include_directories ( CXSparse PUBLIC
     "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( NOT NSTATIC )
-    if ( TARGET SuiteSparse::SuiteSparseConfig_static )
-        target_link_libraries ( CXSparse_static PUBLIC SuiteSparse::SuiteSparseConfig_static )
-    else ( )
-        target_link_libraries ( CXSparse_static PUBLIC SuiteSparse::SuiteSparseConfig )
-    endif ( )
+    target_include_directories ( CXSparse_static PUBLIC
+        "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 endif ( )
 
 # libm:

--- a/CXSparse/Config/CXSparse.pc.in
+++ b/CXSparse/Config/CXSparse.pc.in
@@ -11,7 +11,6 @@ Name: CXSparse
 URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Direct methods for sparse linear systems for real and complex matrices in SuiteSparse
 Version: @CXSPARSE_VERSION_MAJOR@.@CXSPARSE_VERSION_MINOR@.@CXSPARSE_VERSION_SUB@
-Requires.private: SuiteSparse_config
 Libs: -L${libdir} -lcxsparse
 Libs.private: @CXSPARSE_STATIC_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
CXSparse doesn't call a function from the suitesparseconfig library. It only includes its header for some definitions.

Don't link to the library to avoid overlinking.
