### PR TITLE
GraphBLAS: Avoid compiler warnings about format specifier on 32-bit Linux

### DIFF
--- a/GraphBLAS/JITpackage/Source/grb_jitpackage.c
+++ b/GraphBLAS/JITpackage/Source/grb_jitpackage.c
@@ -157,7 +157,7 @@ int main (int argc, char **argv)
         //----------------------------------------------------------------------
 
         fprintf (fp, "// %s:\n", argv [k]) ;
-        fprintf (fp, "uint8_t GB_JITpackage_%d [%lu] = {\n", k-1, dsize) ;
+        fprintf (fp, "uint8_t GB_JITpackage_%d [%zu] = {\n", k-1, dsize) ;
         for (int64_t k = 0 ; k < dsize ; k++)
         {
             fprintf (fp, "%3d,", dst [k]) ;
@@ -181,8 +181,8 @@ int main (int argc, char **argv)
     // print the index
     //--------------------------------------------------------------------------
 
-    printf ("Total uncompressed: %lu bytes\n", total_uncompressed_size) ;
-    printf ("Total compressed:   %lu bytes\n", total_compressed_size) ;
+    printf ("Total uncompressed: %zu bytes\n", total_uncompressed_size) ;
+    printf ("Total compressed:   %zu bytes\n", total_compressed_size) ;
     printf ("Compression:        %g\n", 
         (double) total_compressed_size / (double) total_uncompressed_size) ;
 
@@ -200,7 +200,7 @@ int main (int argc, char **argv)
             }
         }
         // append this file to the index
-        fprintf (fp, "    { %8lu, %8lu, GB_JITpackage_%-3d, \"%s\" },\n",
+        fprintf (fp, "    { %8zu, %8zu, GB_JITpackage_%-3d, \"%s\" },\n",
             Uncompressed_size [k], Compressed_size [k], k-1, name) ;
     }
     fprintf (fp, "} ;\n#endif\n\n") ;


### PR DESCRIPTION
No functional changes.
