### PR TITLE
ParU: Use sequential factorization on Windows with GCC unconditionally

### DIFF
--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -162,6 +162,19 @@ if ( NOT NSTATIC )
 endif ( )
 
 #-------------------------------------------------------------------------------
+# additional definitions
+#-------------------------------------------------------------------------------
+
+if ( WIN32 AND CMAKE_C_COMPILER_ID STREQUAL "GNU" )
+    # Some parallelization levels don't work correctly with GCC on Windows
+    # (because of emuTLS?). Omit them.
+    target_compile_definitions (ParU PRIVATE PARU_GCC_WINDOWS )
+    if ( NOT NSTATIC )
+        target_compile_definitions (ParU_static PRIVATE PARU_GCC_WINDOWS )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
 # add the library dependencies
 #-------------------------------------------------------------------------------
 

--- a/ParU/Source/paru_factorize.cpp
+++ b/ParU/Source/paru_factorize.cpp
@@ -341,6 +341,9 @@ ParU_Ret ParU_Factorize(cholmod_sparse *A, ParU_Symbolic *Sym,
     // execute the task tree
     //--------------------------------------------------------------------------
 
+#if ! defined ( PARU_GCC_WINDOWS )
+    // The parallel factorization gets stuck intermittently on Windows with GCC.
+    // Use the sequential factorization unconditionally in that case.
     if ((int64_t)task_Q.size() * 2 > Control->paru_max_threads)
     {
         printf ("Parallel:\n") ;    // FIXME
@@ -433,6 +436,7 @@ ParU_Ret ParU_Factorize(cholmod_sparse *A, ParU_Symbolic *Sym,
         }
     }
     else
+#endif
     {
         PRLEVEL(1, ("Sequential\n"));
         Work->naft = 1;


### PR DESCRIPTION
GCC with emuTLS on Windows might have trouble with shared linking. See #474.

I don't know if emuTLS is the actual reason why the demo gets stuck intermittently on the MINGW* runners. But this change is probably worth a try.
