### PR TITLE
CMake: Account for changes to library base names by CMake flags

### DIFF
--- a/AMD/CMakeLists.txt
+++ b/AMD/CMakeLists.txt
@@ -230,10 +230,19 @@ if ( NOT MSVC )
     else ( )
         set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
     endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:AMD> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:AMD_static> )
+    endif ( )
     configure_file (
         Config/AMD.pc.in
-        AMD.pc
+        AMD.pc.out
         @ONLY
+        NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT AMD.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/AMD.pc.out
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/AMD.pc

--- a/AMD/Config/AMD.pc.in
+++ b/AMD/Config/AMD.pc.in
@@ -12,6 +12,6 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Routines for permuting sparse matrices prior to factorization in SuiteSparse
 Version: @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@.@AMD_VERSION_SUB@
 Requires.private: SuiteSparse_config
-Libs: -L${libdir} -lamd@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Libs.private: @AMD_STATIC_LIBS@
 Cflags: -I${includedir}

--- a/BTF/CMakeLists.txt
+++ b/BTF/CMakeLists.txt
@@ -216,10 +216,19 @@ if ( NOT MSVC )
     else ( )
         set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
     endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:BTF> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:BTF_static> )
+    endif ( )
     configure_file (
         Config/BTF.pc.in
-        BTF.pc
+        BTF.pc.out
         @ONLY
+        NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT BTF.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/BTF.pc.out
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/BTF.pc

--- a/BTF/Config/BTF.pc.in
+++ b/BTF/Config/BTF.pc.in
@@ -11,6 +11,6 @@ Name: BTF
 URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Software package for permuting a matrix into block upper triangular form in SuiteSparse
 Version: @BTF_VERSION_MAJOR@.@BTF_VERSION_MINOR@.@BTF_VERSION_SUB@
-Libs: -L${libdir} -lbtf@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Libs.private: @BTF_STATIC_LIBS@
 Cflags: -I${includedir}

--- a/CAMD/CMakeLists.txt
+++ b/CAMD/CMakeLists.txt
@@ -222,10 +222,19 @@ if ( NOT MSVC )
     else ( )
         set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
     endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:CAMD> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:CAMD_static> )
+    endif ( )
     configure_file (
         Config/CAMD.pc.in
-        CAMD.pc
+        CAMD.pc.out
         @ONLY
+        NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT CAMD.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/CAMD.pc.out
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/CAMD.pc

--- a/CAMD/Config/CAMD.pc.in
+++ b/CAMD/Config/CAMD.pc.in
@@ -12,6 +12,6 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Routines for permuting sparse matrices prior to factorization in SuiteSparse
 Version: @CAMD_VERSION_MAJOR@.@CAMD_VERSION_MINOR@.@CAMD_VERSION_SUB@
 Requires.private: SuiteSparse_config
-Libs: -L${libdir} -lcamd@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Libs.private: @CAMD_STATIC_LIBS@
 Cflags: -I${includedir}

--- a/CCOLAMD/CMakeLists.txt
+++ b/CCOLAMD/CMakeLists.txt
@@ -219,10 +219,19 @@ if ( NOT MSVC )
     else ( )
         set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
     endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:CCOLAMD> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:CCOLAMD_static> )
+    endif ( )
     configure_file (
         Config/CCOLAMD.pc.in
-        CCOLAMD.pc
+        CCOLAMD.pc.out
         @ONLY
+        NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT CCOLAMD.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/CCOLAMD.pc.out
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/CCOLAMD.pc

--- a/CCOLAMD/Config/CCOLAMD.pc.in
+++ b/CCOLAMD/Config/CCOLAMD.pc.in
@@ -12,6 +12,6 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Routines for column approximate minimum degree ordering algorithm in SuiteSparse
 Version: @CCOLAMD_VERSION_MAJOR@.@CCOLAMD_VERSION_MINOR@.@CCOLAMD_VERSION_SUB@
 Requires.private: SuiteSparse_config
-Libs: -L${libdir} -lccolamd@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Libs.private: @CCOLAMD_STATIC_LIBS@
 Cflags: -I${includedir}

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -628,10 +628,19 @@ if ( NOT MSVC )
     else ( )
         set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
     endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:CHOLMOD> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:CHOLMOD_static> )
+    endif ( )
     configure_file (
         Config/CHOLMOD.pc.in
-        CHOLMOD.pc
+        CHOLMOD.pc.out
         @ONLY
+        NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT CHOLMOD.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/CHOLMOD.pc.out
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/CHOLMOD.pc

--- a/CHOLMOD/Config/CHOLMOD.pc.in
+++ b/CHOLMOD/Config/CHOLMOD.pc.in
@@ -14,6 +14,6 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Routines for factorizing sparse symmetric positive definite matrices in SuiteSparse
 Version: @CHOLMOD_VERSION_MAJOR@.@CHOLMOD_VERSION_MINOR@.@CHOLMOD_VERSION_SUB@
 Requires.private: SuiteSparse_config AMD COLAMD @CHOLMOD_STATIC_MODULES@
-Libs: -L${libdir} -lcholmod@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Libs.private: @CHOLMOD_STATIC_LIBS@
 Cflags: -I${includedir} @CHOLMOD_CFLAGS@

--- a/COLAMD/CMakeLists.txt
+++ b/COLAMD/CMakeLists.txt
@@ -219,11 +219,20 @@ if ( NOT MSVC )
   else ( )
       set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
   endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:COLAMD> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:COLAMD_static> )
+    endif ( )
   configure_file (
       Config/COLAMD.pc.in
-      COLAMD.pc
+      COLAMD.pc.out
       @ONLY
       NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT COLAMD.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/COLAMD.pc.out
+        NEWLINE_STYLE LF )
   install ( FILES
       ${CMAKE_CURRENT_BINARY_DIR}/COLAMD.pc
       DESTINATION ${SUITESPARSE_PKGFILEDIR}/pkgconfig )

--- a/COLAMD/Config/COLAMD.pc.in
+++ b/COLAMD/Config/COLAMD.pc.in
@@ -12,6 +12,6 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Routines for column approximate minimum degree ordering algorithm in SuiteSparse
 Version: @COLAMD_VERSION_MAJOR@.@COLAMD_VERSION_MINOR@.@COLAMD_VERSION_SUB@
 Requires.private: SuiteSparse_config
-Libs: -L${libdir} -lcolamd@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Libs.private: @COLAMD_STATIC_LIBS@
 Cflags: -I${includedir}

--- a/CXSparse/CMakeLists.txt
+++ b/CXSparse/CMakeLists.txt
@@ -254,10 +254,19 @@ if ( NOT MSVC )
     else ( )
         set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
     endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:CXSparse> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:CXSparse_static> )
+    endif ( )
     configure_file (
         Config/CXSparse.pc.in
-        CXSparse.pc
+        CXSparse.pc.out
         @ONLY
+        NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT CXSparse.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/CXSparse.pc.out
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/CXSparse.pc

--- a/CXSparse/Config/CXSparse.pc.in
+++ b/CXSparse/Config/CXSparse.pc.in
@@ -12,6 +12,6 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Direct methods for sparse linear systems for real and complex matrices in SuiteSparse
 Version: @CXSPARSE_VERSION_MAJOR@.@CXSPARSE_VERSION_MINOR@.@CXSPARSE_VERSION_SUB@
 Requires.private: SuiteSparse_config
-Libs: -L${libdir} -lcxsparse@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Libs.private: @CXSPARSE_STATIC_LIBS@
 Cflags: -I${includedir}

--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -649,10 +649,19 @@ if ( NOT MSVC )
     else ( )
         set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
     endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:GraphBLAS> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:GraphBLAS_static> )
+    endif ( )
     configure_file (
         Config/GraphBLAS.pc.in
-        GraphBLAS.pc
+        GraphBLAS.pc.out
         @ONLY
+        NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT GraphBLAS.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/GraphBLAS.pc.out
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/GraphBLAS.pc

--- a/GraphBLAS/Config/GraphBLAS.pc.in
+++ b/GraphBLAS/Config/GraphBLAS.pc.in
@@ -14,7 +14,7 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Complete implementation of the GraphBLAS standard in SuiteSparse
 Version: @GraphBLAS_VERSION_MAJOR@.@GraphBLAS_VERSION_MINOR@.@GraphBLAS_VERSION_SUB@
 Requires.private: @GRAPHBLAS_STATIC_MODULES@
-Libs: -L${libdir} -lgraphblas@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Libs.private: @GRAPHBLAS_STATIC_LIBS@
 Cflags: -I${includedir}
 Cflags.private: -DGB_STATIC

--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -391,10 +391,19 @@ if ( NOT MSVC )
     else ( )
         set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
     endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:KLU> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:KLU_static> )
+    endif ( )
     configure_file (
         Config/KLU.pc.in
-        KLU.pc
+        KLU.pc.out
         @ONLY
+        NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT KLU.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/KLU.pc.out
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/KLU.pc
@@ -473,10 +482,19 @@ if ( NOT NCHOLMOD )
         else ( )
             set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
         endif ( )
+        if ( BUILD_SHARED_LIBS )
+            set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:KLU_CHOLMOD> )
+        else ( )
+            set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:KLU_CHOLMOD_static> )
+        endif ( )
         configure_file (
             Config/KLU_CHOLMOD.pc.in
-            KLU_CHOLMOD.pc
+            KLU_CHOLMOD.pc.out
             @ONLY
+            NEWLINE_STYLE LF )
+        file ( GENERATE
+            OUTPUT KLU_CHOLMOD.pc
+            INPUT ${CMAKE_CURRENT_BINARY_DIR}/KLU_CHOLMOD.pc.out
             NEWLINE_STYLE LF )
         install ( FILES
             ${CMAKE_CURRENT_BINARY_DIR}/KLU_CHOLMOD.pc

--- a/KLU/Config/KLU.pc.in
+++ b/KLU/Config/KLU.pc.in
@@ -12,6 +12,6 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Routines for solving sparse linear systems of equations in SuiteSparse
 Version: @KLU_VERSION_MAJOR@.@KLU_VERSION_MINOR@.@KLU_VERSION_SUB@
 Requires.private: SuiteSparse_config AMD COLAMD BTF @KLU_STATIC_MODULES@
-Libs: -L${libdir} -lklu@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Libs.private: @KLU_STATIC_LIBS@
 Cflags: -I${includedir}

--- a/KLU/Config/KLU_CHOLMOD.pc.in
+++ b/KLU/Config/KLU_CHOLMOD.pc.in
@@ -12,5 +12,5 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Routines for sample ordering for KLU in SuiteSparse
 Version: @KLU_VERSION_MAJOR@.@KLU_VERSION_MINOR@.@KLU_VERSION_SUB@
 Requires.private: KLU BTF CHOLMOD
-Libs: -L${libdir} -lklu_cholmod@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Cflags: -I${includedir}

--- a/LAGraph/CMakeLists.txt
+++ b/LAGraph/CMakeLists.txt
@@ -341,7 +341,6 @@ if ( NOT MSVC )
         if ( NOT WIN32 )
             list ( APPEND LAGRAPH_STATIC_LIBS "m" )
         endif ( )
-        list ( APPEND LAGRAPH_STATIC_LIBS ${GRAPHBLAS_LIBRARY} )
     endif ( )
     # This might be something like:
     #   /usr/lib/libgomp.so;/usr/lib/libpthread.a;m
@@ -369,6 +368,9 @@ if ( NOT MSVC )
             endif ( )
         endforeach ( )
     endforeach ( )
+    if ( BUILD_STATIC_LIBS )
+        set ( LAGRAPH_STATIC_LIBS "-l$<TARGET_FILE_BASE_NAME:GraphBLAS::GraphBLAS> ${LAGRAPH_STATIC_LIBS}" )
+    endif ( )
 
     set ( prefix "${CMAKE_INSTALL_PREFIX}" )
     set ( exec_prefix "\${prefix}" )

--- a/LAGraph/CMakeLists.txt
+++ b/LAGraph/CMakeLists.txt
@@ -384,10 +384,19 @@ if ( NOT MSVC )
     else ( )
         set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
     endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:LAGraph> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:LAGraph_static> )
+    endif ( )
     configure_file (
         config/LAGraph.pc.in
-        LAGraph.pc
+        LAGraph.pc.out
         @ONLY
+        NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT LAGraph.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/LAGraph.pc.out
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/LAGraph.pc

--- a/LAGraph/cmake_modules/FindGraphBLAS.cmake
+++ b/LAGraph/cmake_modules/FindGraphBLAS.cmake
@@ -340,15 +340,68 @@ endif ( )
 
 if ( GRAPHBLAS_LIBRARY )
     message ( STATUS "Create target GraphBLAS::GraphBLAS" )
+    # Get library name from filename of library
+    # This might be something like:
+    #   /usr/lib/libgraphblas.so or /usr/lib/libgraphblas.a or graphblas64
+    # convert to library name that can be used with -l flags for pkg-config
+    set ( GRAPHBLAS_LIBRARY_TMP ${GRAPHBLAS_LIBRARY} )
+    string ( FIND ${GRAPHBLAS_LIBRARY} "." _pos REVERSE )
+    if ( ${_pos} EQUAL "-1" )
+        set ( _graphblas_library_name ${GRAPHBLAS_LIBRARY} )
+    else ( )
+      set ( _kinds "SHARED" "STATIC" )
+      if ( WIN32 )
+          list ( PREPEND _kinds "IMPORT" )
+      endif ( )
+      foreach ( _kind IN LISTS _kinds )
+          set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
+          if ( ${GRAPHBLAS_LIBRARY} MATCHES ${_regex} )
+              string ( REGEX REPLACE ${_regex} "\\2" _libname ${GRAPHBLAS_LIBRARY} )
+              if ( NOT "${_libname}" STREQUAL "" )
+                  set ( _graphblas_library_name ${_libname} )
+                  break ()
+              endif ( )
+          endif ( )
+      endforeach ( )
+    endif ( )
+
     add_library ( GraphBLAS::GraphBLAS UNKNOWN IMPORTED )
     set_target_properties ( GraphBLAS::GraphBLAS PROPERTIES
         IMPORTED_LOCATION "${GRAPHBLAS_LIBRARY}"
-        INTERFACE_INCLUDE_DIRECTORIES "${GRAPHBLAS_INCLUDE_DIR}" )
+        INTERFACE_INCLUDE_DIRECTORIES "${GRAPHBLAS_INCLUDE_DIR}"
+        OUTPUT_NAME ${_graphblas_library_name} )
 endif ( )
+
 if ( GRAPHBLAS_STATIC )
     message ( STATUS "Create target GraphBLAS::GraphBLAS_static" )
+    # Get library name from filename of library
+    # This might be something like:
+    #   /usr/lib/libgraphblas.so or /usr/lib/libgraphblas.a or graphblas64
+    # convert to library name that can be used with -l flags for pkg-config
+    set ( GRAPHBLAS_LIBRARY_TMP ${GRAPHBLAS_STATIC} )
+    string ( FIND ${GRAPHBLAS_STATIC} "." _pos REVERSE )
+    if ( ${_pos} EQUAL "-1" )
+        set ( _graphblas_library_name ${GRAPHBLAS_STATIC} )
+    else ( )
+      set ( _kinds "SHARED" "STATIC" )
+      if ( WIN32 )
+          list ( PREPEND _kinds "IMPORT" )
+      endif ( )
+      foreach ( _kind IN LISTS _kinds )
+          set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
+          if ( ${GRAPHBLAS_STATIC} MATCHES ${_regex} )
+              string ( REGEX REPLACE ${_regex} "\\2" _libname ${GRAPHBLAS_STATIC} )
+              if ( NOT "${_libname}" STREQUAL "" )
+                  set ( _graphblas_library_name ${_libname} )
+                  break ()
+              endif ( )
+          endif ( )
+      endforeach ( )
+    endif ( )
+
     add_library ( GraphBLAS::GraphBLAS_static UNKNOWN IMPORTED )
     set_target_properties ( GraphBLAS::GraphBLAS_static PROPERTIES
         IMPORTED_LOCATION "${GRAPHBLAS_STATIC}"
-        INTERFACE_INCLUDE_DIRECTORIES "${GRAPHBLAS_INCLUDE_DIR}" )
+        INTERFACE_INCLUDE_DIRECTORIES "${GRAPHBLAS_INCLUDE_DIR}"
+        OUTPUT_NAME ${_graphblas_library_name} )
 endif ( )

--- a/LAGraph/config/LAGraph.pc.in
+++ b/LAGraph/config/LAGraph.pc.in
@@ -12,7 +12,7 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Library plus test harness for collecting algorithms that use GraphBLAS in SuiteSparse
 Version: @LAGraph_VERSION_MAJOR@.@LAGraph_VERSION_MINOR@.@LAGraph_VERSION_SUB@
 Requires.private: GraphBLAS
-Libs: -L${libdir} -llagraph@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Libs.private: -lgraphblas @LAGRAPH_STATIC_LIBS@
 Cflags: -I${includedir} -DLG_DLL
 Cflags.private: -ULG_DLL

--- a/LAGraph/config/LAGraph.pc.in
+++ b/LAGraph/config/LAGraph.pc.in
@@ -13,6 +13,6 @@ Description: Library plus test harness for collecting algorithms that use GraphB
 Version: @LAGraph_VERSION_MAJOR@.@LAGraph_VERSION_MINOR@.@LAGraph_VERSION_SUB@
 Requires.private: GraphBLAS
 Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
-Libs.private: -lgraphblas @LAGRAPH_STATIC_LIBS@
+Libs.private: @LAGRAPH_STATIC_LIBS@
 Cflags: -I${includedir} -DLG_DLL
 Cflags.private: -ULG_DLL

--- a/LAGraph/src/test/CMakeLists.txt
+++ b/LAGraph/src/test/CMakeLists.txt
@@ -112,7 +112,7 @@ foreach( testsourcefile ${TEST_SOURCES} )
                 ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:GraphBLAS::GraphBLAS>;PATH=path_list_prepend:$<TARGET_FILE_DIR:lagraphtest>" )
         else ( )
             set_tests_properties ( ${ctestname} PROPERTIES
-                ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:GraphBLAS::GraphBLAS>>" )
+                ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:GraphBLAS::GraphBLAS>" )
         endif ( )
     endif ( )
 endforeach( testsourcefile ${TEST_SOURCES} )

--- a/LDL/CMakeLists.txt
+++ b/LDL/CMakeLists.txt
@@ -229,10 +229,19 @@ if ( NOT MSVC )
     else ( )
         set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
     endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:LDL> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:LDL_static> )
+    endif ( )
     configure_file (
         Config/LDL.pc.in
-        LDL.pc
+        LDL.pc.out
         @ONLY
+        NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT LDL.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/LDL.pc.out
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/LDL.pc

--- a/LDL/Config/LDL.pc.in
+++ b/LDL/Config/LDL.pc.in
@@ -12,6 +12,6 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: A sparse LDL' factorization and solve package in SuiteSparse
 Version: @LDL_VERSION_MAJOR@.@LDL_VERSION_MINOR@.@LDL_VERSION_SUB@
 Requires.private: AMD SuiteSparse_config
-Libs: -L${libdir} -lldl@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Libs.private: @LDL_STATIC_LIBS@
 Cflags: -I${includedir}

--- a/Mongoose/CMakeLists.txt
+++ b/Mongoose/CMakeLists.txt
@@ -613,10 +613,19 @@ if ( NOT MSVC )
     else ( )
         set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
     endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:Mongoose> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:Mongoose_static> )
+    endif ( )
     configure_file (
         Config/Mongoose.pc.in
-        Mongoose.pc
+        Mongoose.pc.out
         @ONLY
+        NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT Mongoose.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/Mongoose.pc.out
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/Mongoose.pc

--- a/Mongoose/Config/Mongoose.pc.in
+++ b/Mongoose/Config/Mongoose.pc.in
@@ -12,5 +12,5 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Graph partitioning library in SuiteSparse
 Version: @Mongoose_VERSION_MAJOR@.@Mongoose_VERSION_MINOR@.@Mongoose_VERSION_PATCH@
 Requires.private: SuiteSparse_config
-Libs: -L${libdir} -lmongoose@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Cflags: -I${includedir}

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -366,10 +366,19 @@ if ( NOT MSVC )
     else ( )
         set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
     endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:ParU> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:ParU_static> )
+    endif ( )
     configure_file (
         Config/ParU.pc.in
-        ParU.pc
+        ParU.pc.out
         @ONLY
+        NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT ParU.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/ParU.pc.out
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/ParU.pc

--- a/ParU/Config/ParU.pc.in
+++ b/ParU/Config/ParU.pc.in
@@ -12,6 +12,6 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Routines for solving sparse linear system via parallel multifrontal LU factorization algorithms in SuiteSparse
 Version: @PARU_VERSION_MAJOR@.@PARU_VERSION_MINOR@.@PARU_VERSION_UPDATE@
 Requires.private: SuiteSparse_config UMFPACK
-Libs: -L${libdir} -lparu@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Libs.private: @PARU_STATIC_LIBS@
 Cflags: -I${includedir}

--- a/RBio/CMakeLists.txt
+++ b/RBio/CMakeLists.txt
@@ -220,10 +220,19 @@ if ( NOT MSVC )
     else ( )
         set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
     endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:RBio> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:RBio_static> )
+    endif ( )
     configure_file (
         Config/RBio.pc.in
-        RBio.pc
+        RBio.pc.out
         @ONLY
+        NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT RBio.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/RBio.pc.out
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/RBio.pc

--- a/RBio/Config/RBio.pc.in
+++ b/RBio/Config/RBio.pc.in
@@ -12,6 +12,6 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: MATLAB Toolbox for reading/writing sparse matrices in Rutherford/Boeing format in SuiteSparse
 Version: @RBIO_VERSION_MAJOR@.@RBIO_VERSION_MINOR@.@RBIO_VERSION_SUB@
 Requires.private: SuiteSparse_config
-Libs: -L${libdir} -lrbio@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Libs.private: @RBIO_STATIC_LIBS@
 Cflags: -I${includedir}

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -317,10 +317,19 @@ if ( NOT MSVC )
     else ( )
         set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
     endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:SPEX> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:SPEX_static> )
+    endif ( )
     configure_file (
         Config/SPEX.pc.in
-        SPEX.pc
+        SPEX.pc.out
         @ONLY
+        NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT SPEX.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/SPEX.pc.out
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/SPEX.pc

--- a/SPEX/Config/SPEX.pc.in
+++ b/SPEX/Config/SPEX.pc.in
@@ -12,6 +12,6 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Software package for SParse EXact algebra in SuiteSparse
 Version: @SPEX_VERSION_MAJOR@.@SPEX_VERSION_MINOR@.@SPEX_VERSION_SUB@
 Requires.private: SuiteSparse_config AMD COLAMD
-Libs: -L${libdir} -lspex@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Libs.private: @SPEX_STATIC_LIBS@
 Cflags: -I${includedir}

--- a/SPQR/CMakeLists.txt
+++ b/SPQR/CMakeLists.txt
@@ -334,10 +334,19 @@ if ( NOT MSVC )
     else ( )
         set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
     endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:SPQR> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:SPQR_static> )
+    endif ( )
     configure_file (
         Config/SPQR.pc.in
-        SPQR.pc
+        SPQR.pc.out
         @ONLY
+        NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT SPQR.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/SPQR.pc.out
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/SPQR.pc

--- a/SPQR/Config/SPQR.pc.in
+++ b/SPQR/Config/SPQR.pc.in
@@ -14,6 +14,6 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Multithreaded, multifrontal, rank-revealing sparse QR factorization method in SuiteSparse
 Version: @SPQR_VERSION_MAJOR@.@SPQR_VERSION_MINOR@.@SPQR_VERSION_SUB@
 Requires.private: SuiteSparse_config CHOLMOD
-Libs: -L${libdir} -lspqr@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Libs.private: @SPQR_STATIC_LIBS@
 Cflags: -I${includedir} @SPQR_CFLAGS@

--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -244,10 +244,19 @@ if ( NOT MSVC )
     else ( )
         set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
     endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:SuiteSparseConfig> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:SuiteSparseConfig_static> )
+    endif ( )
     configure_file (
         Config/SuiteSparse_config.pc.in
-        SuiteSparse_config.pc
+        SuiteSparse_config.pc.out
         @ONLY
+        NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT SuiteSparse_config.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_config.pc.out
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/SuiteSparse_config.pc

--- a/SuiteSparse_config/Config/SuiteSparse_config.pc.in
+++ b/SuiteSparse_config/Config/SuiteSparse_config.pc.in
@@ -11,5 +11,5 @@ Name: SuiteSparseConfig
 URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Configuration for SuiteSparse
 Version: @SUITESPARSE_VERSION_MAJOR@.@SUITESPARSE_VERSION_MINOR@.@SUITESPARSE_VERSION_SUB@
-Libs: -L${libdir} -lsuitesparseconfig@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Cflags: -I${includedir}

--- a/UMFPACK/CMakeLists.txt
+++ b/UMFPACK/CMakeLists.txt
@@ -336,10 +336,19 @@ if ( NOT MSVC )
     else ( )
         set ( includedir "\${prefix}/${SUITESPARSE_INCLUDEDIR}")
     endif ( )
+    if ( BUILD_SHARED_LIBS )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:UMFPACK> )
+    else ( )
+        set ( SUITESPARSE_LIB_BASE_NAME $<TARGET_FILE_BASE_NAME:UMFPACK_static> )
+    endif ( )
     configure_file (
         Config/UMFPACK.pc.in
-        UMFPACK.pc
+        UMFPACK.pc.out
         @ONLY
+        NEWLINE_STYLE LF )
+    file ( GENERATE
+        OUTPUT UMFPACK.pc
+        INPUT ${CMAKE_CURRENT_BINARY_DIR}/UMFPACK.pc.out
         NEWLINE_STYLE LF )
     install ( FILES
         ${CMAKE_CURRENT_BINARY_DIR}/UMFPACK.pc

--- a/UMFPACK/Config/UMFPACK.pc.in
+++ b/UMFPACK/Config/UMFPACK.pc.in
@@ -12,6 +12,6 @@ URL: https://github.com/DrTimothyAldenDavis/SuiteSparse
 Description: Routines solving sparse linear systems via LU factorization in SuiteSparse
 Version: @UMFPACK_VERSION_MAJOR@.@UMFPACK_VERSION_MINOR@.@UMFPACK_VERSION_SUB@
 Requires.private: SuiteSparse_config AMD @UMFPACK_STATIC_MODULES@
-Libs: -L${libdir} -lumfpack@CMAKE_RELEASE_POSTFIX@
+Libs: -L${libdir} -l@SUITESPARSE_LIB_BASE_NAME@
 Libs.private: @UMFPACK_STATIC_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
Library base names can be prefixed, suffixed, or otherwise changed by setting a range of CMake configuration flags.
Extract the base name of the library from the CMake target and use that name when generating the package config files.

For the libraries themselves that should be pretty straight forward.

For the name of the GraphBLAS library used when building LAGraph, this is a bit more tricky because the GraphBLAS library is allowed to come from different sources (with or without import targets).
Try to extract the name of the library from the information that is gathered in `FindGraphBLAS.cmake` and add it to the created target `GraphBLAS::GraphBLAS` also when the used GraphBLAS doesn't provide an import target.

I think the second part should be working. But I haven't actually tested it. (No old or different GraphBLAS here...)

See the issue described in this comment (and following ones): https://github.com/DrTimothyAldenDavis/SuiteSparse/issues/425#issuecomment-1847641837