### PR TITLE
Fix typos in CMake variable `OpenMP_C_FOUND`.

### DIFF
--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -42,8 +42,8 @@ if ( NOT BUILD_SHARED_LIBS )
 endif ( )
 
 # CUDA is under development for now, and not deployed in production:
-  set ( ENABLE_CUDA false )
-# set ( ENABLE_CUDA true )
+set ( ENABLE_CUDA OFF )
+# set ( ENABLE_CUDA ON )
 
 include ( SuiteSparsePolicy )
 
@@ -88,7 +88,7 @@ endif ( )
 option ( NOPENMP "ON: do not use OpenMP.  OFF (default): use OpenMP" off )
 if ( NOPENMP )
     # OpenMP has been disabled.
-    set ( OPENMP_FOUND false )
+    set ( OpenMP_C_FOUND OFF )
 else ( )
     find_package ( OpenMP )
 endif ( )
@@ -403,7 +403,7 @@ endif ( )
 # add the OpenMP, IPP, CUDA, BLAS, etc libraries
 #-------------------------------------------------------------------------------
 
-if ( OPENMP_FOUND )
+if ( OpenMP_C_FOUND )
     message ( STATUS "CMAKE OpenMP libraries:    ${OpenMP_C_LIBRARIES}" )
     message ( STATUS "CMAKE OpenMP include:      ${OpenMP_C_INCLUDE_DIRS}" )
     # revert to ${OpenMP_C_LIBRARIES}:
@@ -534,7 +534,7 @@ if ( DEMO )
     target_link_libraries ( context_demo PUBLIC ${GB_M} ${GB_CUDA} ${GB_RMM} )
     target_link_libraries ( gauss_demo PUBLIC ${GB_M} ${GB_CUDA} ${GB_RMM} )
 
-    if ( OPENMP_C_FOUND )
+    if ( OpenMP_C_FOUND )
         target_link_libraries ( openmp_demo PUBLIC OpenMP::OpenMP_C )
         target_link_libraries ( openmp2_demo PUBLIC OpenMP::OpenMP_C )
         target_link_libraries ( reduce_demo PUBLIC OpenMP::OpenMP_C )

--- a/GraphBLAS/CUDA/CMakeLists.txt
+++ b/GraphBLAS/CUDA/CMakeLists.txt
@@ -81,7 +81,7 @@ endif ( )
 
 target_compile_definitions ( GraphBLAS_CUDA PUBLIC "SUITESPARSE_CUDA" )
 
-if ( OPENMP_CXX_FOUND )
+if ( OpenMP_CXX_FOUND )
     target_include_directories ( GraphBLAS_CUDA PRIVATE OpenMP::OpenMP_CXX )
 endif ( )
 

--- a/GraphBLAS/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/GraphBLAS/CMakeLists.txt
@@ -27,7 +27,7 @@ include ( GraphBLAS_version )
 set ( SUITESPARSE_SECOND_LEVEL true )
 
 # CUDA is under development for now, and not deployed in production:
-set ( SUITESPARSE_CUDA off )
+set ( SUITESPARSE_CUDA OFF )
 
 set ( GBMATLAB on )
 set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -DGBMATLAB=1 " )
@@ -46,10 +46,10 @@ project ( graphblas_matlab
 # find OpenMP and cpu_features
 #-------------------------------------------------------------------------------
 
-option ( NOPENMP "ON: do not use OpenMP.  OFF (default): use OpenMP" off )
+option ( NOPENMP "ON: do not use OpenMP.  OFF (default): use OpenMP" OFF )
 if ( NOPENMP )
     # OpenMP has been disabled
-    set ( OPENMP_FOUND false )
+    set ( OpenMP_C_FOUND OFF )
 else ( )
     find_package ( OpenMP )
 endif ( )
@@ -104,7 +104,7 @@ else ( )
 endif ( )
 
 message ( STATUS "C compiler:                 ${CMAKE_C_COMPILER} ")
-message ( STATUS "CMAKE have OpenMP:          ${OPENMP_FOUND}" )
+message ( STATUS "CMAKE have OpenMP:          ${OpenMP_C_FOUND}" )
 
 #-------------------------------------------------------------------------------
 # include directories
@@ -170,7 +170,7 @@ set_target_properties ( graphblas_matlab PROPERTIES
 # select the threading library
 #-------------------------------------------------------------------------------
 
-if ( OPENMP_FOUND )
+if ( OpenMP_C_FOUND )
     set ( USE_OPENMP true )
 endif ( )
 

--- a/GraphBLAS/cmake_modules/GraphBLAS_JIT_configure.cmake
+++ b/GraphBLAS/cmake_modules/GraphBLAS_JIT_configure.cmake
@@ -44,7 +44,7 @@ endif ( )
 string ( REPLACE "\"" "\\\"" GB_C_FLAGS ${GB_C_FLAGS} )
 
 # construct the -I list for OpenMP
-if ( OPENMP_FOUND )
+if ( OpenMP_C_FOUND )
     set ( GB_OMP_INC_DIRS ${OpenMP_C_INCLUDE_DIRS} )
     set ( GB_OMP_INC ${OpenMP_C_INCLUDE_DIRS} )
     list ( TRANSFORM GB_OMP_INC PREPEND " -I" )

--- a/LAGraph/experimental/test/CMakeLists.txt
+++ b/LAGraph/experimental/test/CMakeLists.txt
@@ -74,7 +74,7 @@ endif ( )
 # add OpenMP
 #-------------------------------------------------------------------------------
 
-if ( OPENMP_C_FOUND )
+if ( OpenMP_C_FOUND )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( lagraphxtest PRIVATE OpenMP::OpenMP_C )
     endif ( )

--- a/LAGraph/src/test/CMakeLists.txt
+++ b/LAGraph/src/test/CMakeLists.txt
@@ -76,7 +76,7 @@ endif ( )
 # add OpenMP
 #-------------------------------------------------------------------------------
 
-if ( OPENMP_C_FOUND )
+if ( OpenMP_C_FOUND )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( lagraphtest PRIVATE OpenMP::OpenMP_C )
     endif ( )


### PR DESCRIPTION
CMake variables are case-sensitive.
This fixes a couple of typos and inconsistencies when it comes to the CMake variable `OpenMP_C_FOUND` (and other similar ones).
