### PR TITLE
De-couple root Makefile from root CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,3 +505,19 @@ include ( SuiteSparseReport )
 
 include ( CTest )
 
+#-------------------------------------------------------------------------------
+# rule to remove all files in build directory
+#-------------------------------------------------------------------------------
+
+file ( GLOB SUITESPARSE_BUILT_FILES ${PROJECT_BINARY_DIR}/* )
+file ( REAL_PATH ${PROJECT_SOURCE_DIR} _real_project_source_dir )
+file ( REAL_PATH ${PROJECT_BINARY_DIR} _real_project_binary_dir )
+if ( _real_project_source_dir STREQUAL _real_project_binary_dir )
+    add_custom_target ( purge
+        COMMENT "The target 'purge' is a no-op for in-tree builds.  Consider building out of the source tree." )
+else ( )
+    add_custom_target ( purge
+        COMMAND ${CMAKE_COMMAND} -E echo "Removing files..."
+        COMMAND ${CMAKE_COMMAND} -E rm -rf ${SUITESPARSE_BUILT_FILES}
+        COMMENT "Purge all files in the build tree" )
+endif ( )

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,6 @@ purge:
 	- ( cd ParU && $(MAKE) purge )
 	- ( cd LAGraph && $(MAKE) purge )
 	- $(RM) -r include/* bin/* lib/*
-	- $(RM) -r build/*
 
 clean: purge
 

--- a/Mongoose/CMakeLists.txt
+++ b/Mongoose/CMakeLists.txt
@@ -520,22 +520,22 @@ if ( BUILD_TESTING )
 
 endif ( )
 
-add_custom_target ( purge
-        COMMAND rm -rf ${PROJECT_BINARY_DIR}/*
-#       COMMAND rm -f ${PROJECT_SOURCE_DIR}/Lib/libmongoose.*
-        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/title-info.tex
-        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/title-info.tex.aux
-        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/Mongoose_UserGuide.idx
-        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/Mongoose_UserGuide.log
-        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/Mongoose_UserGuide.out
-        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/Mongoose_UserGuide.aux
-        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/Mongoose_UserGuide.toc
-        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/Mongoose_UserGuide.bbl
-        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/Mongoose_UserGuide.blg
-        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Matrix/*.tar.gz
-        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Matrix/*.csv
-        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-        )
+#add_custom_target ( purge
+#        COMMAND rm -rf ${PROJECT_BINARY_DIR}/*
+##       COMMAND rm -f ${PROJECT_SOURCE_DIR}/Lib/libmongoose.*
+#        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/title-info.tex
+#        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/title-info.tex.aux
+#        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/Mongoose_UserGuide.idx
+#        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/Mongoose_UserGuide.log
+#        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/Mongoose_UserGuide.out
+#        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/Mongoose_UserGuide.aux
+#        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/Mongoose_UserGuide.toc
+#        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/Mongoose_UserGuide.bbl
+#        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Doc/Mongoose_UserGuide.blg
+#        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Matrix/*.tar.gz
+#        COMMAND rm -f ${PROJECT_SOURCE_DIR}/Matrix/*.csv
+#        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+#        )
 
 add_custom_target(userguide
         COMMAND make


### PR DESCRIPTION
Maybe, that is not a supported use-case. But I'm often using the same source tree to test building with the root Makefile and with the root CMakeLists.txt. However, the `purge` target of the root Makefile also removes the build tree of the root CMakeLists.txt. That is annoying sometimes.

I'm working around that by using a different folder to `./build` when building with the root CMakeLists.txt. So, I don't mind if you would prefer to not accept this change. I could just continue with that "workaround".

The proposed change would remove that the root Makefile interacts with the (default) folder for the build tree of the root CMakeLists.txt. Instead, it would introduce a (new) target "purge" to the root CMakeLists.txt that would remove all files from its own build tree.
That new target doesn't do much more than executing `rm -rf *` (or whatever command that corresponds to on a platform without POSIX-compatible binutils). A developer could probably also just use that command instead of `make purge`. So, it would also be fine if just the second part (of removing the interaction of the root Makefile with the build tree of the root CMakeLists.txt) would be accepted.
