### PR TITLE
Mongoose: Fix ctests with MSVC

### DIFF
--- a/Mongoose/CMakeLists.txt
+++ b/Mongoose/CMakeLists.txt
@@ -298,14 +298,7 @@ endif ( )
 enable_testing ( )
 set ( TESTING_OUTPUT_PATH ${PROJECT_BINARY_DIR}/tests )
 
-if ( Python_Interpreter_FOUND AND (NOT MSVC) )
-    # MSVC has python, but it cannot download matrices from
-    # https://sparse.tamu.edu, probably because of a strict https policy.  The
-    # matrices are linked to from an https but provided by an AWS http backend.
-    # It complains about the ssl certificate.  So disable these tests when
-    # using MSVC.  Linux, Mac, and MINGW on Windows has no trouble with
-    # downloading matrices from sparse.tamu.edu.
-
+if ( Python_Interpreter_FOUND )
     # I/O Tests
     add_executable ( mongoose_test_io
         Tests/Mongoose_Test_IO.cpp
@@ -495,7 +488,7 @@ set_target_properties ( Mongoose_static_dbg PROPERTIES
     LINK_FLAGS "${CMAKE_EXE_LINKER_FLAGS_DEBUG}" )
 
 # Add debug compile/linker flags
-if ( Python_Interpreter_FOUND AND (NOT MSVC) )
+if ( Python_Interpreter_FOUND )
     set_target_properties ( mongoose_test_io mongoose_test_memory
         mongoose_test_edgesep PROPERTIES
         COMPILE_FLAGS "${CMAKE_CXX_FLAGS_DEBUG}"

--- a/Mongoose/Tests/runTests
+++ b/Mongoose/Tests/runTests
@@ -89,11 +89,18 @@ def runTests(args):
                             print(matrix_files)
                         else:
                             # Download matrix if it doesn't exist
-                            print("Downloading " + matrix_name)
-                            url = "https://sparse.tamu.edu/MM/" + matrix_name
-                            print("url: " + url)
-                            with urllib.request.urlopen(url) as response, open(gzip_path, 'wb') as out_file:
-                                shutil.copyfileobj(response, out_file)
+                            try:
+                                print("Downloading " + matrix_name)
+                                url = "https://sparse.tamu.edu/MM/" + matrix_name
+                                print("url: " + url)
+                                with urllib.request.urlopen(url) as response, open(gzip_path, 'wb') as out_file:
+                                    shutil.copyfileobj(response, out_file)
+                            except:
+                                print("Downloading " + matrix_name + "via HTTPS failed. Falling back to HTTP...")
+                                url = "http://sparse.tamu.edu/MM/" + matrix_name
+                                print("url: " + url)
+                                with urllib.request.urlopen(url) as response, open(gzip_path, 'wb') as out_file:
+                                    shutil.copyfileobj(response, out_file)
                             tar = tarfile.open(gzip_path, mode='r:gz')
                             tar.extractall(path=matrix_dir) # Extract the matrix from the tar.gz file
                             tar.close()

--- a/Mongoose/Tests/runTests
+++ b/Mongoose/Tests/runTests
@@ -342,15 +342,25 @@ def checkLocation_source_dir():
 #-------------------------------------------------------------------------------
 
 def checkLocation_tests_dir():
+    tests_dir = ""
     tests_dir1 = "./tests/"
     tests_dir2 = "../Mongoose/tests/"
-    if (os.path.isdir(tests_dir1)):
-        # built in SuiteSparse/Mongoose/build (stand-alone)
-        tests_dir = tests_dir1
-    elif (os.path.isdir(tests_dir2)):
-        # built in SuiteSparse/build (via the root SuiteSparse/CMakeLists.txt)
-        tests_dir = tests_dir2
-    else:
+    # List of multi-config configurations (e.g., for MSVC)
+    # FIXME: Add more multi-config configurations to list?
+    # FIXME: Instead of blindly looking for existing directories, check which
+    #        configuration was selected in ctest flag. E.g., `ctest -C Release`
+    config_dirs = ["Release/", "Debug/", ""]
+    for config_dir in config_dirs:
+        print("checking for: " + tests_dir1 + config_dir)
+        if (os.path.isdir(tests_dir1 + config_dir)):
+            # built in SuiteSparse/Mongoose/build (stand-alone)
+            tests_dir = tests_dir1 + config_dir
+            break
+        elif (os.path.isdir(tests_dir2 + config_dir)):
+            # built in SuiteSparse/build (via the root SuiteSparse/CMakeLists.txt)
+            tests_dir = tests_dir2 + config_dir
+            break
+    if not tests_dir:
         print(
             "\n\033[91mERROR!\033[0m Looks like you might not be running this from "
             "your build directory.\n\n"


### PR DESCRIPTION
Should be fixing the remaining issue described in #571.

This is not a perfect solution and I left a FIXME note describing the shortcomings. But it should be good enough to have the ctests be running in the CI.

