### PR TITLE
GraphBLAS/rmm_wrap: Slightly overhaul build rules

### DIFF
--- a/GraphBLAS/CUDA/CMakeLists.txt
+++ b/GraphBLAS/CUDA/CMakeLists.txt
@@ -243,26 +243,26 @@ set_target_properties(graphblascuda_test PROPERTIES CUDA_ARCHITECTURES "52;75;80
 
 include(GoogleTest)
 
-add_dependencies(graphblascuda_test GraphBLAS)
-add_dependencies(graphblascuda_test GraphBLAS_CUDA)
-add_dependencies(graphblascuda_test gtest_main)
-add_dependencies(graphblascuda_test rmm_wrap)
+if ( ENABLE_SHARED_LIBS )
+    target_link_libraries ( graphblascuda_test PUBLIC GraphBLAS  )
+else ( )
+    target_link_libraries ( graphblascuda_test PUBLIC GraphBLAS_static )
+endif ( )
 
-target_link_libraries(graphblascuda_test
-        PUBLIC
-        GraphBLAS
-        GraphBLAS_CUDA
-        rmm_wrap
-        CUDA::cudart_static
-        CUDA::nvrtc
-        ${ADDITIONAL_DEPS}
-        PRIVATE
-        gtest_main)
+target_link_libraries ( graphblascuda_test
+    PUBLIC
+    GraphBLAS_CUDA
+    RMM_wrap
+    CUDA::cudart_static
+    CUDA::nvrtc
+    ${ADDITIONAL_DEPS}
+    PRIVATE
+    gtest_main )
 
-target_include_directories(graphblascuda_test
-        PUBLIC
-        rmm_wrap
-        ${ADDITIONAL_INCLUDES}
-        ${CUDAToolkit_INCLUDE_DIRS}
-        ${GRAPHBLAS_CUDA_INCLUDES})
+target_include_directories ( graphblascuda_test
+    PUBLIC
+    rmm_wrap
+    ${ADDITIONAL_INCLUDES}
+    ${CUDAToolkit_INCLUDE_DIRS}
+    ${GRAPHBLAS_CUDA_INCLUDES} )
 

--- a/GraphBLAS/rmm_wrap/CMakeLists.txt
+++ b/GraphBLAS/rmm_wrap/CMakeLists.txt
@@ -8,70 +8,71 @@
 
 cmake_minimum_required ( VERSION 3.19 )
 
-project(rmm_wrap VERSION 0.1)
+project ( rmm_wrap VERSION 0.1 )
 
 # This build depends upon having RMM cmake installed from https://github.com/rapidsai/rmm.git
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_C_STANDARD 99)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+set ( CMAKE_CXX_STANDARD 17 )
+set ( CMAKE_C_STANDARD 99 )
+set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC" )
 
-find_package(CUDA REQUIRED)
+find_package ( CUDAToolkit REQUIRED )
 
-set(EXTERNAL_INCLUDES_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/external_includes)
+set ( EXTERNAL_INCLUDES_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/external_includes )
 
-IF(NOT EXISTS ${EXTERNAL_INCLUDES_DIRECTORY})
-file(MAKE_DIRECTORY ${EXTERNAL_INCLUDES_DIRECTORY})
+if ( NOT EXISTS ${EXTERNAL_INCLUDES_DIRECTORY} )
+    file ( MAKE_DIRECTORY ${EXTERNAL_INCLUDES_DIRECTORY} )
+endif ( )
+
+if ( NOT EXISTS ${EXTERNAL_INCLUDES_DIRECTORY}/spdlog )
+    execute_process (
+        COMMAND git clone "https://github.com/gabime/spdlog.git" --branch v1.10.0 --recursive spdlog
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/external_includes )
+endif ( )
+
+set ( SPDLOG_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/external_includes/spdlog/include )
+include_directories ( ${SPDLOG_INCLUDE_DIR} )
+
+if ( NOT EXISTS ${EXTERNAL_INCLUDES_DIRECTORY}/rmm )
+    execute_process (
+        COMMAND git clone "https://github.com/rapidsai/rmm.git" --branch branch-21.10 --recursive rmm
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/external_includes )
 endif()
 
-IF(NOT EXISTS ${EXTERNAL_INCLUDES_DIRECTORY}/spdlog)
-execute_process(
-		COMMAND git clone "https://github.com/gabime/spdlog.git" --branch v1.10.0 --recursive spdlog
-		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/external_includes)
-endif()
+set ( RMM_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/external_includes/rmm/include )
+include_directories ( ${RMM_INCLUDE_DIR} )
 
-set(SPDLOG_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/external_includes/spdlog/include)
-include_directories(${SPDLOG_INCLUDE_DIR})
+add_library ( RMM_wrap rmm_wrap.cpp rmm_wrap.hpp rmm_wrap.h )
 
-IF(NOT EXISTS ${EXTERNAL_INCLUDES_DIRECTORY}/rmm)
-execute_process(
-		COMMAND git clone "https://github.com/rapidsai/rmm.git" --branch branch-21.10 --recursive rmm
-		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/external_includes)
-endif()
+set_target_properties ( RMM_wrap PROPERTIES
+    VERSION ${GraphBLAS_VERSION_MAJOR}.${GraphBLAS_VERSION_MINOR}.${GraphBLAS_VERSION_SUB}
+    OUTPUT_NAME rmm_wrap
+    SOVERSION ${GraphBLAS_VERSION_MAJOR}
+    PUBLIC_HEADER "rmm_wrap.h"
+    WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
-set(RMM_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/external_includes/rmm/include)
-include_directories(${RMM_INCLUDE_DIR})
+add_executable ( rmm_wrap_test rmm_wrap_test.c rmm_wrap.cpp rmm_wrap.hpp rmm_wrap.h )
 
-add_library(rmm_wrap rmm_wrap.cpp rmm_wrap.hpp rmm_wrap.h)
+set ( RMM_WRAP_LIBS ${EXTRA_LIBS} CUDA::cudart_static )
+set ( RMM_WRAP_INCLUDES ${PROJECT_BINARY_DIR}
+    ${SPDLOG_INCLUDE_DIR}
+    ${RMM_INCLUDE_DIR}
+    ${CUDA_INCLUDE_DIRS}
+    ${CONDA_PREFIX}/include
+    ${PROJECT_SOURCE_DIR}/include )
 
-set_target_properties (rmm_wrap PROPERTIES
-		VERSION ${GraphBLAS_VERSION_MAJOR}.${GraphBLAS_VERSION_MINOR}.${GraphBLAS_VERSION_SUB}
-		SOVERSION ${GraphBLAS_VERSION_MAJOR}
-		C_STANDARD 11
-		C_STANDARD_REQUIRED ON
-		PUBLIC_HEADER "rmm_wrap.h" )
+target_link_libraries ( RMM_wrap PRIVATE ${RMM_WRAP_LIBS} )
+target_include_directories ( RMM_wrap PRIVATE "${RMM_WRAP_INCLUDES}" )
 
-add_executable(rmm_wrap_test rmm_wrap_test.c rmm_wrap.cpp rmm_wrap.hpp rmm_wrap.h)
-
-set(RMM_WRAP_LIBS ${EXTRA_LIBS} ${CUDA_LIBRARIES})
-set(RMM_WRAP_INCLUDES ${PROJECT_BINARY_DIR}
-		${SPDLOG_INCLUDE_DIR}
-		${RMM_INCLUDE_DIR}
-		${CUDA_INCLUDE_DIRS}
-		${CONDA_PREFIX}/include
-		${PROJECT_SOURCE_DIR}/include)
-
-target_link_libraries(rmm_wrap PUBLIC ${RMM_WRAP_LIBS})
-target_include_directories(rmm_wrap PUBLIC "${RMM_WRAP_INCLUDES}")
-
-target_link_libraries(rmm_wrap_test PUBLIC ${RMM_WRAP_LIBS})
-target_include_directories(rmm_wrap_test PUBLIC "${RMM_WRAP_INCLUDES}")
+target_link_libraries ( rmm_wrap_test PUBLIC ${RMM_WRAP_LIBS} )
+target_include_directories ( rmm_wrap_test PUBLIC "${RMM_WRAP_INCLUDES}" )
 
 #-------------------------------------------------------------------------------
 # installation location
 #-------------------------------------------------------------------------------
 
-install ( TARGETS rmm_wrap
+install ( TARGETS RMM_wrap
+    EXPORT GraphBLASTargets
     LIBRARY DESTINATION ${SUITESPARSE_LIBDIR}
     ARCHIVE DESTINATION ${SUITESPARSE_LIBDIR}
     RUNTIME DESTINATION ${SUITESPARSE_BINDIR}


### PR DESCRIPTION
Rename target to `RMM_wrap` and export it with the GraphBLASTargets.
Find package CUDAToolkit and link to CMake target instead of CUDA runtime library name.
Fix error when configured with `ENABLE_SHARED_LIBS=OFF`.

I can't test this change locally (no working CUDA yet). But I hope it will help for #541.

