### PR TITLE
GraphBLAS: Support jitifyer without CMake for MinGW

### DIFF
--- a/GraphBLAS/Config/GB_config.h
+++ b/GraphBLAS/Config/GB_config.h
@@ -15,7 +15,7 @@
 
 // GB_C_COMPILER: the C compiler used to compile GraphBLAS:
 #ifndef GB_C_COMPILER
-#define GB_C_COMPILER   "/usr/bin/cc"
+#define GB_C_COMPILER   "/mingw64/bin/cc.exe"
 #endif
 
 // GB_C_FLAGS: the C compiler flags used to compile GraphBLAS.  Used
@@ -36,10 +36,10 @@
 
 // GB_LIB_SUFFIX: library suffix (.so for Linux/Unix, .dylib for Mac, etc):
 #ifndef GB_LIB_SUFFIX
-#define GB_LIB_SUFFIX   ".so"
+#define GB_LIB_SUFFIX   ".dll"
 #endif
 
-// GB_OBJ_SUFFIX: object suffix (.o for Linux/Unix/Mac, .obj for Windows):
+// GB_OBJ_SUFFIX: object suffix (.o for Linux/Unix/Mac/MinGW, .obj for MSVC):
 #ifndef GB_OBJ_SUFFIX
 #define GB_OBJ_SUFFIX   ".o"
 #endif
@@ -57,12 +57,12 @@
 
 // GB_C_LIBRARIES: libraries to link with when using direct compile/link:
 #ifndef GB_C_LIBRARIES
-#define GB_C_LIBRARIES  " -lm -ldl /usr/lib/gcc/x86_64-linux-gnu/9/libgomp.so /usr/lib/x86_64-linux-gnu/libpthread.so"
+#define GB_C_LIBRARIES  " -lgomp -lmingwthrd -lmingwthrd"
 #endif
 
 // GB_CMAKE_LIBRARIES: libraries to link with when using cmake
 #ifndef GB_CMAKE_LIBRARIES
-#define GB_CMAKE_LIBRARIES  "m;dl;/usr/lib/gcc/x86_64-linux-gnu/9/libgomp.so;/usr/lib/x86_64-linux-gnu/libpthread.so"
+#define GB_CMAKE_LIBRARIES  "C:/msys64/mingw64/lib/libgomp.dll.a;C:/msys64/mingw64/lib/libmingwthrd.a;C:/msys64/mingw64/lib/libmingwthrd.a"
 #endif
 
 #endif

--- a/GraphBLAS/Config/GB_config.h.in
+++ b/GraphBLAS/Config/GB_config.h.in
@@ -39,7 +39,7 @@
 #define GB_LIB_SUFFIX   "@GB_LIB_SUFFIX@"
 #endif
 
-// GB_OBJ_SUFFIX: object suffix (.o for Linux/Unix/Mac, .obj for Windows):
+// GB_OBJ_SUFFIX: object suffix (.o for Linux/Unix/Mac/MinGW, .obj for MSVC):
 #ifndef GB_OBJ_SUFFIX
 #define GB_OBJ_SUFFIX   "@GB_OBJ_SUFFIX@"
 #endif

--- a/GraphBLAS/Source/GB_jitifyer.c
+++ b/GraphBLAS/Source/GB_jitifyer.c
@@ -37,8 +37,8 @@ static int64_t  GB_jit_table_populated = 0 ;
 static size_t   GB_jit_table_allocated = 0 ;
 
 static bool GB_jit_use_cmake =
-    #if GB_WINDOWS
-    true ;      // Windows requires cmake
+    #if defined (_MSC_VER)
+    true ;      // MSVC requires cmake
     #else
     false ;     // otherwise, default is to skip cmake and compile directly
     #endif
@@ -2320,8 +2320,9 @@ void GB_jitifyer_direct_compile (char *kernel_name, uint32_t bucket)
     snprintf (GB_jit_temp, GB_jit_temp_allocated,
 
     // compile:
-    "%s -DGB_JIT_RUNTIME=1 "            // compiler command
-    "%s "                               // C flags
+    "sh -c \""                          // execute with POSIX shell
+    "%s "                               // compiler command
+    "-DGB_JIT_RUNTIME=1 %s "            // C flags
     "-I%s/src "                         // include source directory
     "%s "                               // openmp include directories
     "-o %s/c/%02x/%s%s "                // *.o output file
@@ -2336,8 +2337,8 @@ void GB_jitifyer_direct_compile (char *kernel_name, uint32_t bucket)
     "-o %s/lib/%02x/%s%s%s "            // lib*.so output file
     "%s/c/%02x/%s%s "                   // *.o input file
     "%s "                               // libraries to link with
-    "%s"                                // burble stdout
-    "%s %s ",                           // error log file
+    "%s "                               // burble stdout
+    "%s %s\"",                          // error log file
 
     // compile:
     GB_jit_C_compiler,                  // C compiler


### PR DESCRIPTION
These modifications make the JIT compiler work without CMake for me using MinGW compilers (from MSYS2).
I don't know enough about MSVC. So, I left it at using CMake.

With those changes, I see the following timings for the ctests of LAGraph:
* first run: Total Test time (real) = 170.06 sec
* second run: Total Test time (real) =  17.82 sec

Compared to without the patch:
* first run: Total Test time (real) = 647.04 sec
* second run: Total Test time (real) =  19.04 sec

So, it significantly speeds up the first run. (The difference in the respective second runs is probably "random". Maybe caused by different load or alike.)

I believe this should still work on Linux or macOS without any noticeable difference. But I didn't actually try.

Some of these changes are pretty MSYS2-specific (e.g., fixing relocation issues). So, I'd understand if you prefer not to take it (or only take parts?). In that case, I'd propose a similar patch to MSYS2 that could be applied downstream when building GraphBLAS for distribution.
It would be easier though if MSYS2 wouldn't need to maintain a separate patch.
