### PR TITLE
root CMakeLists.txt: Remove unnecessary part.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,11 +30,6 @@ project ( "SuiteSparse" )
 set ( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
     ${PROJECT_SOURCE_DIR}/SuiteSparse_config/cmake_modules )
 
-option ( ENABLE_CUDA "Enable CUDA acceleration" ON )
-
-# SuiteSparsePolicy enables SUITESPARSE_CUDA if a CUDA compiler can be found.
-include ( SuiteSparsePolicy )
-
 #-------------------------------------------------------------------------------
 # build options
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
That part of the instructions were only needed before GPUQREngine and SuiteSparse_GPURuntime were moved to subprojects of SPQR. The root CMakeLists.txt no longer needs to know whether CUDA will be available for subprojects.
