### PR TITLE
CMake: Use `@*_HAS_OPENMP@` in conditions in import target files

### DIFF
--- a/CHOLMOD/Config/CHOLMODConfig.cmake.in
+++ b/CHOLMOD/Config/CHOLMODConfig.cmake.in
@@ -52,7 +52,7 @@ if ( NOT _dependencies_found )
 endif ( )
 
 # Look for OpenMP
-if ( @CHOLMOD_USE_OPENMP@ AND NOT OpenMP_C_FOUND )
+if ( @CHOLMOD_HAS_OPENMP@ AND NOT OpenMP_C_FOUND )
     find_dependency ( OpenMP )
     if ( NOT OpenMP_C_FOUND )
         set ( _dependencies_found OFF )
@@ -156,7 +156,7 @@ endif ( )
 # Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/CHOLMODTargets.cmake )
 
-if ( @CHOLMOD_USE_OPENMP@ )
+if ( @CHOLMOD_HAS_OPENMP@ )
     if ( TARGET SuiteSparse::CHOLMOD )
         get_property ( _cholmod_aliased TARGET SuiteSparse::CHOLMOD
             PROPERTY ALIASED_TARGET )

--- a/GraphBLAS/Config/GraphBLASConfig.cmake.in
+++ b/GraphBLAS/Config/GraphBLASConfig.cmake.in
@@ -61,7 +61,7 @@ if ( @GRAPHBLAS_HAS_CUDA@ )
 endif ( )
 
 # Look for OpenMP
-if ( @GRAPHBLAS_USE_OPENMP@ AND NOT OpenMP_C_FOUND )
+if ( @GRAPHBLAS_HAS_OPENMP@ AND NOT OpenMP_C_FOUND )
     find_dependency ( OpenMP )
     if ( NOT OpenMP_C_FOUND )
         set ( _dependencies_found OFF )
@@ -76,7 +76,7 @@ endif ( )
 # Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/GraphBLASTargets.cmake )
 
-if ( @GRAPHBLAS_USE_OPENMP@ )
+if ( @GRAPHBLAS_HAS_OPENMP@ )
     if ( TARGET SuiteSparse::GraphBLAS )
         get_property ( _graphblas_aliased TARGET SuiteSparse::GraphBLAS
             PROPERTY ALIASED_TARGET )

--- a/LAGraph/config/LAGraphConfig.cmake.in
+++ b/LAGraph/config/LAGraphConfig.cmake.in
@@ -52,7 +52,7 @@ if ( NOT GraphBLAS_FOUND )
 endif ( )
 
 # Look for OpenMP
-if ( @LAGRAPH_USE_OPENMP@ AND NOT OpenMP_C_FOUND )
+if ( @LAGRAPH_HAS_OPENMP@ AND NOT OpenMP_C_FOUND )
     find_dependency ( OpenMP )
     if ( NOT OpenMP_C_FOUND )
         set ( _dependencies_found OFF )
@@ -67,7 +67,7 @@ endif ( )
 # Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/LAGraphTargets.cmake )
 
-if ( @LAGRAPH_USE_OPENMP@ )
+if ( @LAGRAPH_HAS_OPENMP@ )
     if ( TARGET SuiteSparse::LAGraph )
         get_property ( _lagraph_aliased TARGET SuiteSparse::LAGraph
             PROPERTY ALIASED_TARGET )

--- a/SuiteSparse_config/Config/SuiteSparse_configConfig.cmake.in
+++ b/SuiteSparse_config/Config/SuiteSparse_configConfig.cmake.in
@@ -40,7 +40,7 @@ include ( CMakeFindDependencyMacro )
 set ( _dependencies_found ON )
 
 # Look for OpenMP
-if ( @SUITESPARSE_USE_OPENMP@ AND NOT OpenMP_C_FOUND )
+if ( @SUITESPARSE_HAS_OPENMP@ AND NOT OpenMP_C_FOUND )
     find_dependency ( OpenMP )
     if ( NOT OpenMP_C_FOUND )
         set ( _dependencies_found OFF )
@@ -55,7 +55,7 @@ endif ( )
 
 include ( ${CMAKE_CURRENT_LIST_DIR}/SuiteSparse_configTargets.cmake )
 
-if ( @SUITESPARSE_USE_OPENMP@ )
+if ( @SUITESPARSE_HAS_OPENMP@ )
     if ( TARGET SuiteSparse::SuiteSparseConfig )
         get_property ( _suitesparse_config_aliased TARGET SuiteSparse::SuiteSparseConfig
             PROPERTY ALIASED_TARGET )


### PR DESCRIPTION
That was probably an oversight when the `*_USE_OPENMP` and `*_HAS_OPENMP` variables were split.
