### PR TITLE
GraphBLAS: Generate GB_JITpackage.c only if included files have changed.

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -164,8 +164,8 @@ jobs:
 
       - name: check_LAGraph
         run: |
-          cd ${GITHUB_WORKSPACE}/LAGraph/build
-          ctest .
+          cd ${GITHUB_WORKSPACE}/LAGraph
+          make demos
 
       - name: check_ParU
         run: |

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -35,7 +35,7 @@ jobs:
         # re-installed.
         run: |
           brew update
-          brew install --overwrite python@3.10 python@3.11
+          brew install --overwrite python@3.10 python@3.11 python@3.12
           brew reinstall gcc
           brew install autoconf automake ccache cmake gmp lapack libomp mpfr openblas
 

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -7,7 +7,7 @@ on:
       - '**/*dev2'
   pull_request:
 
-concurrency: ci-${{ github.ref }}
+concurrency: ci-macos-${{ github.ref }}
 
 env:
   # string with name of libraries to be built

--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -275,7 +275,7 @@ if ( BUILD_SHARED_LIBS )
 
     if ( NOT NJIT )
         # Make sure compressed sources are built before library
-        add_dependencies ( GraphBLAS grb_jitpackage_source )
+        add_dependencies ( GraphBLAS GB_JITpackage )
     endif ( )
 endif ( )
 
@@ -320,7 +320,7 @@ if ( BUILD_STATIC_LIBS )
 
     if ( NOT NJIT )
         # Make sure compressed sources are built before library
-        add_dependencies ( GraphBLAS_static grb_jitpackage_source )
+        add_dependencies ( GraphBLAS_static GB_JITpackage )
     endif ( )
 
 endif ( )

--- a/GraphBLAS/JITpackage/CMakeLists.txt
+++ b/GraphBLAS/JITpackage/CMakeLists.txt
@@ -9,10 +9,10 @@
 
 cmake_minimum_required ( VERSION 3.20 ) # GraphBLAS can be built stand-alone
 project ( jitpackage LANGUAGES C )
-include_directories ( ../zstd ../zstd/zstd_subset )
-add_executable ( grb_jitpackage  "Source/grb_jitpackage.c" )
+add_executable ( grb_jitpackage "Source/grb_jitpackage.c" )
+target_include_directories ( grb_jitpackage PRIVATE ../zstd/zstd_subset )
 if ( NOT WIN32 )
-    target_link_libraries ( grb_jitpackage PUBLIC m )
+    target_link_libraries ( grb_jitpackage PRIVATE m )
 endif ( )
 
 file ( GLOB GRB_SOURCE_FILES

--- a/GraphBLAS/JITpackage/CMakeLists.txt
+++ b/GraphBLAS/JITpackage/CMakeLists.txt
@@ -24,10 +24,13 @@ file ( GLOB GRB_SOURCE_FILES
     "../CUDA/JitKernels/*h"
     "../Source/Shared/*.h" )
 
-add_custom_target ( grb_jitpackage_source ALL
-    COMMAND $<TARGET_FILE:grb_jitpackage> ${GRB_SOURCE_FILES}
+add_custom_command ( OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/GB_JITpackage.c
+    COMMAND $<TARGET_FILE:grb_jitpackage>
+    ARGS ${GRB_SOURCE_FILES}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${GRB_SOURCE_FILES}
     COMMENT "Generating compressed sources for JIT compiler..."
 )
 
+add_custom_target ( GB_JITpackage
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/GB_JITpackage.c )


### PR DESCRIPTION
This avoids relinking libgraphblas if nothing actually changed.
And in turn that avoids re-linking everything when calling `make demos` for LAGraph.

This might help to avoid the linker being stuck sometimes when relinking the LAGraph binaries on macOS (for an unknown reason).