### PR TITLE
CI (Alpine): Use reference BLAS and LAPACK.

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -67,7 +67,7 @@ jobs:
             m4
             gmp-dev
             mpfr-dev
-            openblas-dev
+            lapack-dev
             valgrind
 
       - name: prepare ccache
@@ -117,7 +117,7 @@ jobs:
                   -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
                   -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
                   -DCMAKE_Fortran_COMPILER_LAUNCHER="ccache" \
-                  -DBLA_VENDOR="OpenBLAS" \
+                  -DBLA_VENDOR="Generic" \
                   -DCOMPACT=ON \
                   ..
             echo "::endgroup::"
@@ -167,7 +167,7 @@ jobs:
           printf "::group::\033[0;32m==>\033[0m Configuring example\n"
           cmake \
             -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/lib/cmake" \
-            -DBLA_VENDOR="OpenBLAS" \
+            -DBLA_VENDOR="Generic" \
             ..
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Building example\n"


### PR DESCRIPTION
Some SuiteSparse libraries rely heavily on OpenMP. But the version of OpenBLAS that is distributed by Alpine Linux is built without OpenMP. This could lead to deadlocks (and OpenBLAS is very verbose about that risk):
> OpenBLAS Warning : Detect OpenMP Loop and this application may hang. Please rebuild the library with USE_OPENMP=1 option.

It looks like that happened in CI at least once: 
https://github.com/DrTimothyAldenDavis/SuiteSparse/actions/runs/6774245825/job/18410892588#step:8:4207
```
  ( cd build && [ -f paru_demo ] && ./paru_demo < ../Matrix/xenon1.mtx || true )
  ================= ParU 1.0.0 ================================== Dec 20, 2022
  OpenBLAS Warning : Detect OpenMP Loop and this application may hang. Please rebuild the library with USE_OPENMP=1 option.
  OpenBLAS Warning : Detect OpenMP Loop and this application may hang. Please rebuild the library with USE_OPENMP=1 option.
  OpenBLAS Warning : Detect OpenMP Loop and this application may hang. Please rebuild the library with USE_OPENMP=1 option.
  OpenBLAS Warning : Detect OpenMP Loop and this application may hang. Please rebuild the library with USE_OPENMP=1 option.
  OpenBLAS Warning : Detect OpenMP Loop and this application may hang. Please rebuild the library with USE_OPENMP=1 option.
  OpenBLAS Warning : Detect OpenMP Loop and this application may hang. Please rebuild the library with USE_OPENMP=1 option.
  OpenBLAS Warning : Detect OpenMP Loop and this application may hang. Please rebuild the library with USE_OPENMP=1 option.
  Error: The action has timed out.
```


Use the reference implementations of the BLAS and LAPACK libraries instead (which might be slower than OpenBLAS but safer on that distribution).
