### PR TITLE
CMake: Don't include folders of imported targets with `SYSTEM` property.

### DIFF
--- a/AMD/CMakeLists.txt
+++ b/AMD/CMakeLists.txt
@@ -92,6 +92,10 @@ if ( BUILD_SHARED_LIBS )
         PUBLIC_HEADER "Include/amd.h"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( AMD PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
+
     target_include_directories ( AMD
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
@@ -112,6 +116,10 @@ if ( BUILD_STATIC_LIBS )
     if ( MSVC )
         set_target_properties ( AMD_static PROPERTIES
             OUTPUT_NAME amd_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( AMD_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     target_include_directories ( AMD_static

--- a/BTF/CMakeLists.txt
+++ b/BTF/CMakeLists.txt
@@ -82,6 +82,10 @@ if ( BUILD_SHARED_LIBS )
         PUBLIC_HEADER "Include/btf.h"
         WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( BTF PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
+
     target_include_directories ( BTF
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
@@ -103,6 +107,10 @@ if ( BUILD_STATIC_LIBS )
     if ( MSVC )
         set_target_properties ( BTF_static PROPERTIES
             OUTPUT_NAME btf_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( BTF_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     target_include_directories ( BTF_static

--- a/CAMD/CMakeLists.txt
+++ b/CAMD/CMakeLists.txt
@@ -85,6 +85,10 @@ if ( BUILD_SHARED_LIBS )
         PUBLIC_HEADER "Include/camd.h"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( CAMD PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
+
     target_include_directories ( CAMD
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
@@ -106,6 +110,10 @@ if ( BUILD_STATIC_LIBS )
     if ( MSVC )
         set_target_properties ( CAMD_static PROPERTIES
             OUTPUT_NAME camd_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( CAMD_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     target_include_directories ( CAMD_static

--- a/CCOLAMD/CMakeLists.txt
+++ b/CCOLAMD/CMakeLists.txt
@@ -82,6 +82,10 @@ if ( BUILD_SHARED_LIBS )
         PUBLIC_HEADER "Include/ccolamd.h"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( CCOLAMD PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
+
     target_include_directories ( CCOLAMD
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
@@ -103,6 +107,10 @@ if ( BUILD_STATIC_LIBS )
     if ( MSVC )
         set_target_properties ( CCOLAMD_static PROPERTIES
             OUTPUT_NAME ccolamd_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( CCOLAMD_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     target_include_directories ( CCOLAMD_static

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -305,6 +305,10 @@ if ( BUILD_SHARED_LIBS )
         set_target_properties ( CHOLMOD PROPERTIES POSITION_INDEPENDENT_CODE ON )
     endif ( )
 
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( CHOLMOD PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
+
     target_include_directories ( CHOLMOD
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
@@ -331,6 +335,10 @@ if ( BUILD_STATIC_LIBS )
     if ( SUITESPARSE_CUDA )
         set_target_properties ( CHOLMOD_static PROPERTIES CUDA_SEPARABLE_COMPILATION on )
         set_target_properties ( CHOLMOD_static PROPERTIES POSITION_INDEPENDENT_CODE on )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( CHOLMOD_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     target_include_directories ( CHOLMOD_static

--- a/COLAMD/CMakeLists.txt
+++ b/COLAMD/CMakeLists.txt
@@ -82,6 +82,10 @@ if ( BUILD_SHARED_LIBS )
         PUBLIC_HEADER "Include/colamd.h"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( COLAMD PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
+
     target_include_directories ( COLAMD
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
@@ -103,6 +107,10 @@ if ( BUILD_STATIC_LIBS )
     if ( MSVC )
         set_target_properties ( COLAMD_static PROPERTIES
             OUTPUT_NAME colamd_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( COLAMD_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     target_include_directories ( COLAMD_static

--- a/CXSparse/CMakeLists.txt
+++ b/CXSparse/CMakeLists.txt
@@ -115,6 +115,10 @@ if ( BUILD_SHARED_LIBS )
         PUBLIC_HEADER "Include/cs.h"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( CXSparse PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
+
     target_include_directories ( CXSparse
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
@@ -136,6 +140,10 @@ if ( BUILD_STATIC_LIBS )
     if ( MSVC )
         set_target_properties ( CXSparse_static PROPERTIES
             OUTPUT_NAME cxsparse_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( CXSparse_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     target_include_directories ( CXSparse_static

--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -253,6 +253,10 @@ if ( BUILD_SHARED_LIBS )
         PUBLIC_HEADER "Include/GraphBLAS.h"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( GraphBLAS PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
+
     target_include_directories ( GraphBLAS
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
@@ -291,6 +295,10 @@ if ( BUILD_STATIC_LIBS )
     if ( MSVC )
         set_target_properties ( GraphBLAS_static PROPERTIES
             OUTPUT_NAME graphblas_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( GraphBLAS_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     target_include_directories ( GraphBLAS_static

--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -127,6 +127,10 @@ if ( BUILD_SHARED_LIBS )
         PUBLIC_HEADER "Include/klu.h"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( KLU PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
+
     target_include_directories ( KLU 
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
@@ -148,6 +152,10 @@ if ( BUILD_STATIC_LIBS )
     if ( MSVC )
         set_target_properties ( KLU_static PROPERTIES
             OUTPUT_NAME klu_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( KLU_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     target_include_directories ( KLU_static
@@ -174,6 +182,10 @@ if ( NOT NCHOLMOD )
             SOVERSION ${KLU_VERSION_MAJOR}
             PUBLIC_HEADER "User/klu_cholmod.h" )
 
+        if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+            set_target_properties ( KLU_CHOLMOD PROPERTIES EXPORT_NO_SYSTEM ON )
+        endif ( )
+
         target_include_directories ( KLU_CHOLMOD 
             INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                       $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
@@ -191,6 +203,10 @@ if ( NOT NCHOLMOD )
         if ( MSVC )
             set_target_properties ( KLU_CHOLMOD_static PROPERTIES
                 OUTPUT_NAME klu_cholmod_static )
+        endif ( )
+
+        if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+            set_target_properties ( KLU_CHOLMOD_static PROPERTIES EXPORT_NO_SYSTEM ON )
         endif ( )
 
         target_include_directories ( KLU_CHOLMOD_static 

--- a/LAGraph/experimental/CMakeLists.txt
+++ b/LAGraph/experimental/CMakeLists.txt
@@ -33,6 +33,11 @@ if ( BUILD_SHARED_LIBS )
         C_STANDARD 11
         PUBLIC_HEADER "include/LAGraphX.h"
         RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/dlls )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( LAGraphX PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
+
     target_link_libraries ( LAGraphX PRIVATE LAGraph GraphBLAS::GraphBLAS )
 
     target_include_directories ( LAGraphX PUBLIC
@@ -59,6 +64,10 @@ if ( BUILD_STATIC_LIBS )
     if ( MSVC )
         set_target_properties ( LAGraphX_static PROPERTIES
             OUTPUT_NAME lagraphx_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( LAGraphX_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     if ( TARGET GraphBLAS::GraphBLAS_static )

--- a/LAGraph/src/CMakeLists.txt
+++ b/LAGraph/src/CMakeLists.txt
@@ -29,7 +29,7 @@ endif ( )
 
 if ( BUILD_SHARED_LIBS )
     add_library ( LAGraph SHARED ${LAGRAPH_LIB_SOURCES} )
-    SET_TARGET_PROPERTIES ( LAGraph PROPERTIES
+    set_target_properties ( LAGraph PROPERTIES
         VERSION ${LAGraph_VERSION_MAJOR}.${LAGraph_VERSION_MINOR}.${LAGraph_VERSION_SUB}
         SOVERSION ${LAGraph_VERSION_MAJOR}
         OUTPUT_NAME lagraph
@@ -37,6 +37,11 @@ if ( BUILD_SHARED_LIBS )
         C_STANDARD 11
         PUBLIC_HEADER "include/LAGraph.h"
         RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/dlls )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( LAGraph PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
+
     target_link_libraries ( LAGraph PRIVATE GraphBLAS::GraphBLAS ${M_LIB} )
 
     target_include_directories ( LAGraph PUBLIC
@@ -64,6 +69,10 @@ if ( BUILD_STATIC_LIBS )
     if ( MSVC )
         set_target_properties ( LAGraph_static PROPERTIES
             OUTPUT_NAME lagraph_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( LAGraph_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     if ( TARGET GraphBLAS::GraphBLAS_static )

--- a/LDL/CMakeLists.txt
+++ b/LDL/CMakeLists.txt
@@ -95,6 +95,10 @@ if ( BUILD_SHARED_LIBS )
         PUBLIC_HEADER "Include/ldl.h"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( LDL PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
+
     target_include_directories ( LDL 
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
@@ -116,6 +120,10 @@ if ( BUILD_STATIC_LIBS )
     if ( MSVC )
         set_target_properties ( LDL_static PROPERTIES
             OUTPUT_NAME ldl_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( LDL_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     target_include_directories ( LDL_static 

--- a/Mongoose/CMakeLists.txt
+++ b/Mongoose/CMakeLists.txt
@@ -200,7 +200,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if ( BUILD_STATIC_LIBS )
     # Build the Mongoose library
     add_library ( Mongoose_static STATIC ${MONGOOSE_LIB_FILES} )
-#   set_property ( TARGET Mongoose_static PROPERTY POSITION_INDEPENDENT_CODE ON )
+
     set_target_properties ( Mongoose_static PROPERTIES
         OUTPUT_NAME mongoose
         PUBLIC_HEADER "Include/Mongoose.hpp" )
@@ -208,6 +208,10 @@ if ( BUILD_STATIC_LIBS )
     if ( MSVC )
         set_target_properties ( Mongoose_static PROPERTIES
             OUTPUT_NAME mongoose_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( Mongoose_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     target_include_directories ( Mongoose_static
@@ -224,12 +228,17 @@ endif ( )
 if ( BUILD_SHARED_LIBS )
     # Build the Mongoose library for dynamic linking
     add_library ( Mongoose SHARED ${MONGOOSE_LIB_FILES} )
-    set_property ( TARGET Mongoose PROPERTY POSITION_INDEPENDENT_CODE ON )
+
     set_target_properties ( Mongoose PROPERTIES
         OUTPUT_NAME mongoose
         SOVERSION ${Mongoose_VERSION_MAJOR}
         PUBLIC_HEADER "Include/Mongoose.hpp"
-        WINDOWS_EXPORT_ALL_SYMBOLS ON )
+        WINDOWS_EXPORT_ALL_SYMBOLS ON
+        POSITION_INDEPENDENT_CODE ON )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( Mongoose PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
 
     target_include_directories ( Mongoose
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -133,6 +133,10 @@ if ( BUILD_SHARED_LIBS )
         PUBLIC_HEADER "Include/ParU.hpp;Include/ParU_C.h;Include/ParU_definitions.h"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( ParU PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
+
     target_include_directories ( ParU
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
@@ -155,6 +159,10 @@ if ( BUILD_STATIC_LIBS )
     if ( MSVC )
         set_target_properties ( ParU_static PROPERTIES
             OUTPUT_NAME ParU_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( ParU_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     target_include_directories ( ParU_static
@@ -229,7 +237,7 @@ if ( OpenMP_CXX_FOUND )
     endif ( )
     if ( BUILD_STATIC_LIBS )
         list ( APPEND PARU_STATIC_LIBS ${OpenMP_CXX_LIBRARIES} )
-        target_link_libraries ( ParU_static PUBLIC OpenMP::OpenMP_CXX )
+        target_link_libraries ( ParU_static PRIVATE OpenMP::OpenMP_CXX )
     endif ( )
 endif ( )
 

--- a/RBio/CMakeLists.txt
+++ b/RBio/CMakeLists.txt
@@ -82,6 +82,10 @@ if ( BUILD_SHARED_LIBS )
         PUBLIC_HEADER "Include/RBio.h"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( RBio PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
+
     target_include_directories ( RBio 
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
@@ -103,6 +107,10 @@ if ( BUILD_STATIC_LIBS )
     if ( MSVC )
         set_target_properties ( RBio_static PROPERTIES
             OUTPUT_NAME rbio_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( RBio_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     target_include_directories ( RBio_static 

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -101,8 +101,11 @@ if ( BUILD_SHARED_LIBS )
         OUTPUT_NAME spex
         SOVERSION ${SPEX_VERSION_MAJOR}
         PUBLIC_HEADER "Include/SPEX.h"
-        WINDOWS_EXPORT_ALL_SYMBOLS ON
-        NO_SYSTEM_FROM_IMPORTED ON )
+        WINDOWS_EXPORT_ALL_SYMBOLS ON )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( SPEX PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
 
     target_include_directories ( SPEX 
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
@@ -120,12 +123,15 @@ if ( BUILD_STATIC_LIBS )
         C_STANDARD 11
         C_STANDARD_REQUIRED ON
         OUTPUT_NAME spex
-        PUBLIC_HEADER "Include/SPEX.h"
-        NO_SYSTEM_FROM_IMPORTED ON )
+        PUBLIC_HEADER "Include/SPEX.h" )
 
     if ( MSVC )
         set_target_properties ( SPEX_static PROPERTIES
             OUTPUT_NAME spex_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( SPEX_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     target_include_directories ( SPEX_static 

--- a/SPQR/CMakeLists.txt
+++ b/SPQR/CMakeLists.txt
@@ -99,6 +99,10 @@ if ( BUILD_SHARED_LIBS )
         SOVERSION ${SPQR_VERSION_MAJOR}
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( SPQR PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
+
     target_include_directories ( SPQR 
         PRIVATE Source Include
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
@@ -122,6 +126,10 @@ if ( BUILD_STATIC_LIBS )
     if ( MSVC )
         set_target_properties ( SPQR_static PROPERTIES
             OUTPUT_NAME spqr_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( SPQR_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     target_include_directories ( SPQR_static 

--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -95,8 +95,11 @@ if ( BUILD_SHARED_LIBS )
         OUTPUT_NAME suitesparseconfig
         SOVERSION ${SUITESPARSE_VERSION_MAJOR}
         PUBLIC_HEADER "SuiteSparse_config.h"
-        WINDOWS_EXPORT_ALL_SYMBOLS ON
-        EXPORT_NO_SYSTEM ON )
+        WINDOWS_EXPORT_ALL_SYMBOLS ON )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( SuiteSparseConfig PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
 
     target_include_directories ( SuiteSparseConfig
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -114,12 +117,15 @@ if ( BUILD_STATIC_LIBS )
         C_STANDARD 11
         C_STANDARD_REQUIRED ON
         OUTPUT_NAME suitesparseconfig
-        PUBLIC_HEADER "SuiteSparse_config.h"
-        EXPORT_NO_SYSTEM ON )
+        PUBLIC_HEADER "SuiteSparse_config.h" )
 
     if ( MSVC )
         set_target_properties ( SuiteSparseConfig_static PROPERTIES
             OUTPUT_NAME suitesparseconfig_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( SuiteSparseConfig_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     target_include_directories ( SuiteSparseConfig_static
@@ -148,24 +154,9 @@ if ( OpenMP_C_FOUND )
     message ( STATUS "OpenMP C flags:          ${OpenMP_C_FLAGS} ")
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( SuiteSparseConfig PRIVATE OpenMP::OpenMP_C )
-#----
-# old:
-#       target_include_directories ( SuiteSparseConfig PUBLIC
-#           "$<TARGET_PROPERTY:OpenMP::OpenMP_C,INTERFACE_INCLUDE_DIRECTORIES>" )
-# new:
-        target_include_directories ( SuiteSparseConfig SYSTEM AFTER PUBLIC
-            "$<TARGET_PROPERTY:OpenMP::OpenMP_C,INTERFACE_INCLUDE_DIRECTORIES>" )
-#----
     endif ( )
     if ( BUILD_STATIC_LIBS )
-#----
-# old:
-#       target_link_libraries ( SuiteSparseConfig_static PUBLIC OpenMP::OpenMP_C )
         target_link_libraries ( SuiteSparseConfig_static PRIVATE OpenMP::OpenMP_C )
-        target_include_directories ( SuiteSparseConfig_static SYSTEM AFTER PUBLIC
-            "$<TARGET_PROPERTY:OpenMP::OpenMP_C,INTERFACE_INCLUDE_DIRECTORIES>" )
-# new
-#----
     endif ( )
 endif ( )
 

--- a/SuiteSparse_config/Config/SuiteSparse_configConfig.cmake.in
+++ b/SuiteSparse_config/Config/SuiteSparse_configConfig.cmake.in
@@ -55,6 +55,17 @@ endif ( )
 
 include ( ${CMAKE_CURRENT_LIST_DIR}/SuiteSparse_configTargets.cmake )
 
+if ( NOT @NOPENMP@ )
+    if ( TARGET SuiteSparse::SuiteSparseConfig )
+        target_include_directories ( SuiteSparse::SuiteSparseConfig SYSTEM AFTER INTERFACE
+            "$<TARGET_PROPERTY:OpenMP::OpenMP_C,INTERFACE_INCLUDE_DIRECTORIES>" )
+    endif ( )
+    if ( TARGET SuiteSparse::SuiteSparseConfig_static )
+        target_include_directories ( SuiteSparse::SuiteSparseConfig_static SYSTEM AFTER INTERFACE
+            "$<TARGET_PROPERTY:OpenMP::OpenMP_C,INTERFACE_INCLUDE_DIRECTORIES>" )
+    endif ( )
+endif ( )
+
 # The following is only for backward compatibility with FindSuiteSparse_config.
 
 set ( _target_shared SuiteSparse::SuiteSparseConfig )

--- a/UMFPACK/CMakeLists.txt
+++ b/UMFPACK/CMakeLists.txt
@@ -119,6 +119,10 @@ if ( BUILD_SHARED_LIBS )
         PUBLIC_HEADER "Include/umfpack.h"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( UMFPACK PROPERTIES EXPORT_NO_SYSTEM ON )
+    endif ( )
+
     target_include_directories ( UMFPACK 
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
@@ -140,6 +144,10 @@ if ( BUILD_STATIC_LIBS )
     if ( MSVC )
         set_target_properties ( UMFPACK_static PROPERTIES
             OUTPUT_NAME umfpack_static )
+    endif ( )
+
+    if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
+        set_target_properties ( UMFPACK_static PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
     target_include_directories ( UMFPACK_static 


### PR DESCRIPTION
Use `SYSTEM` explicitly only for the directory with OpenMP headers needed by SuiteSparse_config.

Might help for the issue discussed in #565.

@DrTimothyAldenDavis: Does it still build with this change? (With your OpenMP, and with SuiteSparse installed from Homebrew.)

Could you please show a compiler command for an object of SPEX when using the top-level Makefile (i.e., `make` in the root directory)?
