### PR TITLE
Add dependency to system libraries after SuiteSparse libraries

### DIFF
--- a/Example/CMakeLists.txt
+++ b/Example/CMakeLists.txt
@@ -207,81 +207,6 @@ endif ( )
 # add the library dependencies
 #-------------------------------------------------------------------------------
 
-# OpenMP:
-message ( STATUS "OpenMP C libraries:      ${OpenMP_C_LIBRARIES} ")
-message ( STATUS "OpenMP C include:        ${OpenMP_C_INCLUDE_DIRS} ")
-message ( STATUS "OpenMP C flags:          ${OpenMP_C_FLAGS} ")
-if ( BUILD_SHARED_LIBS )
-    target_link_libraries ( my PRIVATE OpenMP::OpenMP_C )
-    target_link_libraries ( my_cxx PRIVATE OpenMP::OpenMP_CXX )
-endif ( )
-if ( BUILD_STATIC_LIBS )
-    target_link_libraries ( my_static PUBLIC OpenMP::OpenMP_C )
-    target_link_libraries ( my_cxx_static PUBLIC OpenMP::OpenMP_CXX )
-endif ( )
-
-# libm:
-if ( NOT WIN32 )
-    if ( BUILD_SHARED_LIBS )
-        target_link_libraries ( my PRIVATE m )
-        target_link_libraries ( my_cxx PRIVATE m )
-    endif ( )
-    if ( BUILD_STATIC_LIBS )
-        target_link_libraries ( my_static PUBLIC m )
-        target_link_libraries ( my_cxx_static PUBLIC m )
-    endif ( )
-endif ( )
-
-# BLAS:
-message ( STATUS "BLAS libraries:      ${BLAS_LIBRARIES} ")
-message ( STATUS "BLAS include:        ${BLAS_INCLUDE_DIRS} ")
-message ( STATUS "BLAS linker flags:   ${BLAS_LINKER_FLAGS} ")
-if ( BUILD_SHARED_LIBS )
-    target_link_libraries ( my PRIVATE ${BLAS_LIBRARIES} )
-    target_link_libraries ( my_cxx PRIVATE ${BLAS_LIBRARIES} )
-endif ( )
-if ( BUILD_STATIC_LIBS )
-    target_link_libraries ( my_static PUBLIC ${BLAS_LIBRARIES} )
-    target_link_libraries ( my_cxx_static PUBLIC ${BLAS_LIBRARIES} )
-endif ( )
-include_directories ( ${BLAS_INCLUDE_DIRS} )
-
-# LAPACK:
-message ( STATUS "LAPACK libraries:    ${LAPACK_LIBRARIES} ")
-message ( STATUS "LAPACK include:      ${LAPACK_INCLUDE_DIRS} ")
-message ( STATUS "LAPACK linker flags: ${LAPACK_LINKER_FLAGS} ")
-if ( BUILD_SHARED_LIBS )
-    target_link_libraries ( my PRIVATE ${LAPACK_LIBRARIES} )
-    target_link_libraries ( my_cxx PRIVATE ${LAPACK_LIBRARIES} )
-endif ( )
-if ( BUILD_STATIC_LIBS )
-    target_link_libraries ( my_static PUBLIC ${LAPACK_LIBRARIES} )
-    target_link_libraries ( my_cxx_static PUBLIC ${LAPACK_LIBRARIES} )
-endif ( )
-include_directories ( ${LAPACK_INCLUDE_DIRS} )
-
-# gmp:
-if ( BUILD_SHARED_LIBS )
-    target_link_libraries ( my PRIVATE ${GMP_LIBRARIES} )
-    target_link_libraries ( my_cxx PRIVATE ${GMP_LIBRARIES} )
-endif ( )
-if ( BUILD_STATIC_LIBS )
-    target_link_libraries ( my_static PUBLIC ${GMP_STATIC} )
-    target_link_libraries ( my_cxx_static PUBLIC ${GMP_STATIC} )
-endif ( )
-include_directories ( ${GMP_INCLUDE_DIR} )
-
-# mpfr:
-if ( BUILD_SHARED_LIBS )
-    target_link_libraries ( my PRIVATE ${MPFR_LIBRARIES} )
-    target_link_libraries ( my_cxx PRIVATE ${MPFR_LIBRARIES} )
-endif ( )
-if ( BUILD_STATIC_LIBS )
-    target_link_libraries ( my_static PUBLIC ${MPFR_STATIC} )
-    target_link_libraries ( my_cxx_static PUBLIC ${MPFR_STATIC} )
-endif ( )
-include_directories ( ${MPFR_INCLUDE_DIR} )
-
 # AMD:
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( my PRIVATE SuiteSparse::AMD )
@@ -589,6 +514,81 @@ if ( BUILD_STATIC_LIBS )
     endif ( )
 endif ( )
 
+# OpenMP:
+message ( STATUS "OpenMP C libraries:      ${OpenMP_C_LIBRARIES}" )
+message ( STATUS "OpenMP C include:        ${OpenMP_C_INCLUDE_DIRS}" )
+message ( STATUS "OpenMP C flags:          ${OpenMP_C_FLAGS}" )
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( my PRIVATE OpenMP::OpenMP_C )
+    target_link_libraries ( my_cxx PRIVATE OpenMP::OpenMP_CXX )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    target_link_libraries ( my_static PUBLIC OpenMP::OpenMP_C )
+    target_link_libraries ( my_cxx_static PUBLIC OpenMP::OpenMP_CXX )
+endif ( )
+
+# libm:
+if ( NOT WIN32 )
+    if ( BUILD_SHARED_LIBS )
+        target_link_libraries ( my PRIVATE m )
+        target_link_libraries ( my_cxx PRIVATE m )
+    endif ( )
+    if ( BUILD_STATIC_LIBS )
+        target_link_libraries ( my_static PUBLIC m )
+        target_link_libraries ( my_cxx_static PUBLIC m )
+    endif ( )
+endif ( )
+
+# BLAS:
+message ( STATUS "BLAS libraries:      ${BLAS_LIBRARIES}" )
+message ( STATUS "BLAS include:        ${BLAS_INCLUDE_DIRS}" )
+message ( STATUS "BLAS linker flags:   ${BLAS_LINKER_FLAGS}" )
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( my PRIVATE ${BLAS_LIBRARIES} )
+    target_link_libraries ( my_cxx PRIVATE ${BLAS_LIBRARIES} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    target_link_libraries ( my_static PUBLIC ${BLAS_LIBRARIES} )
+    target_link_libraries ( my_cxx_static PUBLIC ${BLAS_LIBRARIES} )
+endif ( )
+include_directories ( ${BLAS_INCLUDE_DIRS} )
+
+# LAPACK:
+message ( STATUS "LAPACK libraries:    ${LAPACK_LIBRARIES}" )
+message ( STATUS "LAPACK include:      ${LAPACK_INCLUDE_DIRS}" )
+message ( STATUS "LAPACK linker flags: ${LAPACK_LINKER_FLAGS}" )
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( my PRIVATE ${LAPACK_LIBRARIES} )
+    target_link_libraries ( my_cxx PRIVATE ${LAPACK_LIBRARIES} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    target_link_libraries ( my_static PUBLIC ${LAPACK_LIBRARIES} )
+    target_link_libraries ( my_cxx_static PUBLIC ${LAPACK_LIBRARIES} )
+endif ( )
+include_directories ( ${LAPACK_INCLUDE_DIRS} )
+
+# gmp:
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( my PRIVATE ${GMP_LIBRARIES} )
+    target_link_libraries ( my_cxx PRIVATE ${GMP_LIBRARIES} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    target_link_libraries ( my_static PUBLIC ${GMP_STATIC} )
+    target_link_libraries ( my_cxx_static PUBLIC ${GMP_STATIC} )
+endif ( )
+include_directories ( ${GMP_INCLUDE_DIR} )
+
+# mpfr:
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( my PRIVATE ${MPFR_LIBRARIES} )
+    target_link_libraries ( my_cxx PRIVATE ${MPFR_LIBRARIES} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    target_link_libraries ( my_static PUBLIC ${MPFR_STATIC} )
+    target_link_libraries ( my_cxx_static PUBLIC ${MPFR_STATIC} )
+endif ( )
+include_directories ( ${MPFR_INCLUDE_DIR} )
+
 #-------------------------------------------------------------------------------
 # installation location
 #-------------------------------------------------------------------------------
@@ -638,8 +638,8 @@ endif ( )
 # report
 #-------------------------------------------------------------------------------
 
-message ( STATUS "MY source:         ${CMAKE_SOURCE_DIR} ")
-message ( STATUS "MY build:          ${CMAKE_BINARY_DIR} ")
+message ( STATUS "MY source:         ${CMAKE_SOURCE_DIR}" )
+message ( STATUS "MY build:          ${CMAKE_BINARY_DIR}" )
 message ( STATUS "MY install prefix: ${CMAKE_INSTALL_PREFIX}" )
 message ( STATUS "MY install rpath:  ${CMAKE_INSTALL_RPATH}" )
 message ( STATUS "MY build   rpath:  ${CMAKE_BUILD_RPATH}" )

--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -223,17 +223,6 @@ if ( BUILD_STATIC_LIBS )
     endif ( )
 endif ( )
 
-# libm:
-if ( NOT WIN32 )
-    if ( BUILD_SHARED_LIBS )
-        target_link_libraries ( KLU PRIVATE m )
-    endif ( )
-    if ( BUILD_STATIC_LIBS )
-        set ( KLU_STATIC_LIBS "${KLU_STATIC_LIBS} -lm" )
-        target_link_libraries ( KLU_static PUBLIC m )
-    endif ( )
-endif ( )
-
 # AMD:
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( KLU PRIVATE SuiteSparse::AMD )
@@ -306,6 +295,17 @@ if ( NOT NCHOLMOD )
         endif ( )
     endif ( )
 
+endif ( )
+
+# libm:
+if ( NOT WIN32 )
+    if ( BUILD_SHARED_LIBS )
+        target_link_libraries ( KLU PRIVATE m )
+    endif ( )
+    if ( BUILD_STATIC_LIBS )
+        set ( KLU_STATIC_LIBS "${KLU_STATIC_LIBS} -lm" )
+        target_link_libraries ( KLU_static PUBLIC m )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -194,6 +194,30 @@ if ( BUILD_STATIC_LIBS )
     endif ( )
 endif ( )
 
+# umfpack:
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ParU PRIVATE SuiteSparse::UMFPACK )
+    target_include_directories ( ParU PUBLIC
+        "$<TARGET_PROPERTY:SuiteSparse::UMFPACK,INTERFACE_INCLUDE_DIRECTORIES>" )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET SuiteSparse::UMFPACK_static )
+        target_link_libraries ( ParU_static PUBLIC SuiteSparse::UMFPACK_static )
+    else ( )
+        target_link_libraries ( ParU_static PUBLIC SuiteSparse::UMFPACK )
+    endif ( )
+endif ( )
+
+# cholmod:
+if ( BUILD_SHARED_LIBS )
+    target_include_directories ( ParU PUBLIC
+        "$<TARGET_PROPERTY:SuiteSparse::CHOLMOD,INTERFACE_INCLUDE_DIRECTORIES>" )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    target_include_directories ( ParU_static PUBLIC
+        "$<TARGET_PROPERTY:SuiteSparse::CHOLMOD,INTERFACE_INCLUDE_DIRECTORIES>" )
+endif ( )
+
 # OpenMP:
 if ( OpenMP_CXX_FOUND )
     message ( STATUS "OpenMP C++ libraries:    ${OpenMP_CXX_LIBRARIES} ")
@@ -219,20 +243,6 @@ if ( NOT WIN32 )
     endif ( )
 endif ( )
 
-# umfpack:
-if ( BUILD_SHARED_LIBS )
-    target_link_libraries ( ParU PRIVATE SuiteSparse::UMFPACK )
-    target_include_directories ( ParU PUBLIC
-        "$<TARGET_PROPERTY:SuiteSparse::UMFPACK,INTERFACE_INCLUDE_DIRECTORIES>" )
-endif ( )
-if ( BUILD_STATIC_LIBS )
-    if ( TARGET SuiteSparse::UMFPACK_static )
-        target_link_libraries ( ParU_static PUBLIC SuiteSparse::UMFPACK_static )
-    else ( )
-        target_link_libraries ( ParU_static PUBLIC SuiteSparse::UMFPACK )
-    endif ( )
-endif ( )
-
 # BLAS:
 message ( STATUS "BLAS libraries:      ${BLAS_LIBRARIES} ")
 message ( STATUS "BLAS linker flags:   ${BLAS_LINKER_FLAGS} ")
@@ -243,16 +253,6 @@ if ( BUILD_STATIC_LIBS )
     list ( APPEND PARU_STATIC_LIBS ${BLAS_LIBRARIES} )
     target_link_libraries ( ParU_static PUBLIC ${BLAS_LIBRARIES} )
     include_directories ( ${BLAS_INCLUDE_DIRS} )
-endif ( )
-
-# cholmod:
-if ( BUILD_SHARED_LIBS )
-    target_include_directories ( ParU PUBLIC
-        "$<TARGET_PROPERTY:SuiteSparse::CHOLMOD,INTERFACE_INCLUDE_DIRECTORIES>" )
-endif ( )
-if ( BUILD_STATIC_LIBS )
-    target_include_directories ( ParU_static PUBLIC
-        "$<TARGET_PROPERTY:SuiteSparse::CHOLMOD,INTERFACE_INCLUDE_DIRECTORIES>" )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -83,8 +83,7 @@ configure_file ( "Config/SPEX_version.tex.in"
 #-------------------------------------------------------------------------------
 
 include_directories ( SPEX_Left_LU/Source SPEX_Util/Source Include 
-    SPEX_Left_LU/Demo
-    ${GMP_INCLUDE_DIR} ${MPFR_INCLUDE_DIR} )
+    SPEX_Left_LU/Demo )
 
 #-------------------------------------------------------------------------------
 # dynamic spex library properties
@@ -177,20 +176,24 @@ endif ( )
 # MPFR:
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( SPEX PRIVATE ${MPFR_LIBRARIES} )
+    target_include_directories ( SPEX PUBLIC ${MPFR_INCLUDE_DIR} )
 endif ( )
 if ( BUILD_STATIC_LIBS )
     list ( APPEND SPEX_STATIC_LIBS ${MPFR_STATIC} )
     target_link_libraries ( SPEX_static PUBLIC ${MPFR_STATIC} )
+    target_include_directories ( SPEX_static PUBLIC ${MPFR_INCLUDE_DIR} )
 endif ( )
 
 # GMP:
 # must occur after MPFR
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( SPEX PRIVATE ${GMP_LIBRARIES} )
+    target_include_directories ( SPEX PUBLIC ${GMP_INCLUDE_DIR} )
 endif ( )
 if ( BUILD_STATIC_LIBS )
     list ( APPEND SPEX_STATIC_LIBS ${GMP_STATIC} )
     target_link_libraries ( SPEX_static PUBLIC ${GMP_STATIC} )
+    target_include_directories ( SPEX_static PUBLIC ${GMP_INCLUDE_DIR} )
 endif ( )
 
 # libm:

--- a/SPQR/CMakeLists.txt
+++ b/SPQR/CMakeLists.txt
@@ -154,6 +154,34 @@ if ( BUILD_STATIC_LIBS )
     endif ( )
 endif ( )
 
+# CHOLMOD:
+# link with CHOLMOD and its dependencies
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( SPQR PRIVATE SuiteSparse::CHOLMOD )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET SuiteSparse::CHOLMOD_static )
+        target_link_libraries ( SPQR_static PUBLIC SuiteSparse::CHOLMOD_static )
+    else ( )
+        target_link_libraries ( SPQR_static PUBLIC SuiteSparse::CHOLMOD )
+    endif ( )
+endif ( )
+
+if ( SUITESPARSE_CUDA )
+    if ( BUILD_SHARED_LIBS )
+        target_link_libraries ( SPQR PRIVATE GPUQREngine GPURuntime )
+        target_compile_definitions ( SPQR PUBLIC "SUITESPARSE_CUDA" )
+    endif ( )
+    set ( SPQR_CFLAGS "-DSUITESPARSE_CUDA" )
+    if ( BUILD_STATIC_LIBS )
+        target_link_libraries ( SPQR_static PUBLIC GPUQREngine_static GPURuntime_static )
+        target_compile_definitions ( SPQR_static PUBLIC "SUITESPARSE_CUDA" )
+    endif ( )
+
+    # CUDA
+    add_subdirectory ( SPQRGPU )
+endif ( )
+
 # OpenMP:
 if ( OPENMP_FOUND )
     if ( BUILD_SHARED_LIBS )
@@ -202,34 +230,6 @@ if ( BUILD_STATIC_LIBS )
     list ( APPEND SPQR_STATIC_LIBS ${BLAS_LIBRARIES} )
     target_link_libraries ( SPQR_static PUBLIC ${BLAS_LIBRARIES} )
     target_include_directories ( SPQR_static PRIVATE ${BLAS_INCLUDE_DIRS} )
-endif ( )
-
-# CHOLMOD:
-# link with CHOLMOD and its dependencies
-if ( BUILD_SHARED_LIBS )
-    target_link_libraries ( SPQR PRIVATE SuiteSparse::CHOLMOD )
-endif ( )
-if ( BUILD_STATIC_LIBS )
-    if ( TARGET SuiteSparse::CHOLMOD_static )
-        target_link_libraries ( SPQR_static PUBLIC SuiteSparse::CHOLMOD_static )
-    else ( )
-        target_link_libraries ( SPQR_static PUBLIC SuiteSparse::CHOLMOD )
-    endif ( )
-endif ( )
-
-if ( SUITESPARSE_CUDA )
-    # CUDA
-    add_subdirectory ( SPQRGPU )
-
-    if ( BUILD_SHARED_LIBS )
-        target_link_libraries ( SPQR PRIVATE GPUQREngine GPURuntime )
-        target_compile_definitions ( SPQR PUBLIC "SUITESPARSE_CUDA" )
-    endif ( )
-    set ( SPQR_CFLAGS "-DSUITESPARSE_CUDA" )
-    if ( BUILD_STATIC_LIBS )
-        target_link_libraries ( SPQR_static PUBLIC GPUQREngine_static GPURuntime_static )
-        target_compile_definitions ( SPQR_static PUBLIC "SUITESPARSE_CUDA" )
-    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/UMFPACK/CMakeLists.txt
+++ b/UMFPACK/CMakeLists.txt
@@ -201,11 +201,41 @@ if ( BUILD_STATIC_LIBS )
     endif ( )
 endif ( )
 
+# AMD:
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( UMFPACK PRIVATE SuiteSparse::AMD )
+    target_include_directories ( UMFPACK PUBLIC
+        "$<TARGET_PROPERTY:SuiteSparse::AMD,INTERFACE_INCLUDE_DIRECTORIES>" )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET SuiteSparse::AMD_static )
+        target_link_libraries ( UMFPACK_static PUBLIC SuiteSparse::AMD_static )
+    else ( )
+        target_link_libraries ( UMFPACK_static PUBLIC SuiteSparse::AMD )
+    endif ( )
+endif ( )
+
+# CHOLMOD:
+if ( NOT NCHOLMOD )
+    # link with CHOLMOD and its dependencies, both required and optional
+    if ( BUILD_SHARED_LIBS )
+        target_link_libraries ( UMFPACK PRIVATE SuiteSparse::CHOLMOD )
+    endif ( )
+    if ( BUILD_STATIC_LIBS )
+        set ( UMFPACK_STATIC_MODULES "${UMFPACK_STATIC_MODULES} CHOLMOD" )
+        if ( TARGET SuiteSparse::CHOLMOD_static )
+            target_link_libraries ( UMFPACK_static PUBLIC SuiteSparse::CHOLMOD_static )
+        else ( )
+            target_link_libraries ( UMFPACK_static PUBLIC SuiteSparse::CHOLMOD )
+        endif ( )
+    endif ( )
+endif ( )
+
 # OpenMP:
 if ( OPENMP_FOUND )
-    message ( STATUS "OpenMP C libraries:      ${OpenMP_C_LIBRARIES} ")
-    message ( STATUS "OpenMP C include:        ${OpenMP_C_INCLUDE_DIRS} ")
-    message ( STATUS "OpenMP C flags:          ${OpenMP_C_FLAGS} ")
+    message ( STATUS "OpenMP C libraries:      ${OpenMP_C_LIBRARIES}" )
+    message ( STATUS "OpenMP C include:        ${OpenMP_C_INCLUDE_DIRS}" )
+    message ( STATUS "OpenMP C flags:          ${OpenMP_C_FLAGS}" )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( UMFPACK PRIVATE ${OpenMP_C_LIBRARIES} )
     endif ( )
@@ -228,24 +258,10 @@ if ( NOT WIN32 )
     endif ( )
 endif ( )
 
-# AMD:
-if ( BUILD_SHARED_LIBS )
-    target_link_libraries ( UMFPACK PRIVATE SuiteSparse::AMD )
-    target_include_directories ( UMFPACK PUBLIC
-        "$<TARGET_PROPERTY:SuiteSparse::AMD,INTERFACE_INCLUDE_DIRECTORIES>" )
-endif ( )
-if ( BUILD_STATIC_LIBS )
-    if ( TARGET SuiteSparse::AMD_static )
-        target_link_libraries ( UMFPACK_static PUBLIC SuiteSparse::AMD_static )
-    else ( )
-        target_link_libraries ( UMFPACK_static PUBLIC SuiteSparse::AMD )
-    endif ( )
-endif ( )
-
 # BLAS:
-message ( STATUS "BLAS libraries:      ${BLAS_LIBRARIES} ")
-message ( STATUS "BLAS include:        ${BLAS_INCLUDE_DIRS} ")
-message ( STATUS "BLAS linker flags:   ${BLAS_LINKER_FLAGS} ")
+message ( STATUS "BLAS libraries:      ${BLAS_LIBRARIES}" )
+message ( STATUS "BLAS include:        ${BLAS_INCLUDE_DIRS}" )
+message ( STATUS "BLAS linker flags:   ${BLAS_LINKER_FLAGS}" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( UMFPACK PRIVATE ${BLAS_LIBRARIES} )
 endif ( )
@@ -254,22 +270,6 @@ if ( BUILD_STATIC_LIBS )
     target_link_libraries ( UMFPACK_static PUBLIC ${BLAS_LIBRARIES} )
 endif ( )
 include_directories ( ${BLAS_INCLUDE_DIRS} )
-
-# CHOLMOD:
-if ( NOT NCHOLMOD )
-    # link with CHOLMOD and its dependencies, both required and optional
-    if ( BUILD_SHARED_LIBS )
-        target_link_libraries ( UMFPACK PRIVATE SuiteSparse::CHOLMOD )
-    endif ( )
-    if ( BUILD_STATIC_LIBS )
-        set ( UMFPACK_STATIC_MODULES "${UMFPACK_STATIC_MODULES} CHOLMOD" )
-        if ( TARGET SuiteSparse::CHOLMOD_static )
-            target_link_libraries ( UMFPACK_static PUBLIC SuiteSparse::CHOLMOD_static )
-        else ( )
-            target_link_libraries ( UMFPACK_static PUBLIC SuiteSparse::CHOLMOD )
-        endif ( )
-    endif ( )
-endif ( )
 
 #-------------------------------------------------------------------------------
 # UMFPACK installation location


### PR DESCRIPTION
Changes to the CMake build rules for KLU, ParU, SPQR, and UMFPACK that are similar to #555.

Currently, building SuiteSparse can fail if headers of older versions of the SuiteSparse libraries are installed at the same locations where the headers of other dependencies are installed (if that location is *not* one of the default include directories of the used pre-processor).
For the CHOLMOD library, it helped to change the order in which dependencies are added such that dependencies to SuiteSparse libraries are added ahead of dependencies to system libraries. So, do the same for the other libraries that have dependencies on system libraries.

(I can't reproduce the issue here. So, it would be nice if someone who can reproduce could test this.)
