### PR TITLE
UMFPACK: Avoid non-POSIX flags for `diff` in `make demos` target

### DIFF
--- a/UMFPACK/Makefile
+++ b/UMFPACK/Makefile
@@ -53,10 +53,10 @@ all: library
 demos: library
 	( cd build && cmake $(CMAKE_OPTIONS) -DDEMO=1 .. && cmake --build . --config Release -j${JOBS} )
 	( cd build && ./umfpack_simple )
-	- ( cd build && ./umfpack_di_demo > umfpack_di_demo.out && diff --strip-trailing-cr ../Demo/umfpack_di_demo.out umfpack_di_demo.out )
-	- ( cd build && ./umfpack_dl_demo > umfpack_dl_demo.out && diff --strip-trailing-cr ../Demo/umfpack_dl_demo.out umfpack_dl_demo.out )
-	- ( cd build && ./umfpack_zi_demo > umfpack_zi_demo.out && diff --strip-trailing-cr ../Demo/umfpack_zi_demo.out umfpack_zi_demo.out )
-	- ( cd build && ./umfpack_zl_demo > umfpack_zl_demo.out && diff --strip-trailing-cr ../Demo/umfpack_zl_demo.out umfpack_zl_demo.out )
+	- ( cd build && ./umfpack_di_demo > umfpack_di_demo.out && ( command -v d2u && d2u umfpack_di_demo.out || true ) && diff -u umfpack_di_demo.out ../Demo/umfpack_di_demo.out )
+	- ( cd build && ./umfpack_dl_demo > umfpack_dl_demo.out && ( command -v d2u && d2u umfpack_dl_demo.out || true ) && diff -u umfpack_dl_demo.out ../Demo/umfpack_dl_demo.out )
+	- ( cd build && ./umfpack_zi_demo > umfpack_zi_demo.out && ( command -v d2u && d2u umfpack_zi_demo.out || true ) && diff -u umfpack_zi_demo.out ../Demo/umfpack_zi_demo.out )
+	- ( cd build && ./umfpack_zl_demo > umfpack_zl_demo.out && ( command -v d2u && d2u umfpack_zl_demo.out || true ) && diff -u umfpack_zl_demo.out ../Demo/umfpack_zl_demo.out )
 
 # demos requiring a Fortran compiler
 fdemos: demos
@@ -82,14 +82,14 @@ fdemos: demos
 	( cd build && ./readhb_nozeros < ../Demo/HB/arc130.rua > tmp_A          )
 	( cd build && ./readhb_size    < ../Demo/HB/arc130.rua > tmp_Asize      )
 	( cd build && ./umf4 a 1e-6                                             )
-	( cd build && ./umf4hb         < ../Demo/HB/west0067.rua > umf4hb.out   )
-	- diff --strip-trailing-cr ./Demo/umf4hb.out  ./build/umf4hb.out 
-	( cd build && ./umf4hb64       < ../Demo/HB/west0067.rua > umf4hb64.out )
-	- diff --strip-trailing-cr ./Demo/umf4hb64.out  ./build/umf4hb64.out 
-	( cd build && ./umf4zhb        < ../Demo/HB/qc324.cua > umf4zhb.out     )
-	- diff --strip-trailing-cr ./Demo/umf4zhb.out ./build/umf4zhb.out
-	( cd build && ./umf4zhb64      < ../Demo/HB/qc324.cua > umf4zhb64.out   )
-	- diff --strip-trailing-cr ./Demo/umf4zhb64.out ./build/umf4zhb64.out
+	( cd build && ./umf4hb < ../Demo/HB/west0067.rua > umf4hb.out && ( command -v d2u && d2u umf4hb.out || true ) )
+	- diff -u ./build/umf4hb.out ./Demo/umf4hb.out
+	( cd build && ./umf4hb64 < ../Demo/HB/west0067.rua > umf4hb64.out && ( command -v d2u && d2u umf4hb64.out || true ) )
+	- diff -u ./build/umf4hb64.out ./Demo/umf4hb64.out
+	( cd build && ./umf4zhb < ../Demo/HB/qc324.cua > umf4zhb.out && ( command -v d2u && d2u umf4zhb.out || true ) )
+	- diff -u ./build/umf4zhb.out ./Demo/umf4zhb.out
+	( cd build && ./umf4zhb64 < ../Demo/HB/qc324.cua > umf4zhb64.out && ( command -v d2u && d2u umf4zhb64.out || true ) )
+	- diff -u ./build/umf4zhb64.out ./Demo/umf4zhb64.out
 
 cov:
 	( cd Tcov && $(MAKE) )


### PR DESCRIPTION
The flag `--strip-trailing-cr` is a non-standard flag to `diff` and isn't supported by that application on Alpine Linux. Try to use commands that work across POSIX-compatible platforms.

I also opted to use `diff -u` because I'm more used to reading git diffs. I hope it's ok to change the format of the output.