### PR TITLE
GraphBLAS: Add option for relocation of libraries for JIT compiler.

### DIFF
--- a/GraphBLAS/cmake_modules/GraphBLAS_JIT_configure.cmake
+++ b/GraphBLAS/cmake_modules/GraphBLAS_JIT_configure.cmake
@@ -54,37 +54,47 @@ else ( )
 endif ( )
 
 # construct the library list
-if ( MINGW )
+if ( APPLE )
+    set ( default_jit_enable_relocate OFF )
+else ( )
+    set ( default_jit_enable_relocate ON )
+endif ( )
 
-# This might be something like:
-#   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
-# convert to -l flags to avoid relocation issues, i.e.: "-lgomp -lpthread -lm"
-set ( GB_C_LIBRARIES "" )
-foreach ( _lib ${GB_CMAKE_LIBRARIES} )
-    string ( FIND ${_lib} "." _pos REVERSE )
-    if ( ${_pos} EQUAL "-1" )
-        set ( GB_C_LIBRARIES "${GB_C_LIBRARIES} -l${_lib}" )
-        continue ()
-    endif ( )
-    set ( _kinds "SHARED" "STATIC" )
-    if ( WIN32 )
-        list ( PREPEND _kinds "IMPORT" )
-    endif ( )
-    foreach ( _kind IN LISTS _kinds )
-        set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
-        if ( ${_lib} MATCHES ${_regex} )
-            string ( REGEX REPLACE ${_regex} "\\2" _libname ${_lib} )
-            if ( NOT "${_libname}" STREQUAL "" )
-                set ( GB_C_LIBRARIES "${GB_C_LIBRARIES} -l${_libname}" )
-                break ()
-            endif ( )
+option ( GRAPHBLAS_JIT_ENABLE_RELOCATE
+    "ON: Enable relocation of libraries for JIT. OFF: Keep libraries with full path for JIT."
+    default_jit_enable_relocate )
+
+if ( GRAPHBLAS_JIT_ENABLE_RELOCATE )
+
+    # This might be something like:
+    #   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
+    # convert to -l flags to avoid relocation issues, i.e.: "-lgomp -lpthread -lm"
+    set ( GB_C_LIBRARIES "" )
+    foreach ( _lib ${GB_CMAKE_LIBRARIES} )
+        string ( FIND ${_lib} "." _pos REVERSE )
+        if ( ${_pos} EQUAL "-1" )
+            set ( GB_C_LIBRARIES "${GB_C_LIBRARIES} -l${_lib}" )
+            continue ()
         endif ( )
+        set ( _kinds "SHARED" "STATIC" )
+        if ( WIN32 )
+            list ( PREPEND _kinds "IMPORT" )
+        endif ( )
+        foreach ( _kind IN LISTS _kinds )
+            set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
+            if ( ${_lib} MATCHES ${_regex} )
+                string ( REGEX REPLACE ${_regex} "\\2" _libname ${_lib} )
+                if ( NOT "${_libname}" STREQUAL "" )
+                    set ( GB_C_LIBRARIES "${GB_C_LIBRARIES} -l${_libname}" )
+                    break ()
+                endif ( )
+            endif ( )
+        endforeach ( )
     endforeach ( )
-endforeach ( )
 
 else ( )
 
-    # original method (before MINGW changes:
+    # keep full paths to libraries
     string ( REPLACE "." "\\." LIBSUFFIX1 ${GB_LIB_SUFFIX} )
     string ( REPLACE "." "\\." LIBSUFFIX2 ${CMAKE_STATIC_LIBRARY_SUFFIX} )
     set ( GB_C_LIBRARIES "" )


### PR DESCRIPTION
This adds an option `GRAPHBLAS_JIT_ENABLE_RELOCATE` as proposed in #563.

Default to OFF on APPLE platforms, default to ON otherwise.
