### PR TITLE
GraphBLAS: Run `cmake` in POSIX shell for MinGW environments.

### DIFF
--- a/GraphBLAS/Source/GB_jitifyer.c
+++ b/GraphBLAS/Source/GB_jitifyer.c
@@ -2213,9 +2213,15 @@ void GB_jitifyer_cmake_compile (char *kernel_name, uint64_t hash)
     char *burble_stdout = GB_Global_burble_get ( ) ? "" : GB_DEV_NULL ;
     char *err_redirect = (strlen (GB_jit_error_log) > 0) ? " 2>> " : "" ;
 
+#if defined (__MINGW32__)
+#define GB_SH_C "sh -c "
+#else
+#define GB_SH_C
+#endif
+
     // remove any prior build folder for this kernel, and all its contents
     snprintf (GB_jit_temp, GB_jit_temp_allocated,
-        "cmake -E remove_directory \"" GB_BLD_DIR "\" %s %s %s",
+        GB_SH_C "cmake -E remove_directory \"" GB_BLD_DIR "\" %s %s %s",
         GB_jit_cache_path, hash,     // build path
         burble_stdout, err_redirect, GB_jit_error_log) ;
     GB_jitifyer_command (GB_jit_temp) ; // OK: see security comment above
@@ -2273,7 +2279,7 @@ void GB_jitifyer_cmake_compile (char *kernel_name, uint64_t hash)
 
     // generate the build system for this kernel
     snprintf (GB_jit_temp, GB_jit_temp_allocated,
-        "cmake -S \"" GB_BLD_DIR "\" -B \"" GB_BLD_DIR "\""
+        GB_SH_C "cmake -S \"" GB_BLD_DIR "\" -B \"" GB_BLD_DIR "\""
         " -DCMAKE_C_COMPILER=\"%s\" %s %s %s",
         GB_jit_cache_path, hash,     // -S source path
         GB_jit_cache_path, hash,     // -B build path
@@ -2283,7 +2289,7 @@ void GB_jitifyer_cmake_compile (char *kernel_name, uint64_t hash)
 
     // compile the library for this kernel
     snprintf (GB_jit_temp, GB_jit_temp_allocated,
-        "cmake --build \"" GB_BLD_DIR "\" --config Release %s %s %s",
+        GB_SH_C "cmake --build \"" GB_BLD_DIR "\" --config Release %s %s %s",
         // can add "--verbose" here too
         GB_jit_cache_path, hash,     // build path
         burble_stdout, err_redirect, GB_jit_error_log) ;
@@ -2291,14 +2297,14 @@ void GB_jitifyer_cmake_compile (char *kernel_name, uint64_t hash)
 
     // install the library
     snprintf (GB_jit_temp, GB_jit_temp_allocated,
-        "cmake --install \"" GB_BLD_DIR "\" %s %s %s",
+        GB_SH_C "cmake --install \"" GB_BLD_DIR "\" %s %s %s",
         GB_jit_cache_path, hash,     // build path
         burble_stdout, err_redirect, GB_jit_error_log) ;
     GB_jitifyer_command (GB_jit_temp) ; // OK: see security comment above
 
     // remove the build folder and all its contents
     snprintf (GB_jit_temp, GB_jit_temp_allocated,
-        "cmake -E remove_directory \"" GB_BLD_DIR "\" %s %s %s",
+        GB_SH_C "cmake -E remove_directory \"" GB_BLD_DIR "\" %s %s %s",
         GB_jit_cache_path, hash,     // build path
         burble_stdout, err_redirect, GB_jit_error_log) ;
     GB_jitifyer_command (GB_jit_temp) ; // OK: see security comment above


### PR DESCRIPTION
Running the GraphBLAS demo `demo_gauss` still fails for the MinGW runners with this change. But I don't claim to understand what it actually checks...

See also #572.