### PR TITLE
SuiteSparse_config: Include OpenMP include directory late when using root CMakeLists.txt

### DIFF
--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -154,9 +154,13 @@ if ( OpenMP_C_FOUND )
     message ( STATUS "OpenMP C flags:          ${OpenMP_C_FLAGS} ")
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( SuiteSparseConfig PRIVATE OpenMP::OpenMP_C )
+        target_include_directories ( SuiteSparseConfig SYSTEM AFTER INTERFACE
+            "$<TARGET_PROPERTY:OpenMP::OpenMP_C,INTERFACE_INCLUDE_DIRECTORIES>" )
     endif ( )
     if ( BUILD_STATIC_LIBS )
         target_link_libraries ( SuiteSparseConfig_static PRIVATE OpenMP::OpenMP_C )
+        target_include_directories ( SuiteSparseConfig_static SYSTEM AFTER INTERFACE
+            "$<TARGET_PROPERTY:OpenMP::OpenMP_C,INTERFACE_INCLUDE_DIRECTORIES>" )
     endif ( )
 endif ( )
 


### PR DESCRIPTION
Fix part missing from #569.