### PR TITLE
GraphBLAS: Fix include directory of static library in build tree

### DIFF
--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -37,7 +37,7 @@ set ( PROJECT_VERSION "${GraphBLAS_VERSION_MAJOR}.${GraphBLAS_VERSION_MINOR}.${G
 
 # GraphBLAS takes a long time to build, so do not build the static library
 # by default
-set ( NSTATIC_DEFAULT_ON true )
+set ( NSTATIC_DEFAULT_ON ON )
 
 # CUDA is under development for now, and not deployed in production:
   set ( ENABLE_CUDA false )
@@ -292,7 +292,7 @@ if ( NOT NSTATIC )
     endif ( )
 
     target_include_directories ( GraphBLAS_static
-        INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 
     if ( SUITESPARSE_CUDA )


### PR DESCRIPTION
This is only an issue when trying to link to the GraphBLAS_static CMake target before it is installed. No functional change for that target after it is installed.

I missed that part in e1c7e4ea0bc651c8136cc3a71fd8228bccb72644. Sorry for that.

This fixes the issue discovered in #500. For a test, I switched building the static libraries of GraphBLAS ON in CI. And the build succeeded.