### PR TITLE
GraphBLAS: Don't use dllexport or dllimport attribute for static library

### DIFF
--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -304,6 +304,11 @@ if ( BUILD_STATIC_LIBS )
         target_compile_definitions ( GraphBLAS_static PRIVATE "SUITESPARSE_CUDA" )
     endif ( )
 
+    if ( WIN32 )
+        # On Windows, don't use __declspec ( dllimport ) for static library.
+        target_compile_definitions ( GraphBLAS_static PUBLIC GB_STATIC )
+    endif ( )
+
     if ( NOT NJIT )
         # Make sure compressed sources are built before library
         add_dependencies ( GraphBLAS_static grb_jitpackage )

--- a/GraphBLAS/Config/GraphBLAS.h.in
+++ b/GraphBLAS/Config/GraphBLAS.h.in
@@ -96,9 +96,9 @@
         #define GB_GLOBAL extern __declspec ( dllexport )
     #elif defined ( GB_STATIC )
         // Compiling the user application on Windows, importing symbols from
-        // a static GraphBLAS library on Windows. The user application must do:
-        //      #define GB_STATIC
-        //      #include "GraphBLAS.h"
+        // a static GraphBLAS library on Windows. The user application must
+        // define GB_STATIC (e.g., with the pre-processor flag -DGB_STATIC) for
+        // all compilation units that include "GraphBLAS.h".
         #define GB_GLOBAL extern
     #else
         // Compiling the user application on Windows, importing symbols from

--- a/GraphBLAS/Config/GraphBLAS.pc.in
+++ b/GraphBLAS/Config/GraphBLAS.pc.in
@@ -17,3 +17,4 @@ Requires.private: @GRAPHBLAS_STATIC_MODULES@
 Libs: -L${libdir} -lgraphblas
 Libs.private: @GRAPHBLAS_STATIC_LIBS@
 Cflags: -I${includedir}
+Cflags.private: -DGB_STATIC

--- a/GraphBLAS/Include/GraphBLAS.h
+++ b/GraphBLAS/Include/GraphBLAS.h
@@ -96,9 +96,9 @@
         #define GB_GLOBAL extern __declspec ( dllexport )
     #elif defined ( GB_STATIC )
         // Compiling the user application on Windows, importing symbols from
-        // a static GraphBLAS library on Windows. The user application must do:
-        //      #define GB_STATIC
-        //      #include "GraphBLAS.h"
+        // a static GraphBLAS library on Windows. The user application must
+        // define GB_STATIC (e.g., with the pre-processor flag -DGB_STATIC) for
+        // all compilation units that include "GraphBLAS.h".
         #define GB_GLOBAL extern
     #else
         // Compiling the user application on Windows, importing symbols from


### PR DESCRIPTION
Facilitate using the static GraphBLAS library on Windows by adding the necessary preprocessor definition to the CMake target and pkg-config file.
