### PR TITLE
GraphBLAS: Don't override setting for GB_jitifyer_set_use_cmake on MinGW

### DIFF
--- a/GraphBLAS/Source/GB_jitifyer.c
+++ b/GraphBLAS/Source/GB_jitifyer.c
@@ -1159,7 +1159,7 @@ void GB_jitifyer_set_use_cmake (bool use_cmake)
 { 
     #pragma omp critical (GB_jitifyer_worker)
     {
-        #if GB_WINDOWS
+        #if defined (_MSC_VER)
         // Windows requires cmake
         GB_jit_use_cmake = true ;
         #else


### PR DESCRIPTION
Missing part from #513.

The changes from #513 stopped having an effect as soon as the function `GB_jitifyer_set_use_cmake` was called (with any argument) on MinGW.

I didn't see that in my tests because I didn't call `GB_jitifyer_set_use_cmake`.
