### PR TITLE
LAGraph: workaround for strange handling of integer constant in MSVC

### DIFF
--- a/LAGraph/src/test/test_minmax.c
+++ b/LAGraph/src/test/test_minmax.c
@@ -80,7 +80,7 @@ const matrix_info files [ ] =
     {                  1,                  1, "matrix_fp32_structure.mtx" } ,
     {          -INFINITY,           INFINITY, "matrix_fp64.mtx" } ,
     {             -32768,              32767, "matrix_int16.mtx" } ,
-    {        -2147483648,         2147483647, "matrix_int32.mtx" } ,
+    {      -2147483648.0,         2147483647, "matrix_int32.mtx" } ,
     {               -128,                127, "matrix_int8.mtx" } ,
     {                  0,              65535, "matrix_uint16.mtx" } ,
     {                  0,         4294967295, "matrix_uint32.mtx" } ,

--- a/LAGraph/src/test/test_minmax.c
+++ b/LAGraph/src/test/test_minmax.c
@@ -228,6 +228,8 @@ void test_minmax (void)
             // failure on MSVC, OpenMP
             // https://github.com/DrTimothyAldenDavis/SuiteSparse/actions/runs/6763376325/job/18380420493?pr=503
             printf ("Test failure, k: %d name: %s\n", k, aname) ;
+            printf ("emin1: %30.20g\n", emin1) ;
+            printf ("emin2: %30.20g\n", emin2) ;
             OK (LAGraph_Matrix_Print (G->A, 5, stdout, msg)) ;
         }
         TEST_CHECK (emin1 == emin2) ;

--- a/LAGraph/src/test/test_minmax.c
+++ b/LAGraph/src/test/test_minmax.c
@@ -212,6 +212,10 @@ void test_minmax (void)
         double emin2 = 0 ;
         double emax2 = 0 ;
 
+        printf ("min/max as GrB_Scalars:\n") ;
+        GxB_print (G->emin, 3) ;
+        GxB_print (G->emax, 3) ;
+
         int result ;
         result = GrB_Scalar_extractElement_FP64 (&emin2, G->emin) ;
         printf ("min: %g %g err %g\n", emin1, emin2, emin1 - emin2) ;
@@ -231,6 +235,15 @@ void test_minmax (void)
             printf ("emin1: %30.20g\n", emin1) ;
             printf ("emin2: %30.20g\n", emin2) ;
             OK (LAGraph_Matrix_Print (G->A, 5, stdout, msg)) ;
+
+            // extract as int64:
+            int64_t emin2_int64 = 0 ;
+            int64_t emax2_int64 = 0 ;
+            GrB_Scalar_extractElement_INT64 (&emin2_int64, G->emin) ;
+            GrB_Scalar_extractElement_INT64 (&emax2_int64, G->emax) ;
+            printf ("emin2 int64: %" PRId64 "\n", emin2_int64) ;
+            printf ("emax2 int64: %" PRId64 "\n", emax2_int64) ;
+
         }
         TEST_CHECK (emin1 == emin2) ;
 


### PR DESCRIPTION
MSVC doesn't handle typecasting of the literal INT32_MIN (-2147483648) to double, in a list of expected test outputs.  The value becomes +2.147...e9.  The value is fine if changed to -2147483648.0 instead, so it's treated as a double precision value.