### PR TITLE
[ParU] Small performance improvement in update rowDeg

### DIFF
--- a/ParU/Source/paru_update_rowDeg.cpp
+++ b/ParU/Source/paru_update_rowDeg.cpp
@@ -178,9 +178,10 @@ void paru_update_rowDeg(int64_t panel_num, int64_t row_end, int64_t f,
                 //if (curCol < col2 && curCol >= col1) continue;
                 ASSERT(curCol >= col2 || curCol < col1); 
 
-                if (stl_colSet.find(curCol) == stl_colSet.end())
+                auto insertResult = stl_colSet.insert(curCol);
+                // inserted to stl_colSet => insert to stl_newColSet
+                if (insertResult.second)
                 {
-                    stl_colSet.insert(curCol);
                     stl_newColSet.insert(curCol);
                     colCount++;
                 }


### PR DESCRIPTION
std::set only inserts an element, if it does not already contain the element. Thus, we can get rid of the additional find.

This was found by cppcheck.

No pull request can be accepted unless you first sign the Contributor License Agreement [ CONTRIBUTOR-LICENSE.txt ].  Print it as a PDF and email me a signed PDF (digital signature OK).  Submit all PRs to the dev2 branch only.
