### PR TITLE
CHOLMOD: Automatically import CUDA targets if needed.

### DIFF
--- a/CHOLMOD/Config/CHOLMODConfig.cmake.in
+++ b/CHOLMOD/Config/CHOLMODConfig.cmake.in
@@ -38,6 +38,19 @@ set ( CHOLMOD_VERSION "@CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_
 include ( CMakeFindDependencyMacro )
 set ( _dependencies_found ON )
 
+# Look for NVIDIA CUDA toolkit
+if ( @SUITESPARSE_CUDA@ AND NOT CUDAToolkit_FOUND )
+    find_dependency ( CUDAToolkit @CUDAToolkit_VERSION_MAJOR@ )
+    if ( NOT CUDAToolkit_FOUND )
+        set ( _dependencies_found OFF )
+    endif ( )
+endif ( )
+
+if ( NOT _dependencies_found )
+    set ( CHOLMOD_FOUND OFF )
+    return ( )
+endif ( )
+
 # Look for SuiteSparse_config, COLAMD, and AMD targets
 if ( @SUITESPARSE_IN_BUILD_TREE@ )
     if ( NOT TARGET SuiteSparse::SuiteSparseConfig )

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -38,14 +38,7 @@ set ( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
     ${PROJECT_SOURCE_DIR}/../SuiteSparse_config/cmake_modules
     )
 
-option ( ENABLE_CUDA "Enable CUDA acceleration" on )
-
 include ( SuiteSparsePolicy )
-
-if ( SUITESPARSE_CUDA )
-    # ParU with CHOLMOD (which can use CUDA)
-    enable_language ( CUDA )
-endif ( )
 
 #-------------------------------------------------------------------------------
 # find library dependencies

--- a/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
+++ b/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
@@ -16,12 +16,9 @@
 #
 #   ENABLE_CUDA:        if set to true, CUDA is enabled for the project.
 #                       Default: true for CHOLMOD and SPQR, which use the GPU
-#                       for their numerical factorizsation.  It is also enabled
-#                       for UMFPACK, KLU, and ParU (which use CHOLMOD and this
-#                       require this flag if CHOLMOD has been compiled with
-#                       ENABLE_CUDA).  The flag is false for false for
-#                       GraphBLAS since CUDA for that package is in progress
-#                       and not ready for production use.
+#                       for their numerical factorizsation.  The flag is false
+#                       for GraphBLAS since CUDA for that package is in
+#                       progress and not ready for production use.
 #
 #   LOCAL_INSTALL:      if true, "cmake --install" will install
 #                       into SuiteSparse/lib and SuiteSparse/include.


### PR DESCRIPTION
This change allows to automatically import the CUDA targets when importing the CHOLMOD targets (when the CUDA targets are needed). Dependent projects don't need to worry about importing that (potential) dependency explicitly.

This also reverts the respective changes from https://github.com/DrTimothyAldenDavis/SuiteSparse/commit/eb2809103b76ef907807a7c63c57038d26e5fb3a. I hope that is ok.

Should fix #549.
