### PR TITLE
CHOLMOD: Add dependency to system libraries after SuiteSparse libraries

### DIFF
--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -357,40 +357,6 @@ if ( BUILD_STATIC_LIBS )
     endif ( )
 endif ( )
 
-# OpenMP:
-if ( OPENMP_FOUND )
-    message ( STATUS "OpenMP C libraries:      ${OpenMP_C_LIBRARIES} ")
-    message ( STATUS "OpenMP C include:        ${OpenMP_C_INCLUDE_DIRS} ")
-    message ( STATUS "OpenMP C flags:          ${OpenMP_C_FLAGS} ")
-    if ( BUILD_SHARED_LIBS )
-        target_link_libraries ( CHOLMOD PRIVATE ${OpenMP_C_LIBRARIES} )
-    endif ( )
-    if ( BUILD_STATIC_LIBS )
-        target_link_libraries ( CHOLMOD_static PUBLIC ${OpenMP_C_LIBRARIES} )
-        list ( APPEND CHOLMOD_STATIC_LIBS ${OpenMP_C_LIBRARIES} )
-    endif ( )
-    set ( CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   ${OpenMP_C_FLAGS} " )
-    set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_C_FLAGS} " )
-    include_directories ( ${OpenMP_C_INCLUDE_DIRS} )
-else ( )
-    # to fix METIS: use threadprivate variables for GKRAND instead globals,
-    # so multiple user threads can call cholmod_analyze in parallel on
-    # different matrices, and avoid global locking of the system rand.
-    include ( SuiteSparse__thread )
-endif ( )
-
-# libm:
-if ( NOT WIN32 )
-    if ( BUILD_SHARED_LIBS )
-        target_link_libraries ( CHOLMOD PRIVATE m )
-    endif ( )
-    if ( BUILD_STATIC_LIBS )
-        list ( APPEND CHOLMOD_STATIC_LIBS "m" )
-        target_link_libraries ( CHOLMOD_static PUBLIC m )
-    endif ( )
-endif ( )
-        list ( APPEND CHOLMOD_STATIC_LIBS "m" )
-
 # AMD:
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( CHOLMOD PRIVATE SuiteSparse::AMD )
@@ -413,35 +379,6 @@ if ( BUILD_STATIC_LIBS )
     else ( )
         target_link_libraries ( CHOLMOD_static PUBLIC SuiteSparse::COLAMD )
     endif ( )
-endif ( )
-
-# BLAS and LAPACK: for the Supernodal Module
-if ( NOT NSUPERNODAL )
-    # LAPACK:
-    message ( STATUS "LAPACK libraries:    ${LAPACK_LIBRARIES} ")
-    message ( STATUS "LAPACK include:      ${LAPACK_INCLUDE_DIRS} ")
-    message ( STATUS "LAPACK linker flags: ${LAPACK_LINKER_FLAGS} ")
-    if ( BUILD_SHARED_LIBS )
-        target_link_libraries ( CHOLMOD PRIVATE ${LAPACK_LIBRARIES} )
-    endif ( )
-    if ( BUILD_STATIC_LIBS )
-        list ( APPEND CHOLMOD_STATIC_LIBS ${LAPACK_LIBRARIES} )
-        target_link_libraries ( CHOLMOD_static PUBLIC ${LAPACK_LIBRARIES} )
-    endif ( )
-    include_directories ( ${LAPACK_INCLUDE_DIR} )
-
-    # BLAS:
-    message ( STATUS "BLAS libraries:      ${BLAS_LIBRARIES} ")
-    message ( STATUS "BLAS include:        ${BLAS_INCLUDE_DIRS} ")
-    message ( STATUS "BLAS linker flags:   ${BLAS_LINKER_FLAGS} ")
-    if ( BUILD_SHARED_LIBS )
-        target_link_libraries ( CHOLMOD PRIVATE ${BLAS_LIBRARIES} )
-    endif ( )
-    if ( BUILD_STATIC_LIBS )
-        list ( APPEND CHOLMOD_STATIC_LIBS ${BLAS_LIBRARIES} )
-        target_link_libraries ( CHOLMOD_static PUBLIC ${BLAS_LIBRARIES} )
-    endif ( )
-    include_directories ( ${BLAS_INCLUDE_DIRS} )
 endif ( )
 
 # CAMD and CCOLAMD:
@@ -469,6 +406,66 @@ if ( NOT NCAMD )
             target_link_libraries ( CHOLMOD_static PUBLIC SuiteSparse::CCOLAMD )
         endif ( )
     endif ( )
+endif ( )
+
+# OpenMP:
+if ( OPENMP_C_FOUND )
+    message ( STATUS "OpenMP C libraries:      ${OpenMP_C_LIBRARIES}" )
+    message ( STATUS "OpenMP C include:        ${OpenMP_C_INCLUDE_DIRS}" )
+    message ( STATUS "OpenMP C flags:          ${OpenMP_C_FLAGS}" )
+    if ( BUILD_SHARED_LIBS )
+        target_link_libraries ( CHOLMOD PRIVATE OpenMP::OpenMP_C )
+    endif ( )
+    if ( BUILD_STATIC_LIBS )
+        target_link_libraries ( CHOLMOD_static PUBLIC OpenMP::OpenMP_C )
+        list ( APPEND CHOLMOD_STATIC_LIBS ${OpenMP_C_LIBRARIES} )
+    endif ( )
+else ( )
+    # to fix METIS: use threadprivate variables for GKRAND instead globals,
+    # so multiple user threads can call cholmod_analyze in parallel on
+    # different matrices, and avoid global locking of the system rand.
+    include ( SuiteSparse__thread )
+endif ( )
+
+# libm:
+if ( NOT WIN32 )
+    if ( BUILD_SHARED_LIBS )
+        target_link_libraries ( CHOLMOD PRIVATE m )
+    endif ( )
+    if ( BUILD_STATIC_LIBS )
+        list ( APPEND CHOLMOD_STATIC_LIBS "m" )
+        target_link_libraries ( CHOLMOD_static PUBLIC m )
+    endif ( )
+endif ( )
+        list ( APPEND CHOLMOD_STATIC_LIBS "m" )
+
+# BLAS and LAPACK: for the Supernodal Module
+if ( NOT NSUPERNODAL )
+    # LAPACK:
+    message ( STATUS "LAPACK libraries:    ${LAPACK_LIBRARIES}" )
+    message ( STATUS "LAPACK include:      ${LAPACK_INCLUDE_DIRS}" )
+    message ( STATUS "LAPACK linker flags: ${LAPACK_LINKER_FLAGS}" )
+    if ( BUILD_SHARED_LIBS )
+        target_link_libraries ( CHOLMOD PRIVATE ${LAPACK_LIBRARIES} )
+    endif ( )
+    if ( BUILD_STATIC_LIBS )
+        list ( APPEND CHOLMOD_STATIC_LIBS ${LAPACK_LIBRARIES} )
+        target_link_libraries ( CHOLMOD_static PUBLIC ${LAPACK_LIBRARIES} )
+    endif ( )
+    include_directories ( ${LAPACK_INCLUDE_DIR} )
+
+    # BLAS:
+    message ( STATUS "BLAS libraries:      ${BLAS_LIBRARIES}" )
+    message ( STATUS "BLAS include:        ${BLAS_INCLUDE_DIRS}" )
+    message ( STATUS "BLAS linker flags:   ${BLAS_LINKER_FLAGS}" )
+    if ( BUILD_SHARED_LIBS )
+        target_link_libraries ( CHOLMOD PRIVATE ${BLAS_LIBRARIES} )
+    endif ( )
+    if ( BUILD_STATIC_LIBS )
+        list ( APPEND CHOLMOD_STATIC_LIBS ${BLAS_LIBRARIES} )
+        target_link_libraries ( CHOLMOD_static PUBLIC ${BLAS_LIBRARIES} )
+    endif ( )
+    include_directories ( ${BLAS_INCLUDE_DIRS} )
 endif ( )
 
 # METIS and the Partition module:

--- a/CHOLMOD/Config/CHOLMODConfig.cmake.in
+++ b/CHOLMOD/Config/CHOLMODConfig.cmake.in
@@ -51,6 +51,19 @@ if ( NOT _dependencies_found )
     return ( )
 endif ( )
 
+# Look for OpenMP
+if ( NOT @NOPENMP@ AND NOT OpenMP_C_FOUND )
+    find_dependency ( OpenMP )
+    if ( NOT OpenMP_C_FOUND )
+        set ( _dependencies_found OFF )
+    endif ( )
+endif ( )
+
+if ( NOT _dependencies_found )
+    set ( CHOLMOD_FOUND OFF )
+    return ( )
+endif ( )
+
 # Look for SuiteSparse_config, COLAMD, and AMD targets
 if ( @SUITESPARSE_IN_BUILD_TREE@ )
     if ( NOT TARGET SuiteSparse::SuiteSparseConfig )


### PR DESCRIPTION
The headers of OpenMP might be installed at a location where headers of older versions of SuiteSparse libraries are installed.
Try two approaches to avoid that these older headers are picked up when building CHOLMOD:
* Add the dependency to OpenMP (and other system libraries) *after* the dependencies to other SuiteSparse libraries have been added.
* Link to the OpenMP target instead of adding the include folder.

Maybe that helps with the issue described in #175.

@Fabian188: Could you please test this if you come around to it?
