### PR TITLE
CI: Reduce timeout for check step

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -127,6 +127,7 @@ jobs:
           done
 
       - name: check
+        timeout-minutes: 30
         run: |
           IFS=':'
           CHECK_LIBS="${CHECK_LIBS}${{ matrix.extra-check-libs }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -145,6 +145,7 @@ jobs:
           done
 
       - name: check
+        timeout-minutes: 20
         run: |
           IFS=':' read -r -a libs <<< "${CHECK_LIBS}"
           for lib in "${libs[@]}"; do
@@ -265,6 +266,7 @@ jobs:
           done
 
       - name: check
+        timeout-minutes: 20
         run: |
           IFS=':' read -r -a libs <<< "${CHECK_LIBS}"
           for lib in "${libs[@]}"; do
@@ -427,6 +429,7 @@ jobs:
           done
 
       - name: check
+        timeout-minutes: 20
         # Need to install the libraries for the tests
         run: |
           echo "::group::Install libraries"


### PR DESCRIPTION
Running that step takes usually hardly longer than 5 minutes on native hardware. Set the timeout to 20 minutes to fail earlier if a runner gets stuck.
On emulated hardware, this step takes usually around 10 minutes. Set the timeout for this step to 30 minutes for the emulated runners.
