### PR TITLE
CI: Display CPU information for runner at start of job.

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -51,6 +51,10 @@ jobs:
     name: alpine (${{ matrix.arch }})
 
     steps:
+      - name: get CPU information (host)
+        shell: bash
+        run: lscpu
+
       - name: checkout repository
         uses: actions/checkout@v3
         # shell: bash
@@ -70,6 +74,10 @@ jobs:
             mpfr-dev
             lapack-dev
             valgrind
+            util-linux-misc
+
+      - name: get CPU information (emulated)
+        run: lscpu
 
       - name: prepare ccache
         # create key with human readable timestamp

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,6 @@ env:
   BUILD_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:ParU:RBio:SPQR:SPEX:GraphBLAS:LAGraph"
   # string with name of libraries to be checked
   CHECK_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:ParU:RBio:SPQR:SPEX:GraphBLAS:LAGraph"
-  CHECK_LIBS_MAC: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:RBio:SPQR:SPEX:GraphBLAS:LAGraph"
 
 
 jobs:
@@ -85,6 +84,9 @@ jobs:
       CXX: ${{ matrix.cxx }}
 
     steps:
+      - name: get CPU information
+        run: lscpu
+
       - name: checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -21,6 +21,11 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      - name: get runner hardware information
+        run: |
+          sysctl hw
+          sysctl machdep
+
       - name: checkout repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -70,6 +70,9 @@ jobs:
       CXX: ${{ matrix.cxx }}
 
     steps:
+      - name: get CPU information
+        run: lscpu
+
       - name: checkout repository
         uses: actions/checkout@v3
 


### PR DESCRIPTION
Show some CPU information at the start of each CI job.
(That additional information might help to find out why some runners intermittently get stuck.)
