### PR TITLE
Replace many C-style casts

### DIFF
--- a/ParU/Source/paru_analyze.cpp
+++ b/ParU/Source/paru_analyze.cpp
@@ -81,7 +81,7 @@ ParU_Ret ParU_Analyze(cholmod_sparse *A, ParU_Symbolic **S_handle,
     double start_time = PARU_OPENMP_GET_WTIME;
 #endif
     ParU_Symbolic *Sym;
-    Sym = (ParU_Symbolic *)paru_alloc(1, sizeof(ParU_Symbolic));
+    Sym = static_cast<ParU_Symbolic*>(paru_alloc(1, sizeof(ParU_Symbolic)));
     if (!Sym)
     {
         return PARU_OUT_OF_MEMORY;
@@ -106,9 +106,9 @@ ParU_Ret ParU_Analyze(cholmod_sparse *A, ParU_Symbolic **S_handle,
         return PARU_INVALID;
     }
 
-    int64_t *Ap = (int64_t *)A->p;
-    int64_t *Ai = (int64_t *)A->i;
-    double *Ax = (double *)A->x;
+    int64_t *Ap = static_cast<int64_t*>(A->p);
+    int64_t *Ai = static_cast<int64_t*>(A->i);
+    double *Ax = static_cast<double*>(A->x);
 
     // Initializaing pointers with NULL; just in case for an early exit
     // not to free an uninitialized space
@@ -483,17 +483,17 @@ ParU_Ret ParU_Analyze(cholmod_sparse *A, ParU_Symbolic **S_handle,
     /* ---------------------------------------------------------------------- */
     /*    Copy the contents of Symbolic in my data structure                  */
     /* ---------------------------------------------------------------------- */
-    SymbolicType *Sym_umf = (SymbolicType *)Symbolic;  // just an alias
+    SymbolicType *Sym_umf = static_cast<SymbolicType*>(Symbolic);  // just an alias
     // temp amalgamation data structure
-    fmap = (int64_t *)paru_alloc((n + 1), sizeof(int64_t));
-    newParent = (int64_t *)paru_alloc((n + 1), sizeof(int64_t));
+    fmap = static_cast<int64_t*>(paru_alloc((n + 1), sizeof(int64_t)));
+    newParent = static_cast<int64_t*>(paru_alloc((n + 1), sizeof(int64_t)));
     if (Sym->strategy == PARU_STRATEGY_SYMMETRIC)
         Diag_map = Sym_umf->Diagonal_map;
     else
         Diag_map = NULL;
 
     if (Diag_map)
-        inv_Diag_map = (int64_t *)paru_alloc(n, sizeof(int64_t));
+        inv_Diag_map = static_cast<int64_t*>(paru_alloc(n, sizeof(int64_t)));
     else
         inv_Diag_map = NULL;
     if (!fmap || !newParent || (!Diag_map != !inv_Diag_map))
@@ -638,10 +638,10 @@ ParU_Ret ParU_Analyze(cholmod_sparse *A, ParU_Symbolic **S_handle,
 
     // Parent size is nf+1 potentially smaller than what UMFPACK allocate
     size_t size = n + 1;
-    Parent = (int64_t *)paru_realloc(nf + 1, sizeof(int64_t), Front_parent, &size);
+    Parent = static_cast<int64_t*>(paru_realloc(nf + 1, sizeof(int64_t), Front_parent, &size));
     Sym->Parent = Parent;
-    ASSERT(size <= (size_t)n + 1);
-    if (size != (size_t)nf + 1)
+    ASSERT(size <= static_cast<size_t>(n) + 1);
+    if (size != static_cast<size_t>(nf) + 1)
     {  // should not happen anyway it is always shrinking
         PRLEVEL(1, ("ParU: out of memory\n"));
         Sym->Parent = NULL;
@@ -656,8 +656,8 @@ ParU_Ret ParU_Analyze(cholmod_sparse *A, ParU_Symbolic **S_handle,
     // like SPQR: Super[f]<= pivotal columns of (f) < Super[f+1]
     if (nf > 0)
     {
-        Super = Sym->Super = (int64_t *)paru_alloc((nf + 1), sizeof(int64_t));
-        Depth = Sym->Depth = (int64_t *)paru_calloc(nf, sizeof(int64_t));
+        Super = Sym->Super = static_cast<int64_t*>(paru_alloc((nf + 1), sizeof(int64_t)));
+        Depth = Sym->Depth = static_cast<int64_t*>(paru_calloc(nf, sizeof(int64_t)));
         if (Super == NULL || Depth == NULL)
         {
             PRLEVEL(1, ("ParU: out of memory\n"));
@@ -758,7 +758,7 @@ ParU_Ret ParU_Analyze(cholmod_sparse *A, ParU_Symbolic **S_handle,
     // newParent size is newF+1 potentially smaller than nf
     if (newF > 0)
         newParent =
-            (int64_t *)paru_realloc(newF + 1, sizeof(int64_t), newParent, &size);
+            static_cast<int64_t*>(paru_realloc(newF + 1, sizeof(int64_t), newParent, &size));
     if (size != (size_t)newF + 1)
     {
         PRLEVEL(1, ("ParU: out of memory\n"));
@@ -781,14 +781,14 @@ ParU_Ret ParU_Analyze(cholmod_sparse *A, ParU_Symbolic **S_handle,
     /* ---------------------------------------------------------------------- */
     /*         Finding the Upper bound of rows and cols                       */
     /* ---------------------------------------------------------------------- */
-    SWType *mySW = (SWType *)SW;
-    int64_t *Front_nrows = (int64_t *)mySW->Front_nrows;
-    int64_t *Front_ncols = (int64_t *)mySW->Front_ncols;
+    SWType *mySW = static_cast<SWType*>(SW);
+    int64_t *Front_nrows = static_cast<int64_t*>(mySW->Front_nrows);
+    int64_t *Front_ncols = static_cast<int64_t*>(mySW->Front_ncols);
 
     if (newNf > 0)
     {
-        Fm = (int64_t *)paru_calloc((newNf + 1), sizeof(int64_t));
-        Cm = (int64_t *)paru_alloc((newNf + 1), sizeof(int64_t));
+        Fm = static_cast<int64_t*>(paru_calloc((newNf + 1), sizeof(int64_t)));
+        Cm = static_cast<int64_t*>(paru_alloc((newNf + 1), sizeof(int64_t)));
         // int64_t *roots = (int64_t *)paru_alloc((num_roots), sizeof(int64_t));
         Sym->Fm = Fm;
         Sym->Cm = Cm;
@@ -1102,16 +1102,16 @@ ParU_Ret ParU_Analyze(cholmod_sparse *A, ParU_Symbolic **S_handle,
 
 #endif
 
-    Ps = (int64_t *)paru_calloc(m - n1, sizeof(int64_t));
+    Ps = static_cast<int64_t*>(paru_calloc(m - n1, sizeof(int64_t)));
     if (cs1 > 0)
     {
-        Sup = Sym->ustons.Sup = (int64_t *)paru_calloc(cs1 + 1, sizeof(int64_t));
-        cSup = (int64_t *)paru_alloc(cs1 + 1, sizeof(int64_t));
+        Sup = Sym->ustons.Sup = static_cast<int64_t*>(paru_calloc(cs1 + 1, sizeof(int64_t)));
+        cSup = static_cast<int64_t*>(paru_alloc(cs1 + 1, sizeof(int64_t)));
     }
     if (rs1 > 0)
     {
-        Slp = Sym->lstons.Slp = (int64_t *)paru_calloc(rs1 + 1, sizeof(int64_t));
-        cSlp = (int64_t *)paru_alloc(rs1 + 1, sizeof(int64_t));
+        Slp = Sym->lstons.Slp = static_cast<int64_t*>(paru_calloc(rs1 + 1, sizeof(int64_t)));
+        cSlp = static_cast<int64_t*>(paru_alloc(rs1 + 1, sizeof(int64_t)));
     }
 
     if (((Slp == NULL || cSlp == NULL) && rs1 != 0) ||
@@ -1403,18 +1403,18 @@ ParU_Ret ParU_Analyze(cholmod_sparse *A, ParU_Symbolic **S_handle,
     Sym->lstons.nnz = slnz;
     if (cs1 > 0)
     {
-        Suj = (int64_t *)paru_alloc(sunz, sizeof(int64_t));
+        Suj = static_cast<int64_t*>(paru_alloc(sunz, sizeof(int64_t)));
     }
     Sym->ustons.Suj = Suj;
 
     if (rs1 > 0)
     {
-        Sli = (int64_t *)paru_alloc(slnz, sizeof(int64_t));
+        Sli = static_cast<int64_t*>(paru_alloc(slnz, sizeof(int64_t)));
     }
     Sym->lstons.Sli = Sli;
 
     // Updating Sj using copy of Sp
-    Sj = (int64_t *)paru_alloc(snz, sizeof(int64_t));
+    Sj = static_cast<int64_t*>(paru_alloc(snz, sizeof(int64_t)));
     Sym->Sj = Sj;
 
     if (Sj == NULL || (cs1 > 0 && Suj == NULL) || (rs1 > 0 && Sli == NULL))
@@ -1569,17 +1569,17 @@ ParU_Ret ParU_Analyze(cholmod_sparse *A, ParU_Symbolic **S_handle,
 
     if (nf > 0)
     {
-        Sym->aParent = aParent = (int64_t *)paru_alloc(ms + nf, sizeof(int64_t));
-        Sym->aChild = aChild = (int64_t *)paru_alloc(ms + nf + 1, sizeof(int64_t));
-        Sym->aChildp = aChildp = (int64_t *)paru_alloc(ms + nf + 2, sizeof(int64_t));
-        Sym->first = first = (int64_t *)paru_alloc(nf + 1, sizeof(int64_t));
-        Sym->row2atree = rM = (int64_t *)paru_alloc(ms, sizeof(int64_t));
-        Sym->super2atree = snM = (int64_t *)paru_alloc(nf, sizeof(int64_t));
+        Sym->aParent = aParent = static_cast<int64_t*>(paru_alloc(ms + nf, sizeof(int64_t)));
+        Sym->aChild = aChild = static_cast<int64_t*>(paru_alloc(ms + nf + 1, sizeof(int64_t)));
+        Sym->aChildp = aChildp = static_cast<int64_t*>(paru_alloc(ms + nf + 2, sizeof(int64_t)));
+        Sym->first = first = static_cast<int64_t*>(paru_alloc(nf + 1, sizeof(int64_t)));
+        Sym->row2atree = rM = static_cast<int64_t*>(paru_alloc(ms, sizeof(int64_t)));
+        Sym->super2atree = snM = static_cast<int64_t*>(paru_alloc(nf, sizeof(int64_t)));
 
         Sym->front_flop_bound = front_flop_bound =
-            (double *)paru_alloc(nf + 1, sizeof(double));
+            static_cast<double*>(paru_alloc(nf + 1, sizeof(double)));
         Sym->stree_flop_bound = stree_flop_bound =
-            (double *)paru_calloc(nf + 1, sizeof(double));
+            static_cast<double*>(paru_calloc(nf + 1, sizeof(double)));
 
         if (aParent == NULL || aChild == NULL || aChildp == NULL ||
             rM == NULL || snM == NULL || first == NULL ||
@@ -1740,11 +1740,11 @@ ParU_Ret ParU_Analyze(cholmod_sparse *A, ParU_Symbolic **S_handle,
     Sym->ntasks = ntasks;
     if (nf > 0)
     {
-        Sym->task_map = task_map = (int64_t *)paru_alloc(ntasks + 1, sizeof(int64_t));
-        Sym->task_parent = task_parent = (int64_t *)paru_alloc(ntasks, sizeof(int64_t));
+        Sym->task_map = task_map = static_cast<int64_t*>(paru_alloc(ntasks + 1, sizeof(int64_t)));
+        Sym->task_parent = task_parent = static_cast<int64_t*>(paru_alloc(ntasks, sizeof(int64_t)));
         Sym->task_num_child = task_num_child =
-            (int64_t *)paru_calloc(ntasks, sizeof(int64_t));
-        Sym->task_depth = task_depth = (int64_t *)paru_calloc(ntasks, sizeof(int64_t));
+            static_cast<int64_t*>(paru_calloc(ntasks, sizeof(int64_t)));
+        Sym->task_depth = task_depth = static_cast<int64_t*>(paru_calloc(ntasks, sizeof(int64_t)));
 
         if (task_map == NULL || task_parent == NULL || task_num_child == NULL ||
             task_depth == NULL)

--- a/ParU/Source/paru_backward.cpp
+++ b/ParU/Source/paru_backward.cpp
@@ -37,7 +37,7 @@ ParU_Ret paru_backward(double *x1, double &resid, double &anorm, double &xnorm,
     }
     PRLEVEL(PR, (" \n"));
 #endif
-    double *b = (double *)paru_calloc(m, sizeof(double));
+    double *b = static_cast<double*>(paru_calloc(m, sizeof(double)));
     if (b == NULL)
     {
         PRLEVEL(1, ("ParU: memory problem inside backward\n"));

--- a/ParU/Source/paru_create_element.cpp
+++ b/ParU/Source/paru_create_element.cpp
@@ -30,7 +30,7 @@ paru_element *paru_create_element(int64_t nrows, int64_t ncols)
     size_t tot_size = sizeof(paru_element) +
                       sizeof(int64_t) * (2 * (nrows + ncols)) +
                       sizeof(double) * nrows * ncols;
-    curEl = (paru_element *)paru_alloc(1, tot_size);
+    curEl = static_cast<paru_element*>(paru_alloc(1, tot_size));
     if (curEl == NULL) return NULL;  // do not do error checking
 
     PRLEVEL(1, (" with size of " LD " in %p\n", tot_size, curEl));

--- a/ParU/Source/paru_gaxpy.cpp
+++ b/ParU/Source/paru_gaxpy.cpp
@@ -23,9 +23,9 @@ int64_t paru_gaxpy(cholmod_sparse *A, const double *x, double *y, double alpha)
     DEBUGLEVEL(0);
 
     if (!A || !x || !y) return (0);
-    int64_t *Ap = (int64_t *)A->p;
-    int64_t *Ai = (int64_t *)A->i;
-    double *Ax = (double *)A->x;
+    int64_t *Ap = static_cast<int64_t*>(A->p);
+    int64_t *Ai = static_cast<int64_t*>(A->i);
+    double *Ax = static_cast<double*>(A->x);
     int64_t n = A->ncol;
 
     for (int64_t j = 0; j < n; j++)

--- a/ParU/Source/paru_init_rowFronts.cpp
+++ b/ParU/Source/paru_init_rowFronts.cpp
@@ -50,7 +50,7 @@ ParU_Ret paru_init_rowFronts(paru_work *Work,
    
     // initializing Numeric
     ParU_Numeric *Num = NULL;
-    Num = (ParU_Numeric *)paru_alloc(1, sizeof(ParU_Numeric));
+    Num = static_cast<ParU_Numeric*>(paru_alloc(1, sizeof(ParU_Numeric)));
     if (Num == NULL)
     {  // out of memory
         PRLEVEL(1, ("ParU: out of memory, Num\n"));
@@ -83,36 +83,36 @@ ParU_Ret paru_init_rowFronts(paru_work *Work,
     if (nf != 0)
     {
         // Memory allocations for Num
-        rowMark = Work->rowMark = (int64_t *)paru_alloc(m + nf + 1, sizeof(int64_t));
-        elRow = Work->elRow = (int64_t *)paru_alloc(m + nf, sizeof(int64_t));
-        elCol = Work->elCol = (int64_t *)paru_alloc(m + nf, sizeof(int64_t));
-        rowSize = Work->rowSize = (int64_t *)paru_alloc(m, sizeof(int64_t));
+        rowMark = Work->rowMark = static_cast<int64_t*>(paru_alloc(m + nf + 1, sizeof(int64_t)));
+        elRow = Work->elRow = static_cast<int64_t*>(paru_alloc(m + nf, sizeof(int64_t)));
+        elCol = Work->elCol = static_cast<int64_t*>(paru_alloc(m + nf, sizeof(int64_t)));
+        rowSize = Work->rowSize = static_cast<int64_t*>(paru_alloc(m, sizeof(int64_t)));
         row_degree_bound = Work->row_degree_bound =
-            (int64_t *)paru_alloc(m, sizeof(int64_t));
+            static_cast<int64_t*>(paru_alloc(m, sizeof(int64_t)));
         RowList = Work->RowList =
-            (paru_tupleList *)paru_calloc(1, m * sizeof(paru_tupleList));
-        Work->lacList = (int64_t *)paru_alloc(m + nf, sizeof(int64_t));
-        Num->frowCount = (int64_t *)paru_alloc(1, nf * sizeof(int64_t));
-        Num->fcolCount = (int64_t *)paru_alloc(1, nf * sizeof(int64_t));
-        Num->frowList = (int64_t **)paru_calloc(1, nf * sizeof(int64_t *));
-        Num->fcolList = (int64_t **)paru_calloc(1, nf * sizeof(int64_t *));
+            static_cast<paru_tupleList*>(paru_calloc(1, m * sizeof(paru_tupleList)));
+        Work->lacList = static_cast<int64_t*>(paru_alloc(m + nf, sizeof(int64_t)));
+        Num->frowCount = static_cast<int64_t*>(paru_alloc(1, nf * sizeof(int64_t)));
+        Num->fcolCount = static_cast<int64_t*>(paru_alloc(1, nf * sizeof(int64_t)));
+        Num->frowList = static_cast<int64_t**>(paru_calloc(1, nf * sizeof(int64_t *)));
+        Num->fcolList = static_cast<int64_t**>(paru_calloc(1, nf * sizeof(int64_t *)));
         Num->partial_Us =  // Initialize with NULL
-            (ParU_Factors *)paru_calloc(1, nf * sizeof(ParU_Factors));
+            static_cast<ParU_Factors*>(paru_calloc(1, nf * sizeof(ParU_Factors)));
         Num->partial_LUs =  // Initialize with NULL
-            (ParU_Factors *)paru_calloc(1, nf * sizeof(ParU_Factors));
+            static_cast<ParU_Factors*>(paru_calloc(1, nf * sizeof(ParU_Factors)));
 
-        Work->time_stamp = (int64_t *)paru_alloc(1, nf * sizeof(int64_t));
-        Work->task_num_child = (int64_t *)paru_alloc(Sym->ntasks, sizeof(int64_t));
-        heapList = Work->heapList = (std::vector<int64_t> **)paru_calloc(
-            1, (m + nf + 1) * sizeof(std::vector<int64_t> *));
+        Work->time_stamp = static_cast<int64_t*>(paru_alloc(1, nf * sizeof(int64_t)));
+        Work->task_num_child = static_cast<int64_t*>(paru_alloc(Sym->ntasks, sizeof(int64_t)));
+        heapList = Work->heapList = static_cast<std::vector<int64_t>**>(paru_calloc(
+            1, (m + nf + 1) * sizeof(std::vector<int64_t> *)));
         elementList = Work->elementList =  // Initialize with NULL
-            (paru_element **)paru_calloc(1,
-                                         (m + nf + 1) * sizeof(paru_element));
+            static_cast<paru_element**>(paru_calloc(1,
+                                         (m + nf + 1) * sizeof(paru_element)));
         if (Sym->strategy == PARU_STRATEGY_SYMMETRIC)
         {
-            Diag_map = Work->Diag_map = (int64_t *)paru_alloc(Sym->n, sizeof(int64_t));
+            Diag_map = Work->Diag_map = static_cast<int64_t*>(paru_alloc(Sym->n, sizeof(int64_t)));
             inv_Diag_map = Work->inv_Diag_map =
-                (int64_t *)paru_alloc(Sym->n, sizeof(int64_t));
+                static_cast<int64_t*>(paru_alloc(Sym->n, sizeof(int64_t)));
 #ifndef NDEBUG
             paru_memset(Diag_map, 0, Sym->n * sizeof(int64_t), Control);
             paru_memset(inv_Diag_map, 0, Sym->n * sizeof(int64_t), Control);
@@ -123,9 +123,9 @@ ParU_Ret paru_init_rowFronts(paru_work *Work,
 
     int64_t snz = Num->snz = Sym->snz;
     double *Sx = NULL;
-    Sx = Num->Sx = (double *)paru_alloc(snz, sizeof(double));
+    Sx = Num->Sx = static_cast<double*>(paru_alloc(snz, sizeof(double)));
     int64_t *cSp = NULL;  // copy of Sp, temporary for making Sx
-    cSp = (int64_t *)paru_alloc(m + 1, sizeof(int64_t));
+    cSp = static_cast<int64_t*>(paru_alloc(m + 1, sizeof(int64_t)));
     double *Sux = NULL;
     int64_t *cSup = NULL;  // copy of Sup temporary for making Sux
     int64_t cs1 = Sym->cs1;
@@ -134,8 +134,8 @@ ParU_Ret paru_init_rowFronts(paru_work *Work,
     if (cs1 > 0)
     {
         sunz = Sym->ustons.nnz;
-        Sux = (double *)paru_alloc(sunz, sizeof(double));
-        cSup = (int64_t *)paru_alloc(cs1 + 1, sizeof(int64_t));
+        Sux = static_cast<double*>(paru_alloc(sunz, sizeof(double)));
+        cSup = static_cast<int64_t*>(paru_alloc(cs1 + 1, sizeof(int64_t)));
     }
     Num->Sux = Sux;
     double *Slx = NULL;
@@ -144,15 +144,15 @@ ParU_Ret paru_init_rowFronts(paru_work *Work,
     if (rs1 > 0)
     {
         slnz = Sym->lstons.nnz;
-        Slx = (double *)paru_alloc(slnz, sizeof(double));
-        cSlp = (int64_t *)paru_alloc(rs1 + 1, sizeof(int64_t));
+        Slx = static_cast<double*>(paru_alloc(slnz, sizeof(double)));
+        cSlp = static_cast<int64_t*>(paru_alloc(rs1 + 1, sizeof(int64_t)));
     }
     Num->sunz = sunz;
     Num->slnz = slnz;
     Num->Slx = Slx;
     double *Rs = NULL;
     int64_t scale = Control->scale;  // if 1 the S will be scaled by max_row
-    if (scale == 1) Rs = (double *)paru_calloc(Sym->m, sizeof(double));
+    if (scale == 1) Rs = static_cast<double*>(paru_calloc(Sym->m, sizeof(double)));
     Num->Rs = Rs;
     if ((nf != 0 &&
          (rowMark == NULL || elRow == NULL || elCol == NULL ||
@@ -197,9 +197,9 @@ ParU_Ret paru_init_rowFronts(paru_work *Work,
     }
 
     //////////////////Initializing numerics Sx, Sux and Slx //////////////////{
-    int64_t *Ap = (int64_t *)A->p;
-    int64_t *Ai = (int64_t *)A->i;
-    double *Ax = (double *)A->x;
+    int64_t *Ap = static_cast<int64_t*>(A->p);
+    int64_t *Ai = static_cast<int64_t*>(A->i);
+    double *Ax = static_cast<double*>(A->x);
     int64_t *Sp = Sym->Sp;
     int64_t *Slp = NULL;
     int64_t *Sup = NULL;
@@ -296,7 +296,7 @@ ParU_Ret paru_init_rowFronts(paru_work *Work,
             int64_t srow = newrow - n1;
             int64_t scol = newcol - n1;
             if (srow >= 0 && scol >= 0)
-            {  // it is insdie S otherwise it is part of singleton
+            {  // it is inside S otherwise it is part of singleton
                 Sx[cSp[srow]++] = (Rs == NULL) ? Ax[p] : Ax[p] / Rs[oldrow];
             }
             else if (srow < 0 && scol >= 0)
@@ -456,8 +456,8 @@ ParU_Ret paru_init_rowFronts(paru_work *Work,
                 int64_t slackRow = 2;
 
                 // Allocating Rowlist and updating its tuples
-                RowList[row].list = (paru_tuple *)paru_alloc(
-                    slackRow * nrows, sizeof(paru_tuple));
+                RowList[row].list = static_cast<paru_tuple*>(paru_alloc(
+                    slackRow * nrows, sizeof(paru_tuple)));
                 if (RowList[row].list == NULL)
                 {  // out of memory
                     PRLEVEL(1, ("ParU: out of memory, RowList[row].list \n"));

--- a/ParU/Source/paru_lsolve.cpp
+++ b/ParU/Source/paru_lsolve.cpp
@@ -102,7 +102,7 @@ ParU_Ret ParU_Lsolve(ParU_Symbolic *Sym, ParU_Numeric *Num, double *x, ParU_Cont
     BLAS_set_num_threads(control_nthreads (Control)) ;
 
     // gather scatter space for dgemm
-    double *work = (double *)paru_alloc((Num->max_row_count), sizeof(double));
+    double *work = static_cast<double*>(paru_alloc((Num->max_row_count), sizeof(double)));
     if (work == NULL)
     {
         PRLEVEL(1, ("ParU: out of memory lsolve\n"));
@@ -282,7 +282,7 @@ ParU_Ret ParU_Lsolve( ParU_Symbolic *Sym, ParU_Numeric *Num,
 
     // gather scatter space for dgemm
     double *work =
-        (double *)paru_alloc((Num->max_row_count * nrhs), sizeof(double));
+        static_cast<double*>(paru_alloc((Num->max_row_count * nrhs), sizeof(double)));
     if (work == NULL)
     {
         PRLEVEL(1, ("ParU: out of memory lsolve\n"));

--- a/ParU/Source/paru_memcpy.cpp
+++ b/ParU/Source/paru_memcpy.cpp
@@ -41,8 +41,8 @@ void paru_memcpy(void *destination, const void *source,
             {
                 size_t chunk = MIN(num - start, mem_chunk);
                 // void* arithmetic is illegal it is why I am using this
-                unsigned char *pdest = (unsigned char *)destination + start;
-                const unsigned char *psrc = (unsigned char *)source + start;
+                unsigned char *pdest = static_cast<unsigned char*>(destination) + start;
+                const unsigned char *psrc = static_cast<const unsigned char*>(source) + start;
                 memcpy(pdest, psrc, chunk);
             }
         }

--- a/ParU/Source/paru_memset.cpp
+++ b/ParU/Source/paru_memset.cpp
@@ -15,7 +15,7 @@
 void paru_memset(void *ptr, int64_t value, size_t num, ParU_Control *Control)
 {
     int nthreads = control_nthreads (Control) ;
-    size_t mem_chunk = (size_t) control_mem_chunk (Control) ;
+    size_t mem_chunk = static_cast<size_t>(control_mem_chunk(Control));
 
     if (num < mem_chunk)
     {  // single task memse
@@ -24,24 +24,23 @@ void paru_memset(void *ptr, int64_t value, size_t num, ParU_Control *Control)
     else
     {  // multiple task memset
         size_t nchunks = 1 + (num / mem_chunk);
-        if (((size_t) nthreads) > nchunks)
+        if (static_cast<size_t>(nthreads) > nchunks)
         { 
-            nthreads = (int) nchunks ;
+            nthreads = static_cast<int>(nchunks);
         }
 
         int64_t k;
         #pragma omp parallel for num_threads(nthreads) schedule(dynamic,1)
-        for (k = 0; k < (int64_t)nchunks; k++)
+        for (k = 0; k < static_cast<int64_t>(nchunks); k++)
         {
             size_t start = k * mem_chunk;
             if (start < num)
             {
                 size_t chunk = MIN(num - start, mem_chunk);
                 // void* arithmetic is illegal it is why I am using this
-                unsigned char *ptr_chunk = (unsigned char *)ptr + start;
+                unsigned char *ptr_chunk = static_cast<unsigned char*>(ptr) + start;
                 memset(ptr_chunk, value, chunk);
             }
         }
     }
 }
-

--- a/ParU/Source/paru_norms.cpp
+++ b/ParU/Source/paru_norms.cpp
@@ -18,8 +18,8 @@ double paru_spm_1norm(cholmod_sparse *A)
     DEBUGLEVEL(0);
     if (!(A) || !A->x) return (-1);
     int64_t n = A->ncol;
-    int64_t *Ap = (int64_t *)A->p;
-    double *Ax = (double *)A->x;
+    int64_t *Ap = static_cast<int64_t*>(A->p);
+    double *Ax = static_cast<double*>(A->x);
 
     double norm = 0;
     for (int64_t j = 0; j < n; j++)

--- a/ParU/Source/paru_residual.cpp
+++ b/ParU/Source/paru_residual.cpp
@@ -43,7 +43,7 @@ ParU_Ret ParU_Residual (cholmod_sparse *A, double *x, double *b, int64_t m,
     }
     PRLEVEL(PR, (" \n"));
 #endif
-    double *ax_b = (double *)paru_alloc(m, sizeof(double));
+    double *ax_b = static_cast<double*>(paru_alloc(m, sizeof(double)));
     if (ax_b == NULL)
     {
         PRLEVEL(1, ("ParU: memory problem inside residual\n"));
@@ -110,7 +110,7 @@ ParU_Ret ParU_Residual(cholmod_sparse *A, double *X, double *B, int64_t m,
     }
 
 #endif
-    double *AX_B = (double *)paru_alloc(m * nrhs, sizeof(double));
+    double *AX_B = static_cast<double*>(paru_alloc(m * nrhs, sizeof(double)));
     if (AX_B == NULL)
     {
         PRLEVEL(1, ("ParU: memory problem inside mRHS residual\n"));

--- a/ParU/Source/paru_solve.cpp
+++ b/ParU/Source/paru_solve.cpp
@@ -48,7 +48,7 @@ ParU_Ret ParU_Solve(ParU_Symbolic *Sym, ParU_Numeric *Num, double *b, double *x,
     double start_time = PARU_OPENMP_GET_WTIME;
 #endif
 
-    double *t = (double *)paru_alloc(m, sizeof(double));
+    double *t = static_cast<double*>(paru_alloc(m, sizeof(double)));
     if (t == NULL)
     {
         PRLEVEL(1, ("ParU: memory problem inside solve\n"));
@@ -131,7 +131,7 @@ ParU_Ret ParU_Solve(ParU_Symbolic *Sym, ParU_Numeric *Num, int64_t nrhs,
 #ifndef NTIME
     double start_time = PARU_OPENMP_GET_WTIME;
 #endif
-    double *T = (double *)paru_alloc(m * nrhs, sizeof(double));
+    double *T = static_cast<double*>(paru_alloc(m * nrhs, sizeof(double)));
     if (T == NULL)
     {
         PRLEVEL(1, ("ParU: memory problem inside Solve\n"));

--- a/ParU/Source/paru_tuples.cpp
+++ b/ParU/Source/paru_tuples.cpp
@@ -32,7 +32,7 @@ ParU_Ret paru_add_rowTuple(paru_tupleList *RowList, int64_t row, paru_tuple T)
         PRLEVEL(1, ("%%Row paru_tuple reallocating space\n"));
         int64_t newLen = cur->len * 2 + 1;
         paru_tuple *newList =
-            (paru_tuple *)paru_alloc(newLen, sizeof(paru_tuple));
+            static_cast<paru_tuple*>(paru_alloc(newLen, sizeof(paru_tuple)));
         if (newList == NULL)  // Error in allocating memory
             return PARU_OUT_OF_MEMORY;
         for (int64_t i = 0; i < cur->numTuple; ++i)  // copy old to new

--- a/ParU/Source/paru_usolve.cpp
+++ b/ParU/Source/paru_usolve.cpp
@@ -60,7 +60,7 @@ ParU_Ret ParU_Usolve(ParU_Symbolic *Sym, ParU_Numeric *Num,
     int64_t *Super = Sym->Super;
 
     BLAS_set_num_threads(control_nthreads (Control)) ;
-    double *work = (double *)paru_alloc((Num->max_col_count), sizeof(double));
+    double *work = static_cast<double*>(paru_alloc((Num->max_col_count), sizeof(double)));
     if (work == NULL)
     {
         PRLEVEL(1, ("ParU: out of memory usolve\n"));
@@ -215,7 +215,7 @@ ParU_Ret ParU_Usolve(ParU_Symbolic *Sym, ParU_Numeric *Num,
 
     BLAS_set_num_threads(control_nthreads (Control)) ;
     double *work =
-        (double *)paru_alloc((Num->max_col_count * nrhs), sizeof(double));
+        static_cast<double*>(paru_alloc((Num->max_col_count * nrhs), sizeof(double)));
     if (work == NULL)
     {
         PRLEVEL(1, ("ParU: out of memory Usolve\n"));

--- a/ParU/Source/paru_write.cpp
+++ b/ParU/Source/paru_write.cpp
@@ -73,8 +73,8 @@ void paru_write(int scale, char *id, paru_work *Work, ParU_Numeric *Num)
     int64_t *newRofS = NULL;
     int64_t *Pinit = Sym->Pinit;
 
-    oldRofS = (int64_t *)paru_alloc(m, sizeof(int64_t));  // S -> LU P
-    newRofS = (int64_t *)paru_alloc(m, sizeof(int64_t));  // Pinv of S
+    oldRofS = static_cast<int64_t*>(paru_alloc(m, sizeof(int64_t)));  // S -> LU P
+    newRofS = static_cast<int64_t*>(paru_alloc(m, sizeof(int64_t)));  // Pinv of S
 
     if (oldRofS == NULL || newRofS == NULL)
     {


### PR DESCRIPTION
Replace C-style casts by C++'s static_casts.
    
static_cast has type checking which helps to find mistakes.
Only for the cases where static_cast is ok, other cases might profit from further investigation.
Found by cppcheck.