### PR TITLE
Set INSTALL_RPATH to $ORIGIN for all installed binaries

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -176,9 +176,9 @@ jobs:
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Executing example\n"
           printf "\033[1;35m  C binary with shared libraries\033[0m\n"
-          LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_demo
+          ./my_demo
           printf "\033[1;35m  C++ binary with shared libraries\033[0m\n"
-          LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_cxx_demo
+          ./my_cxx_demo
           printf "\033[1;35m  C binary with statically linked libraries\033[0m\n"
           ./my_demo_static
           printf "\033[1;35m  C++ binary with statically linked libraries\033[0m\n"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -216,9 +216,9 @@ jobs:
           printf "::group::\033[0;32m==>\033[0m Executing example\n"
           if [ -f ./my_demo -a -f ./my_cxx_demo ]; then
             printf "\033[1;35m  C binary with shared libraries\033[0m\n"
-            LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_demo
+            ./my_demo
             printf "\033[1;35m  C++ binary with shared libraries\033[0m\n"
-            LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_cxx_demo
+            ./my_cxx_demo
           fi
           printf "\033[1;35m  C binary with statically linked libraries\033[0m\n"
           ./my_demo_static

--- a/GraphBLAS/cmake_modules/SuiteSparsePolicy.cmake
+++ b/GraphBLAS/cmake_modules/SuiteSparsePolicy.cmake
@@ -165,6 +165,13 @@ else ( )
         ${CMAKE_SOURCE_DIR}/../lib/cmake )
 endif ( )
 
+# allow libraries to "see" each other if they are installed in a non-default LIBRARY_PATH
+list ( FIND CMAKE_INSTALL_RPATH "$ORIGIN" _idx )
+if ( _idx LESS 0 )
+    # "$ORIGIN" not yet included in CMAKE_INSTALL_RPATH
+    list ( PREPEND CMAKE_INSTALL_RPATH "$ORIGIN" )
+endif ( )
+
 set ( INSIDE_SUITESPARSE OFF )
 if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
     # determine if this Package is inside the SuiteSparse folder

--- a/LAGraph/cmake_modules/SuiteSparsePolicy.cmake
+++ b/LAGraph/cmake_modules/SuiteSparsePolicy.cmake
@@ -165,6 +165,13 @@ else ( )
         ${CMAKE_SOURCE_DIR}/../lib/cmake )
 endif ( )
 
+# allow libraries to "see" each other if they are installed in a non-default LIBRARY_PATH
+list ( FIND CMAKE_INSTALL_RPATH "$ORIGIN" _idx )
+if ( _idx LESS 0 )
+    # "$ORIGIN" not yet included in CMAKE_INSTALL_RPATH
+    list ( PREPEND CMAKE_INSTALL_RPATH "$ORIGIN" )
+endif ( )
+
 set ( INSIDE_SUITESPARSE OFF )
 if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
     # determine if this Package is inside the SuiteSparse folder

--- a/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
+++ b/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
@@ -165,6 +165,13 @@ else ( )
         ${CMAKE_SOURCE_DIR}/../lib/cmake )
 endif ( )
 
+# allow libraries to "see" each other if they are installed in a non-default LIBRARY_PATH
+list ( FIND CMAKE_INSTALL_RPATH "$ORIGIN" _idx )
+if ( _idx LESS 0 )
+    # "$ORIGIN" not yet included in CMAKE_INSTALL_RPATH
+    list ( PREPEND CMAKE_INSTALL_RPATH "$ORIGIN" )
+endif ( )
+
 set ( INSIDE_SUITESPARSE OFF )
 if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
     # determine if this Package is inside the SuiteSparse folder


### PR DESCRIPTION
That is needed so that the libraries "see" each other if they are installed at a path that is not in the default LIBRARY_PATH. Apparently, `CMAKE_INSTALL_RPATH_USE_LINK_PATH` only adds RPATHs to libraries that are *not* installed in the same folder as the library itself.

See https://gitlab.com/petsc/petsc/-/merge_requests/7104#note_1706457216

Also, remove setting `LD_LIBRARY_PATH` when running the example to check if the RPATH is set correctly for the libraries.
