### PR TITLE
Fix some compilation errors on windows with newest toolkits

### DIFF
--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -504,13 +504,13 @@ if ( SUITESPARSE_CUDA )
     endif ( )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( CHOLMOD PRIVATE CUDA::nvrtc CUDA::cudart_static
-            CUDA::nvToolsExt CUDA::cublas )
+            CUDA::nvtx3 CUDA::cublas )
         target_include_directories ( CHOLMOD INTERFACE
             $<TARGET_PROPERTY:CUDA::cublas,INTERFACE_INCLUDE_DIRECTORIES> )
     endif ( )
     if ( BUILD_STATIC_LIBS )
         target_link_libraries ( CHOLMOD_static PUBLIC CUDA::nvrtc CUDA::cudart_static
-            CUDA::nvToolsExt CUDA::cublas )
+            CUDA::nvtx3 CUDA::cublas )
     endif ( )
 
     set ( old_CMAKE_EXTRA_INCLUDE_FILES CMAKE_EXTRA_INCLUDE_FILES )
@@ -804,7 +804,7 @@ add_test ( NAME CHOLMOD_int64_single_supernodal
 if ( WIN32 AND BUILD_SHARED_LIBS )
     # Set PATH to pick up the necessary libraries for all tests
 
-    set ( CHOLMOD_CTEST_NAMES 
+    set ( CHOLMOD_CTEST_NAMES
         CHOLMOD_int32_double_bcsstk01 CHOLMOD_int64_double_bcsstk01 CHOLMOD_int32_single_bcsstk01 CHOLMOD_int64_single_bcsstk01
         CHOLMOD_int32_double_lp_afiro CHOLMOD_int64_double_lp_afiro CHOLMOD_int32_single_lp_afiro CHOLMOD_int64_single_lp_afiro
         CHOLMOD_int32_double_can24 CHOLMOD_int64_double_can24 CHOLMOD_int32_single_can24 CHOLMOD_int64_single_can24

--- a/CHOLMOD/GPU/CMakeLists.txt
+++ b/CHOLMOD/GPU/CMakeLists.txt
@@ -90,11 +90,11 @@ endif ( )
 
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( CHOLMOD_CUDA PRIVATE CUDA::nvrtc CUDA::cudart_static
-        CUDA::nvToolsExt CUDA::cublas )
+        CUDA::nvtx3 CUDA::cublas )
 endif ( )
 if ( BUILD_STATIC_LIBS )
     target_link_libraries ( CHOLMOD_CUDA_static PUBLIC CUDA::nvrtc CUDA::cudart_static
-        CUDA::nvToolsExt CUDA::cublas )
+        CUDA::nvtx3 CUDA::cublas )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/SPQR/GPUQREngine/CMakeLists.txt
+++ b/SPQR/GPUQREngine/CMakeLists.txt
@@ -21,7 +21,7 @@ message ( STATUS "Building SPQR/GPUQRENGINE version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( gpuqrengine 
+project ( gpuqrengine
     VERSION "${SPQR_VERSION_MAJOR}.${SPQR_VERSION_MINOR}.${SPQR_VERSION_SUB}"
     LANGUAGES CXX CUDA )
 
@@ -100,7 +100,7 @@ if ( BUILD_SHARED_LIBS )
         CUDA_RESOLVE_DEVICE_SYMBOLS ON
         CUDA_RUNTIME_LIBRARY Static )
     target_link_libraries ( GPUQREngine PRIVATE
-        CUDA::nvrtc CUDA::cudart_static CUDA::nvToolsExt CUDA::cublas )
+        CUDA::nvrtc CUDA::cudart_static CUDA::nvtx3 CUDA::cublas )
     target_compile_definitions ( GPUQREngine PRIVATE "SUITESPARSE_CUDA" )
 
     target_include_directories ( GPUQREngine
@@ -138,7 +138,7 @@ if ( BUILD_STATIC_LIBS )
         CUDA_RESOLVE_DEVICE_SYMBOLS ON
         CUDA_RUNTIME_LIBRARY Static )
     target_link_libraries ( GPUQREngine_static PUBLIC
-        CUDA::nvrtc CUDA::cudart_static CUDA::nvToolsExt CUDA::cublas )
+        CUDA::nvrtc CUDA::cudart_static CUDA::nvtx3 CUDA::cublas )
     target_compile_definitions ( GPUQREngine_static PRIVATE "SUITESPARSE_CUDA" )
 
     target_include_directories ( GPUQREngine_static

--- a/SPQR/GPUQREngine/Include/GPUQREngine_BucketList.hpp
+++ b/SPQR/GPUQREngine/Include/GPUQREngine_BucketList.hpp
@@ -72,7 +72,7 @@ public:
     int VThead;              // Index of the first available entry in VTlist
 
     // Constructors
-    void *operator new(long unsigned int, BucketList <Int>* p)
+    void *operator new(size_t, BucketList <Int>* p)
     {
         return p;
     }

--- a/SPQR/GPUQREngine/Include/GPUQREngine_Front.hpp
+++ b/SPQR/GPUQREngine/Include/GPUQREngine_Front.hpp
@@ -53,7 +53,7 @@ public:
     /* Debug Fields */
     bool printMe;
 
-    void* operator new(long unsigned int reqMem, Front* ptr){ return ptr; }
+    void* operator new(size_t reqMem, Front* ptr){ return ptr; }
 
     Front(
         Int fids_arg,                   // the front identifier

--- a/SPQR/GPUQREngine/Include/GPUQREngine_LLBundle.hpp
+++ b/SPQR/GPUQREngine/Include/GPUQREngine_LLBundle.hpp
@@ -76,7 +76,7 @@ public:
 
     TaskType CurrentTask;
 
-    void *operator new(long unsigned int, LLBundle <Int>* p){ return p; }
+    void *operator new(size_t, LLBundle <Int>* p){ return p; }
     //------------------------------------------------------------------------------
     //
     // This file contains the constructor and destructor for the LLBundle class.

--- a/SPQR/GPUQREngine/Include/GPUQREngine_Scheduler.hpp
+++ b/SPQR/GPUQREngine/Include/GPUQREngine_Scheduler.hpp
@@ -97,7 +97,7 @@ public:
     cudaStream_t memoryStreamD2H;
 
     /* Scheduler.cpp */
-    void *operator new(long unsigned int, Scheduler <Int>* p){ return p; }
+    void *operator new(size_t, Scheduler <Int>* p){ return p; }
     Scheduler(Front <Int> *fronts, Int numFronts, size_t gpuMemorySize);
     ~Scheduler();
 

--- a/SPQR/GPURuntime/CMakeLists.txt
+++ b/SPQR/GPURuntime/CMakeLists.txt
@@ -21,7 +21,7 @@ message ( STATUS "Building SPQR/GPURUNTIME version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( suitesparse_gpuruntime 
+project ( suitesparse_gpuruntime
     VERSION "${SPQR_VERSION_MAJOR}.${SPQR_VERSION_MINOR}.${SPQR_VERSION_SUB}"
     LANGUAGES C CXX CUDA )
 
@@ -78,10 +78,10 @@ if ( BUILD_SHARED_LIBS )
         CUDA_SEPARABLE_COMPILATION ON
         CUDA_RUNTIME_LIBRARY Static )
     target_link_libraries ( GPURuntime PRIVATE
-        CUDA::nvrtc CUDA::cudart_static CUDA::nvToolsExt CUDA::cublas )
+        CUDA::nvrtc CUDA::cudart_static CUDA::nvtx3 CUDA::cublas )
     target_compile_definitions ( GPURuntime PRIVATE "SUITESPARSE_CUDA" )
 
-    target_include_directories ( GPURuntime 
+    target_include_directories ( GPURuntime
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 endif ( )
@@ -114,10 +114,10 @@ if ( BUILD_STATIC_LIBS )
         CUDA_SEPARABLE_COMPILATION ON
         CUDA_RUNTIME_LIBRARY Static )
     target_link_libraries ( GPURuntime_static PUBLIC
-        CUDA::nvrtc CUDA::cudart_static CUDA::nvToolsExt CUDA::cublas )
+        CUDA::nvrtc CUDA::cudart_static CUDA::nvtx3 CUDA::cublas )
     target_compile_definitions ( GPURuntime_static PRIVATE "SUITESPARSE_CUDA" )
 
-    target_include_directories ( GPURuntime_static 
+    target_include_directories ( GPURuntime_static
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 endif ( )

--- a/SPQR/SPQRGPU/CMakeLists.txt
+++ b/SPQR/SPQRGPU/CMakeLists.txt
@@ -20,7 +20,7 @@ message ( STATUS "Building SPQR_CUDA version: v"
 
 include ( SuiteSparsePolicy )
 
-project ( spqr_cuda 
+project ( spqr_cuda
     VERSION "${SPQR_VERSION_MAJOR}.${SPQR_VERSION_MINOR}.${SPQR_VERSION_SUB}"
     LANGUAGES CXX )
 message ( STATUS "C++ flags for CUDA:  ${CMAKE_CXX_FLAGS}" )
@@ -71,7 +71,7 @@ if ( BUILD_SHARED_LIBS )
     target_link_libraries ( SPQR_CUDA PRIVATE SuiteSparse::CHOLMOD )
 
     target_link_libraries ( SPQR_CUDA PRIVATE CUDA::nvrtc CUDA::cudart_static
-        CUDA::nvToolsExt CUDA::cublas )
+        CUDA::nvtx3 CUDA::cublas )
 endif ( )
 
 if ( BUILD_STATIC_LIBS )
@@ -93,7 +93,7 @@ if ( BUILD_STATIC_LIBS )
     endif ( )
 
     target_link_libraries ( SPQR_CUDA_static PUBLIC CUDA::nvrtc CUDA::cudart_static
-        CUDA::nvToolsExt CUDA::cublas )
+        CUDA::nvtx3 CUDA::cublas )
 endif ( )
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Change CUDA::nvToolsExt to CUDA::nvtx3 as described in the [issue](https://github.com/DrTimothyAldenDavis/SuiteSparse/issues/530)

Change **operator new** definition from  **unsigned long int** to **size_t** as described in the [issue](https://github.com/DrTimothyAldenDavis/SuiteSparse/issues/530)

