### PR TITLE
Example: Build and run also with static linking

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -174,6 +174,13 @@ jobs:
           cmake --build .
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Executing example\n"
+          printf "\033[1;35m  C binary with shared libraries\033[0m\n"
           LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_demo
+          printf "\033[1;35m  C++ binary with shared libraries\033[0m\n"
+          LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_cxx_demo
+          printf "\033[1;35m  C binary with statically linked libraries\033[0m\n"
+          ./my_demo_static
+          printf "\033[1;35m  C++ binary with statically linked libraries\033[0m\n"
+          ./my_cxx_demo_static
           echo "::endgroup::"
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -191,7 +191,14 @@ jobs:
           cmake --build .
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Executing example\n"
+          printf "\033[1;35m  C binary with shared libraries\033[0m\n"
           LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_demo
+          printf "\033[1;35m  C++ binary with shared libraries\033[0m\n"
+          LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_cxx_demo
+          printf "\033[1;35m  C binary with statically linked libraries\033[0m\n"
+          ./my_demo_static
+          printf "\033[1;35m  C++ binary with statically linked libraries\033[0m\n"
+          ./my_cxx_demo_static
           echo "::endgroup::"
 
 
@@ -310,7 +317,14 @@ jobs:
           cmake --build .
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Executing example\n"
+          printf "\033[1;35m  C binary with shared libraries\033[0m\n"
           ./my_demo
+          printf "\033[1;35m  C++ binary with shared libraries\033[0m\n"
+          ./my_cxx_demo
+          printf "\033[1;35m  C binary with statically linked libraries\033[0m\n"
+          ./my_demo_static
+          printf "\033[1;35m  C++ binary with statically linked libraries\033[0m\n"
+          ./my_cxx_demo_static
           echo "::endgroup::"
 
 
@@ -468,8 +482,20 @@ jobs:
           cmake --build .
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Executing example\n"
+          printf "\033[1;35m  C binary with shared libraries\033[0m\n"
           PATH="${GITHUB_WORKSPACE}/bin:${PATH}" \
             ./my_demo
+          printf "\033[1;35m  C++ binary with shared libraries\033[0m\n"
+          PATH="${GITHUB_WORKSPACE}/bin:${PATH}" \
+            ./my_cxx_demo
+          # We don't build a static version of GraphBLAS in CI.
+          # So we need to prepare the environment also for the following tests.
+          printf "\033[1;35m  C binary with statically linked libraries\033[0m\n"
+          PATH="${GITHUB_WORKSPACE}/bin:${PATH}" \
+            ./my_demo_static
+          printf "\033[1;35m  C++ binary with statically linked libraries\033[0m\n"
+          PATH="${GITHUB_WORKSPACE}/bin:${PATH}" \
+            ./my_cxx_demo_static
           echo "::endgroup::"
 
 
@@ -664,5 +690,19 @@ jobs:
           cmake --build . --config Release
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Executing example\n"
-          PATH="${GITHUB_WORKSPACE}/bin;${GITHUB_WORKSPACE}/dependencies/bin;${PATH}" ./Release/my_demo
+          printf "\033[1;35m  C binary with shared libraries\033[0m\n"
+          PATH="${GITHUB_WORKSPACE}/bin;${GITHUB_WORKSPACE}/dependencies/bin;${PATH}" \
+            ./Release/my_demo
+          printf "\033[1;35m  C++ binary with shared libraries\033[0m\n"
+          PATH="${GITHUB_WORKSPACE}/bin;${GITHUB_WORKSPACE}/dependencies/bin;${PATH}" \
+            ./Release/my_cxx_demo
+          # We don't build a static version of GraphBLAS in CI.
+          # So we need to prepare the environment also for the following tests.
+          # Additionally, gmp, mpfr and BLAS are always shared libraries.
+          printf "\033[1;35m  C binary with statically linked libraries\033[0m\n"
+          PATH="${GITHUB_WORKSPACE}/bin;${GITHUB_WORKSPACE}/dependencies/bin;${PATH}" \
+            ./Release/my_demo_static
+          printf "\033[1;35m  C++ binary with statically linked libraries\033[0m\n"
+          PATH="${GITHUB_WORKSPACE}/bin;${GITHUB_WORKSPACE}/dependencies/bin;${PATH}" \
+            ./Release/my_cxx_demo_static
           echo "::endgroup::"

--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -170,7 +170,14 @@ jobs:
           cmake --build .
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Executing example\n"
+          printf "\033[1;35m  C binary with shared libraries\033[0m\n"
           LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_demo
+          printf "\033[1;35m  C++ binary with shared libraries\033[0m\n"
+          LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_cxx_demo
+          printf "\033[1;35m  C binary with statically linked libraries\033[0m\n"
+          ./my_demo_static
+          printf "\033[1;35m  C++ binary with statically linked libraries\033[0m\n"
+          ./my_cxx_demo_static
           echo "::endgroup::"
 
 
@@ -349,5 +356,19 @@ jobs:
           cmake --build . --config Release
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Executing example\n"
-          PATH="${GITHUB_WORKSPACE}/bin;${GITHUB_WORKSPACE}/dependencies/bin;${PATH}" ./Release/my_demo
+          printf "\033[1;35m  C binary with shared libraries\033[0m\n"
+          PATH="${GITHUB_WORKSPACE}/bin;${GITHUB_WORKSPACE}/dependencies/bin;${PATH}" \
+            ./Release/my_demo
+          printf "\033[1;35m  C++ binary with shared libraries\033[0m\n"
+          PATH="${GITHUB_WORKSPACE}/bin;${GITHUB_WORKSPACE}/dependencies/bin;${PATH}" \
+            ./Release/my_cxx_demo
+          # We don't build a static version of GraphBLAS in CI.
+          # So we need to prepare the environment also for the following tests.
+          # Additionally, gmp, mpfr and BLAS are always shared libraries.
+          printf "\033[1;35m  C binary with statically linked libraries\033[0m\n"
+          PATH="${GITHUB_WORKSPACE}/bin;${GITHUB_WORKSPACE}/dependencies/bin;${PATH}" \
+            ./Release/my_demo_static
+          printf "\033[1;35m  C++ binary with statically linked libraries\033[0m\n"
+          PATH="${GITHUB_WORKSPACE}/bin;${GITHUB_WORKSPACE}/dependencies/bin;${PATH}" \
+            ./Release/my_cxx_demo_static
           echo "::endgroup::"

--- a/Example/CMakeLists.txt
+++ b/Example/CMakeLists.txt
@@ -463,3 +463,9 @@ target_link_libraries ( my_demo PUBLIC my )
 
 add_executable ( my_cxx_demo "Demo/my_demo.c" )
 target_link_libraries ( my_cxx_demo PUBLIC my_cxx )
+
+add_executable ( my_demo_static "Demo/my_demo.c" )
+target_link_libraries ( my_demo_static PUBLIC my_static )
+
+add_executable ( my_cxx_demo_static "Demo/my_demo.c" )
+target_link_libraries ( my_cxx_demo_static PUBLIC my_cxx_static )

--- a/SPQR/GPUQREngine/CMakeLists.txt
+++ b/SPQR/GPUQREngine/CMakeLists.txt
@@ -37,6 +37,8 @@ project ( gpuqrengine
 set ( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
     ${PROJECT_SOURCE_DIR}/../../SuiteSparse_config/cmake_modules )
 
+option ( ENABLE_CUDA "Enable CUDA acceleration" ON )
+
 include ( SuiteSparsePolicy )
 
 #-------------------------------------------------------------------------------
@@ -96,8 +98,11 @@ target_include_directories ( GPUQREngine PRIVATE
     "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>"
     "$<TARGET_PROPERTY:GPURuntime,INTERFACE_INCLUDE_DIRECTORIES>" )
 
-set_target_properties ( GPUQREngine PROPERTIES POSITION_INDEPENDENT_CODE ON )
-set_target_properties ( GPUQREngine PROPERTIES CUDA_SEPARABLE_COMPILATION ON )
+set_target_properties ( GPUQREngine PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    CUDA_SEPARABLE_COMPILATION ON
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON
+    CUDA_RUNTIME_LIBRARY Static )
 target_link_libraries ( GPUQREngine PRIVATE
     CUDA::nvrtc CUDA::cudart_static CUDA::nvToolsExt CUDA::cublas )
 target_compile_definitions ( GPUQREngine PRIVATE "SUITESPARSE_CUDA" )
@@ -128,13 +133,14 @@ if ( NOT NSTATIC )
     target_include_directories ( GPUQREngine_static PRIVATE
         ${CUDAToolkit_INCLUDE_DIRS}
         ${GPUQRENGINE_INCLUDES}
-        "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
+        $<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:GPURuntime,INTERFACE_INCLUDE_DIRECTORIES> )
 
-    target_include_directories ( GPUQREngine_static PRIVATE
-        "$<TARGET_PROPERTY:GPURuntime,INTERFACE_INCLUDE_DIRECTORIES>" )
-
-    set_target_properties ( GPUQREngine_static PROPERTIES CUDA_SEPARABLE_COMPILATION ON )
-    set_target_properties ( GPUQREngine_static PROPERTIES POSITION_INDEPENDENT_CODE ON )
+    set_target_properties ( GPUQREngine_static PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        CUDA_SEPARABLE_COMPILATION ON
+        CUDA_RESOLVE_DEVICE_SYMBOLS ON
+        CUDA_RUNTIME_LIBRARY Static )
     target_link_libraries ( GPUQREngine_static PUBLIC
         CUDA::nvrtc CUDA::cudart_static CUDA::nvToolsExt CUDA::cublas )
     target_compile_definitions ( GPUQREngine_static PRIVATE "SUITESPARSE_CUDA" )

--- a/SPQR/GPURuntime/CMakeLists.txt
+++ b/SPQR/GPURuntime/CMakeLists.txt
@@ -51,10 +51,6 @@ configure_file ( "Config/SuiteSparse_GPURuntime.hpp.in"
 
 #-------------------------------------------------------------------------------
 
-set ( CMAKE_CUDA_FLAGS "-cudart=static -lineinfo" )
-message ( STATUS "C++ flags for CUDA:  ${CMAKE_CXX_FLAGS}" )
-message ( STATUS "nvcc flags for CUDA: ${CMAKE_CUDA_FLAGS}" )
-
 file ( GLOB SUITESPARSE_GPURUNTIME_SOURCES "Source/*.cpp" )
 
 set ( SUITESPARSE_GPURUNTIME_INCLUDES Include )
@@ -81,8 +77,10 @@ target_include_directories ( GPURuntime PRIVATE
     ${SUITESPARSE_GPURUNTIME_INCLUDES}
     $<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES> )
 
-set_target_properties ( GPURuntime PROPERTIES POSITION_INDEPENDENT_CODE ON )
-set_target_properties ( GPURuntime PROPERTIES CUDA_SEPARABLE_COMPILATION ON )
+set_target_properties ( GPURuntime PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    CUDA_SEPARABLE_COMPILATION ON
+    CUDA_RUNTIME_LIBRARY Static )
 target_link_libraries ( GPURuntime PRIVATE
     CUDA::nvrtc CUDA::cudart_static CUDA::nvToolsExt CUDA::cublas )
 target_compile_definitions ( GPURuntime PRIVATE "SUITESPARSE_CUDA" )
@@ -115,8 +113,10 @@ if ( NOT NSTATIC )
         ${SUITESPARSE_GPURUNTIME_INCLUDES}
         $<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES> )
 
-    set_target_properties ( GPURuntime_static PROPERTIES CUDA_SEPARABLE_COMPILATION ON )
-    set_target_properties ( GPURuntime_static PROPERTIES POSITION_INDEPENDENT_CODE ON )
+    set_target_properties ( GPURuntime_static PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        CUDA_SEPARABLE_COMPILATION ON
+        CUDA_RUNTIME_LIBRARY Static )
     target_link_libraries ( GPURuntime_static PUBLIC
         CUDA::nvrtc CUDA::cudart_static CUDA::nvToolsExt CUDA::cublas )
     target_compile_definitions ( GPURuntime_static PRIVATE "SUITESPARSE_CUDA" )


### PR DESCRIPTION
Statically linking requires that transitional dependencies are correctly described by the CMake targets.

Link executables in the example that are statically linked to the SuiteSparse libraries, and run them in the CI to check that.

That's not an extensive test. (Theoretically, we'd need to check if linking any combination of libraries works correctly.) But it's better than nothing.

This also revealed an issue when trying to link to a static library that was built with nvcc:
```
  [ 87%] Linking CXX executable my_demo_static
  /usr/bin/ld: /home/runner/work/SuiteSparse/SuiteSparse/lib/libgpuqrengine.a(GPUQREngine_UberKernel.cu.o): in function `__sti____cudaRegisterAll()':
  tmpxft_0000835f_00000000-6_GPUQREngine_UberKernel.compute_80.cudafe1.cpp:(.text.startup+0x21): undefined reference to `__cudaRegisterLinkedBinary_1763c3b7_25_GPUQREngine_UberKernel_cu_4549ffb9'
  collect2: error: ld returned 1 exit status
```

I think the relevant change was setting [CUDA_RESOLVE_DEVICE_SYMBOLS](https://cmake.org/cmake/help/latest/prop_tgt/CUDA_RESOLVE_DEVICE_SYMBOLS.html) to `ON`.
