### PR TITLE
Fix *_USE_OPENMP, *_HAS_OPENMP, *_USE_CUDA, and *_HAS_CUDA

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -176,9 +176,9 @@ jobs:
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Executing example\n"
           printf "\033[1;35m  C binary with shared libraries\033[0m\n"
-          LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_demo
+          ./my_demo
           printf "\033[1;35m  C++ binary with shared libraries\033[0m\n"
-          LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_cxx_demo
+          ./my_cxx_demo
           printf "\033[1;35m  C binary with statically linked libraries\033[0m\n"
           ./my_demo_static
           printf "\033[1;35m  C++ binary with statically linked libraries\033[0m\n"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
             cuda-cmake-flags:
               -DSUITESPARSE_USE_CUDA=ON
               -DSUITESPARSE_USE_STRICT=ON
-              -DCUDAToolkit_INCLUDE_DIR="/usr/include"
+              -DCUDAToolkit_INCLUDE_DIRS="/usr/include"
               -DCMAKE_CUDA_COMPILER_LAUNCHER="ccache"
           - compiler: gcc
             compiler-pkgs: "g++ gcc"
@@ -73,7 +73,7 @@ jobs:
             cuda-cmake-flags:
               -DSUITESPARSE_USE_CUDA=ON
               -DSUITESPARSE_USE_STRICT=ON
-              -DCUDAToolkit_INCLUDE_DIR="/usr/include"
+              -DCUDAToolkit_INCLUDE_DIRS="/usr/include"
               -DCMAKE_CUDA_COMPILER_LAUNCHER="ccache"
             openmp: with
             link: static

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -216,9 +216,9 @@ jobs:
           printf "::group::\033[0;32m==>\033[0m Executing example\n"
           if [ -f ./my_demo -a -f ./my_cxx_demo ]; then
             printf "\033[1;35m  C binary with shared libraries\033[0m\n"
-            LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_demo
+            ./my_demo
             printf "\033[1;35m  C++ binary with shared libraries\033[0m\n"
-            LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_cxx_demo
+            ./my_cxx_demo
           fi
           printf "\033[1;35m  C binary with statically linked libraries\033[0m\n"
           ./my_demo_static

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -87,7 +87,7 @@ jobs:
                   -DNSTATIC=ON \
                   -DCOMPACT=ON \
                   -DSUITESPARSE_USE_CUDA=ON \
-                  -DCUDAToolkit_INCLUDE_DIR="/usr/include" \
+                  -DCUDAToolkit_INCLUDE_DIRS="/usr/include" \
                   ..
             echo "::endgroup::"
             echo "::group::Build $lib"

--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -48,7 +48,7 @@ jobs:
             cuda-cmake-flags:
               -DSUITESPARSE_USE_CUDA=ON
               -DSUITESPARSE_USE_STRICT=ON
-              -DCUDAToolkit_INCLUDE_DIR="/usr/include"
+              -DCUDAToolkit_INCLUDE_DIRS="/usr/include"
               -DCMAKE_CUDA_COMPILER_LAUNCHER="ccache"
           - compiler: gcc
             compiler-pkgs: "g++ gcc"
@@ -60,7 +60,7 @@ jobs:
             cuda-cmake-flags:
               -DSUITESPARSE_USE_CUDA=ON
               -DSUITESPARSE_USE_STRICT=ON
-              -DCUDAToolkit_INCLUDE_DIR="/usr/include"
+              -DCUDAToolkit_INCLUDE_DIRS="/usr/include"
               -DCMAKE_CUDA_COMPILER_LAUNCHER="ccache"
             link: static
             link-cmake-flags:

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -41,13 +41,17 @@ set ( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 include ( SuiteSparsePolicy )
 
 option ( CHOLMOD_USE_CUDA "ON (default): enable CUDA acceleration for CHOLMOD, OFF: do not use CUDA" ${SUITESPARSE_USE_CUDA} )
+if ( NOT SUITESPARSE_USE_CUDA )
+    set ( CHOLMOD_USE_CUDA "OFF" CACHE STRING "" FORCE )
+endif ( )
+
 option ( CHOLMOD_GPL "ON (default): enable GPL-licensed modules, OFF: do not use any CHOLMOD GPL-licensed modules" ON )
 if ( NOT CHOLMOD_GPL )
     # CHOLMOD_GPL: if OFF, do not include any GPL-licensed module
     set ( CHOLMOD_MATRIXOPS OFF )
     set ( CHOLMOD_MODIFY OFF )
     set ( CHOLMOD_SUPERNODAL OFF )
-    set ( CHOLMOD_USE_CUDA OFF )    # OK: disabled by user-setting of CHOLMOD_GPL
+    set ( CHOLMOD_USE_CUDA "OFF" CACHE STRING "" FORCE ) # OK: disabled by user-setting of CHOLMOD_GPL
     add_compile_definitions ( NGPL )
 endif ( )
 
@@ -80,6 +84,9 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 option ( CHOLMOD_USE_OPENMP "ON: Use OpenMP in CHOLMOD if available.  OFF: Do not use OpenMP.  (Default: SUITESPARSE_USE_OPENMP)" ${SUITESPARSE_USE_OPENMP} )
+if ( NOT SUITESPARSE_USE_OPENMP )
+    set ( CHOLMOD_USE_OPENMP "OFF" CACHE STRING "" FORCE )
+endif ( )
 if ( CHOLMOD_USE_OPENMP )
     find_package ( OpenMP GLOBAL )
 else ( )

--- a/CHOLMOD/Config/CHOLMODConfig.cmake.in
+++ b/CHOLMOD/Config/CHOLMODConfig.cmake.in
@@ -52,7 +52,7 @@ if ( NOT _dependencies_found )
 endif ( )
 
 # Look for OpenMP
-if ( @CHOLMOD_USE_OPENMP@ AND NOT OpenMP_C_FOUND )
+if ( @CHOLMOD_HAS_OPENMP@ AND NOT OpenMP_C_FOUND )
     find_dependency ( OpenMP )
     if ( NOT OpenMP_C_FOUND )
         set ( _dependencies_found OFF )
@@ -156,7 +156,7 @@ endif ( )
 # Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/CHOLMODTargets.cmake )
 
-if ( @CHOLMOD_USE_OPENMP@ )
+if ( @CHOLMOD_HAS_OPENMP@ )
     if ( TARGET SuiteSparse::CHOLMOD )
         get_property ( _cholmod_aliased TARGET SuiteSparse::CHOLMOD
             PROPERTY ALIASED_TARGET )

--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -56,6 +56,12 @@ endif ( )
 # find CUDA
 #-------------------------------------------------------------------------------
 
+# in the future, when GraphBLAS can use CUDA in production:
+# option ( GRAPHBLAS_USE_CUDA "ON (default): enable CUDA acceleration for GraphBLAS, OFF: do not use CUDA" ${SUITESPARSE_USE_CUDA} )
+# if ( NOT SUITESPARSE_USE_CUDA )
+#     set ( GRAPHBLAS_USE_CUDA "OFF" CACHE STRING "" FORCE )
+# endif ( )
+
 if ( SUITESPARSE_HAS_CUDA AND GRAPHBLAS_USE_CUDA )
     # FOR NOW: do not compile FactoryKernels when developing the CUDA kernels
     set ( GRAPHBLAS_COMPACT ON )
@@ -96,6 +102,9 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 option ( GRAPHBLAS_USE_OPENMP "ON: Use OpenMP in GraphBLAS if available.  OFF: Do not use OpenMP.  (Default: SUITESPARSE_USE_OPENMP)" ${SUITESPARSE_USE_OPENMP} )
+if ( NOT SUITESPARSE_USE_OPENMP )
+    set ( GRAPHBLAS_USE_OPENMP "OFF" CACHE STRING "" FORCE )
+endif ( )
 if ( GRAPHBLAS_USE_OPENMP )
     find_package ( OpenMP GLOBAL )
 else ( )

--- a/GraphBLAS/Config/GraphBLASConfig.cmake.in
+++ b/GraphBLAS/Config/GraphBLASConfig.cmake.in
@@ -61,7 +61,7 @@ if ( @GRAPHBLAS_HAS_CUDA@ )
 endif ( )
 
 # Look for OpenMP
-if ( @GRAPHBLAS_USE_OPENMP@ AND NOT OpenMP_C_FOUND )
+if ( @GRAPHBLAS_HAS_OPENMP@ AND NOT OpenMP_C_FOUND )
     find_dependency ( OpenMP )
     if ( NOT OpenMP_C_FOUND )
         set ( _dependencies_found OFF )
@@ -76,7 +76,7 @@ endif ( )
 # Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/GraphBLASTargets.cmake )
 
-if ( @GRAPHBLAS_USE_OPENMP@ )
+if ( @GRAPHBLAS_HAS_OPENMP@ )
     if ( TARGET SuiteSparse::GraphBLAS )
         get_property ( _graphblas_aliased TARGET SuiteSparse::GraphBLAS
             PROPERTY ALIASED_TARGET )

--- a/GraphBLAS/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/GraphBLAS/CMakeLists.txt
@@ -38,12 +38,20 @@ include ( SuiteSparsePolicy )
 # find CUDA
 #-------------------------------------------------------------------------------
 
-include ( GraphBLAS_JIT_paths )
+# in the future, when GraphBLAS can use CUDA in production:
+# option ( GRAPHBLAS_USE_CUDA "ON (default): enable CUDA acceleration for GraphBLAS, OFF: do not use CUDA" ${SUITESPARSE_USE_CUDA} )
+# if ( NOT SUITESPARSE_USE_CUDA )
+#     set ( GRAPHBLAS_USE_CUDA "OFF" CACHE STRING "" FORCE )
+# endif ( )
+
+set ( GRAPHBLAS_HAS_CUDA OFF )
 
 # check for strict usage
 if ( SUITESPARSE_USE_STRICT AND GRAPHBLAS_USE_CUDA AND NOT GRAPHBLAS_HAS_CUDA )
     message ( FATAL_ERROR "CUDA required for GraphBLAS but not found" )
 endif ( )
+
+include ( GraphBLAS_JIT_paths )
 
 #-------------------------------------------------------------------------------
 # define the project
@@ -57,6 +65,9 @@ project ( graphblas_matlab
 #-------------------------------------------------------------------------------
 
 option ( GRAPHBLAS_USE_OPENMP "ON: Use OpenMP in GraphBLAS if available.  OFF: Do not use OpenMP.  (Default: SUITESPARSE_USE_OPENMP)" ${SUITESPARSE_USE_OPENMP} )
+if ( NOT SUITESPARSE_USE_OPENMP )
+    set ( GRAPHBLAS_USE_OPENMP "OFF" CACHE STRING "" FORCE )
+endif ( )
 if ( GRAPHBLAS_USE_OPENMP )
     find_package ( OpenMP )
 else ( )

--- a/GraphBLAS/cmake_modules/SuiteSparsePolicy.cmake
+++ b/GraphBLAS/cmake_modules/SuiteSparsePolicy.cmake
@@ -165,6 +165,13 @@ else ( )
         ${CMAKE_SOURCE_DIR}/../lib/cmake )
 endif ( )
 
+# allow libraries to "see" each other if they are installed in a non-default LIBRARY_PATH
+list ( FIND CMAKE_INSTALL_RPATH "$ORIGIN" _idx )
+if ( _idx LESS 0 )
+    # "$ORIGIN" not yet included in CMAKE_INSTALL_RPATH
+    list ( PREPEND CMAKE_INSTALL_RPATH "$ORIGIN" )
+endif ( )
+
 set ( INSIDE_SUITESPARSE OFF )
 if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
     # determine if this Package is inside the SuiteSparse folder

--- a/LAGraph/CMakeLists.txt
+++ b/LAGraph/CMakeLists.txt
@@ -156,8 +156,11 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 option ( LAGRAPH_USE_OPENMP "ON: Use OpenMP in LAGraph if available.  OFF: Do not use OpenMP.  (Default: SUITESPARSE_USE_OPENMP)" ${SUITESPARSE_USE_OPENMP} )
+if ( NOT SUITESPARSE_USE_OPENMP )
+    set ( LAGRAPH_USE_OPENMP "OFF" CACHE STRING "" FORCE )
+endif ( )
 if ( COVERAGE )
-    set ( LAGRAPH_USE_OPENMP OFF )  # OK: test coverage is enabled
+    set ( LAGRAPH_USE_OPENMP "OFF" CACHE STRING "" FORCE ) # OK: test coverage is enabled
     message ( STATUS "OpenMP disabled for test coverage" )
 else ( )
     if ( LAGRAPH_USE_OPENMP )

--- a/LAGraph/cmake_modules/SuiteSparsePolicy.cmake
+++ b/LAGraph/cmake_modules/SuiteSparsePolicy.cmake
@@ -165,6 +165,13 @@ else ( )
         ${CMAKE_SOURCE_DIR}/../lib/cmake )
 endif ( )
 
+# allow libraries to "see" each other if they are installed in a non-default LIBRARY_PATH
+list ( FIND CMAKE_INSTALL_RPATH "$ORIGIN" _idx )
+if ( _idx LESS 0 )
+    # "$ORIGIN" not yet included in CMAKE_INSTALL_RPATH
+    list ( PREPEND CMAKE_INSTALL_RPATH "$ORIGIN" )
+endif ( )
+
 set ( INSIDE_SUITESPARSE OFF )
 if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
     # determine if this Package is inside the SuiteSparse folder

--- a/LAGraph/config/LAGraphConfig.cmake.in
+++ b/LAGraph/config/LAGraphConfig.cmake.in
@@ -52,7 +52,7 @@ if ( NOT GraphBLAS_FOUND )
 endif ( )
 
 # Look for OpenMP
-if ( @LAGRAPH_USE_OPENMP@ AND NOT OpenMP_C_FOUND )
+if ( @LAGRAPH_HAS_OPENMP@ AND NOT OpenMP_C_FOUND )
     find_dependency ( OpenMP )
     if ( NOT OpenMP_C_FOUND )
         set ( _dependencies_found OFF )
@@ -67,7 +67,7 @@ endif ( )
 # Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/LAGraphTargets.cmake )
 
-if ( @LAGRAPH_USE_OPENMP@ )
+if ( @LAGRAPH_HAS_OPENMP@ )
     if ( TARGET SuiteSparse::LAGraph )
         get_property ( _lagraph_aliased TARGET SuiteSparse::LAGraph
             PROPERTY ALIASED_TARGET )

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -55,6 +55,9 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 option ( PARU_USE_OPENMP "ON: Use OpenMP in ParU if available.  OFF: Do not use OpenMP.  (Default: SUITESPARSE_USE_OPENMP)" ${SUITESPARSE_USE_OPENMP} )
+if ( NOT SUITESPARSE_USE_OPENMP )
+    set ( PARU_USE_OPENMP "OFF" CACHE STRING "" FORCE )
+endif ( )
 
 if ( PARU_USE_OPENMP )
     # OpenMP 4.5 or later is required

--- a/ParU/Source/paru_omp.hpp
+++ b/ParU/Source/paru_omp.hpp
@@ -30,7 +30,7 @@
     #define PARU_OPENMP_GET_NUM_THREADS   (1)
     #define PARU_OPENMP_GET_WTIME         (0)
     #define PARU_OPENMP_GET_THREAD_ID     (0)
-    #define PARU_OPENMP_SET_DYNAMIC       (0)
+    #define PARU_OPENMP_SET_DYNAMIC
     #define PARU_OPENMP_SET_MAX_ACTIVE_LEVELS(l)
     #define PARU_OPENMP_GET_ACTIVE_LEVEL   (0)
     #define PARU_OPENMP_GET_THREAD_NUM     (0)

--- a/SPQR/CMakeLists.txt
+++ b/SPQR/CMakeLists.txt
@@ -65,7 +65,10 @@ include ( SuiteSparseLAPACK )   # requires cmake 3.22
 # find CUDA
 #-------------------------------------------------------------------------------
 
-option ( SPQR_USE_CUDA "Enable CUDA acceleration for SPQR" ${SUITESPARSE_USE_CUDA} )
+option ( SPQR_USE_CUDA "ON (default): enable CUDA acceleration for SPQR, OFF: do not use CUDA" ${SUITESPARSE_USE_CUDA} )
+if ( NOT SUITESPARSE_USE_CUDA )
+    set ( SPQR_USE_CUDA "OFF" CACHE STRING "" FORCE )
+endif ( )
 
 if ( SUITESPARSE_HAS_CUDA AND SPQR_USE_CUDA )
     # with CUDA

--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -57,23 +57,31 @@ endif ( )
 # find OpenMP
 #-------------------------------------------------------------------------------
 
-if ( SUITESPARSE_USE_OPENMP )
+option ( SUITESPARSE_CONFIG_USE_OPENMP "ON: Use OpenMP in SuiteSparse_config if available.  OFF: Do not use OpenMP.  (Default: SUITESPARSE_USE_OPENMP)" ${SUITESPARSE_USE_OPENMP} )
+if ( NOT SUITESPARSE_USE_OPENMP )
+    set ( SUITESPARSE_CONFIG_USE_OPENMP "OFF" CACHE STRING "" FORCE )
+endif ( )
+if ( SUITESPARSE_CONFIG_USE_OPENMP OR SUITESPARSE_USE_OPENMP )
     find_package ( OpenMP GLOBAL )
 else ( )
     # OpenMP has been disabled
-    message ( STATUS "OpenMP disabled" )
     set ( OpenMP_C_FOUND OFF )
 endif ( )
 
 if ( OpenMP_C_FOUND )
     set ( SUITESPARSE_HAS_OPENMP ON )
+    set ( SUITESPARSE_CONFIG_HAS_OPENMP ON )
 else ( )
     set ( SUITESPARSE_HAS_OPENMP OFF )
+    set ( SUITESPARSE_CONFIG_HAS_OPENMP OFF )
 endif ( )
 
 # check for strict usage
 if ( SUITESPARSE_USE_STRICT AND SUITESPARSE_USE_OPENMP AND NOT SUITESPARSE_HAS_OPENMP )
     message ( FATAL_ERROR "OpenMP required for SuiteSparse but not found" )
+endif ( )
+if ( SUITESPARSE_USE_STRICT AND SUITESPARSE_CONFIG_USE_OPENMP AND NOT SUITESPARSE_CONFIG_HAS_OPENMP )
+    message ( FATAL_ERROR "OpenMP required for SuiteSparse_config but not found" )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -163,7 +171,7 @@ if ( NOT WIN32 )
 endif ( )
 
 # OpenMP:
-if ( OpenMP_C_FOUND )
+if ( SUITESPARSE_CONFIG_USE_OPENMP )
     message ( STATUS "OpenMP C libraries:      ${OpenMP_C_LIBRARIES} ")
     message ( STATUS "OpenMP C include:        ${OpenMP_C_INCLUDE_DIRS} ")
     message ( STATUS "OpenMP C flags:          ${OpenMP_C_FLAGS} ")

--- a/SuiteSparse_config/Config/SuiteSparse_configConfig.cmake.in
+++ b/SuiteSparse_config/Config/SuiteSparse_configConfig.cmake.in
@@ -40,7 +40,7 @@ include ( CMakeFindDependencyMacro )
 set ( _dependencies_found ON )
 
 # Look for OpenMP
-if ( @SUITESPARSE_USE_OPENMP@ AND NOT OpenMP_C_FOUND )
+if ( @SUITESPARSE_HAS_OPENMP@ AND NOT OpenMP_C_FOUND )
     find_dependency ( OpenMP )
     if ( NOT OpenMP_C_FOUND )
         set ( _dependencies_found OFF )
@@ -55,7 +55,7 @@ endif ( )
 
 include ( ${CMAKE_CURRENT_LIST_DIR}/SuiteSparse_configTargets.cmake )
 
-if ( @SUITESPARSE_USE_OPENMP@ )
+if ( @SUITESPARSE_HAS_OPENMP@ )
     if ( TARGET SuiteSparse::SuiteSparseConfig )
         get_property ( _suitesparse_config_aliased TARGET SuiteSparse::SuiteSparseConfig
             PROPERTY ALIASED_TARGET )

--- a/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
+++ b/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
@@ -165,6 +165,13 @@ else ( )
         ${CMAKE_SOURCE_DIR}/../lib/cmake )
 endif ( )
 
+# allow libraries to "see" each other if they are installed in a non-default LIBRARY_PATH
+list ( FIND CMAKE_INSTALL_RPATH "$ORIGIN" _idx )
+if ( _idx LESS 0 )
+    # "$ORIGIN" not yet included in CMAKE_INSTALL_RPATH
+    list ( PREPEND CMAKE_INSTALL_RPATH "$ORIGIN" )
+endif ( )
+
 set ( INSIDE_SUITESPARSE OFF )
 if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
     # determine if this Package is inside the SuiteSparse folder


### PR DESCRIPTION
See https://github.com/DrTimothyAldenDavis/SuiteSparse/issues/622 .

If `SUITESPARSE_USE_OPENMP` is OFF, this forces all `*_USE_OPENMP` options to be `OFF`.

Likewise if `SUITESPARSE_USE_CUDA` is OFF, this forces all `*_USE_CUDA` options to be `OFF`.

Added `SUITESPARSE_CONFIG_USE_OPENMP` option, since `SuiteSparse_config` can optionally use OpenMP.

Also fixed a bug in ParU when OpenMP was disabled, to allow it to compile without OpenMP.  ParU is fundamentally a parallel package, so OpenMP is highly recommended for ParU ... but it still can be compiled without it.  If using OpenMP, ParU requires OpenMP 4.5 or later.
