### PR TITLE
add SUITESPARSE_TIME

### DIFF
--- a/CHOLMOD/Demo/cholmod_demo.h
+++ b/CHOLMOD/Demo/cholmod_demo.h
@@ -19,7 +19,7 @@
 #define TRUE 1
 #define FALSE 0
 
-#define CPUTIME (SuiteSparse_time ( ))
+#define CPUTIME SUITESPARSE_TIME
 
 #define MAX(a,b) (((a) > (b)) ? (a) : (b))
 #define MIN(a,b) (((a) < (b)) ? (a) : (b))

--- a/CHOLMOD/Demo/cholmod_di_simple.c
+++ b/CHOLMOD/Demo/cholmod_di_simple.c
@@ -41,15 +41,15 @@ int main (void)
     }
     b = cholmod_ones (A->nrow, 1, A->xtype + dtype, &c) ;   // b = ones(n,1)
 
-    double t1 = SuiteSparse_time ( ) ;
+    double t1 = SUITESPARSE_TIME ;
     L = cholmod_analyze (A, &c) ;                   // analyze
-    t1 = SuiteSparse_time ( ) - t1 ;
-    double t2 = SuiteSparse_time ( ) ;
+    t1 = SUITESPARSE_TIME - t1 ;
+    double t2 = SUITESPARSE_TIME ;
     cholmod_factorize (A, L, &c) ;                  // factorize
-    t2 = SuiteSparse_time ( ) - t2 ;
-    double t3 = SuiteSparse_time ( ) ;
+    t2 = SUITESPARSE_TIME - t2 ;
+    double t3 = SUITESPARSE_TIME ;
     x = cholmod_solve (CHOLMOD_A, L, b, &c) ;       // solve Ax=b
-    t3 = SuiteSparse_time ( ) - t3 ;
+    t3 = SUITESPARSE_TIME - t3 ;
     printf ("analyze   time: %10.3f sec\n", t1) ;
     printf ("factorize time: %10.3f sec\n", t2) ;
     printf ("solve     time: %10.3f sec\n", t3) ;

--- a/CHOLMOD/Demo/cholmod_dl_simple.c
+++ b/CHOLMOD/Demo/cholmod_dl_simple.c
@@ -41,15 +41,15 @@ int main (void)
     }
     b = cholmod_l_ones (A->nrow, 1, A->xtype + dtype, &c) ;   // b = ones(n,1)
 
-    double t1 = SuiteSparse_time ( ) ;
+    double t1 = SUITESPARSE_TIME ;
     L = cholmod_l_analyze (A, &c) ;                   // analyze
-    t1 = SuiteSparse_time ( ) - t1 ;
-    double t2 = SuiteSparse_time ( ) ;
+    t1 = SUITESPARSE_TIME - t1 ;
+    double t2 = SUITESPARSE_TIME ;
     cholmod_l_factorize (A, L, &c) ;                  // factorize
-    t2 = SuiteSparse_time ( ) - t2 ;
-    double t3 = SuiteSparse_time ( ) ;
+    t2 = SUITESPARSE_TIME - t2 ;
+    double t3 = SUITESPARSE_TIME ;
     x = cholmod_l_solve (CHOLMOD_A, L, b, &c) ;       // solve Ax=b
-    t3 = SuiteSparse_time ( ) - t3 ;
+    t3 = SUITESPARSE_TIME - t3 ;
     printf ("analyze   time: %10.3f sec\n", t1) ;
     printf ("factorize time: %10.3f sec\n", t2) ;
     printf ("solve     time: %10.3f sec\n", t3) ;

--- a/CHOLMOD/Demo/cholmod_si_simple.c
+++ b/CHOLMOD/Demo/cholmod_si_simple.c
@@ -41,15 +41,15 @@ int main (void)
     }
     b = cholmod_ones (A->nrow, 1, A->xtype + dtype, &c) ;   // b = ones(n,1)
 
-    double t1 = SuiteSparse_time ( ) ;
+    double t1 = SUITESPARSE_TIME ;
     L = cholmod_analyze (A, &c) ;                   // analyze
-    t1 = SuiteSparse_time ( ) - t1 ;
-    double t2 = SuiteSparse_time ( ) ;
+    t1 = SUITESPARSE_TIME - t1 ;
+    double t2 = SUITESPARSE_TIME ;
     cholmod_factorize (A, L, &c) ;                  // factorize
-    t2 = SuiteSparse_time ( ) - t2 ;
-    double t3 = SuiteSparse_time ( ) ;
+    t2 = SUITESPARSE_TIME - t2 ;
+    double t3 = SUITESPARSE_TIME ;
     x = cholmod_solve (CHOLMOD_A, L, b, &c) ;       // solve Ax=b
-    t3 = SuiteSparse_time ( ) - t3 ;
+    t3 = SUITESPARSE_TIME - t3 ;
     printf ("analyze   time: %10.3f sec\n", t1) ;
     printf ("factorize time: %10.3f sec\n", t2) ;
     printf ("solve     time: %10.3f sec\n", t3) ;

--- a/CHOLMOD/Demo/cholmod_sl_simple.c
+++ b/CHOLMOD/Demo/cholmod_sl_simple.c
@@ -41,15 +41,15 @@ int main (void)
     }
     b = cholmod_l_ones (A->nrow, 1, A->xtype + dtype, &c) ;   // b = ones(n,1)
 
-    double t1 = SuiteSparse_time ( ) ;
+    double t1 = SUITESPARSE_TIME ;
     L = cholmod_l_analyze (A, &c) ;                   // analyze
-    t1 = SuiteSparse_time ( ) - t1 ;
-    double t2 = SuiteSparse_time ( ) ;
+    t1 = SUITESPARSE_TIME - t1 ;
+    double t2 = SUITESPARSE_TIME ;
     cholmod_l_factorize (A, L, &c) ;                  // factorize
-    t2 = SuiteSparse_time ( ) - t2 ;
-    double t3 = SuiteSparse_time ( ) ;
+    t2 = SUITESPARSE_TIME - t2 ;
+    double t3 = SUITESPARSE_TIME ;
     x = cholmod_l_solve (CHOLMOD_A, L, b, &c) ;       // solve Ax=b
-    t3 = SuiteSparse_time ( ) - t3 ;
+    t3 = SUITESPARSE_TIME - t3 ;
     printf ("analyze   time: %10.3f sec\n", t1) ;
     printf ("factorize time: %10.3f sec\n", t2) ;
     printf ("solve     time: %10.3f sec\n", t3) ;

--- a/CHOLMOD/GPU/cholmod_gpu.c
+++ b/CHOLMOD/GPU/cholmod_gpu.c
@@ -45,20 +45,15 @@ static int poll_gpu (size_t s)          /* TRUE if OK, FALSE otherwise */
     /* Returns TRUE if the GPU has a block of memory of size s,
        FALSE otherwise.  The block of memory is immediately freed. */
     void *p = NULL ;
-    // double t = SuiteSparse_time ( ) ;
     if (s == 0)
     {
         return (FALSE) ;
     }
     if (cudaMalloc (&p, s) != cudaSuccess)
     {
-        // t = SuiteSparse_time ( ) - t ;
-        // printf ("poll s %lu failed, time %g\n", s, t) ;
         return (FALSE) ;
     }
     cudaFree (p) ;
-    // t = SuiteSparse_time ( ) - t ;
-    // printf ("poll s %lu OK time %g\n", s, t) ;
     return (TRUE) ;
 #else
     return (FALSE) ;
@@ -74,7 +69,6 @@ int CHOLMOD(gpu_memorysize)      /* returns 1 on error, 0 otherwise */
 {
     size_t good, bad, s, total_free, total_memory ;
     int k ;
-    double t ;
 
     *total_mem = 0;
     *available_mem = 0;
@@ -90,10 +84,7 @@ int CHOLMOD(gpu_memorysize)      /* returns 1 on error, 0 otherwise */
 #ifdef CHOLMOD_HAS_CUDA
 
     /* find the total amount of free memory */
-    t = SuiteSparse_time ( ) ;
     cudaMemGetInfo (&total_free, &total_memory) ;
-    t = SuiteSparse_time ( ) - t ;
-// printf ("free %lu tot %lu time %g\n", total_free, total_memory, t) ;
 
     *total_mem = total_memory;
 

--- a/CHOLMOD/GPU/t_cholmod_gpu.c
+++ b/CHOLMOD/GPU/t_cholmod_gpu.c
@@ -417,7 +417,7 @@ int TEMPLATE2 (CHOLMOD (gpu_updateC))
     ndrow3 = ndrow2 - ndrow1 ;
 
 #ifdef BLAS_TIMER
-    Common->syrkStart = SuiteSparse_time ( ) ;
+    Common->syrkStart = SUITESPARSE_TIME ;
     Common->CHOLMOD_GPU_SYRK_CALLS++ ;
 #endif
 
@@ -532,7 +532,7 @@ int TEMPLATE2 (CHOLMOD (gpu_updateC))
     }
 
 #ifdef BLAS_TIMER
-    Common->CHOLMOD_GPU_SYRK_TIME += SuiteSparse_time() - Common->syrkStart;
+    Common->CHOLMOD_GPU_SYRK_TIME += SUITESPARSE_TIME - Common->syrkStart;
 #endif
 
     /* ---------------------------------------------------------------------- */
@@ -541,7 +541,7 @@ int TEMPLATE2 (CHOLMOD (gpu_updateC))
 
 #ifdef BLAS_TIMER
     Common->CHOLMOD_GPU_GEMM_CALLS++ ;
-    tstart = SuiteSparse_time();
+    tstart = SUITESPARSE_TIME;
 #endif
 
     if (ndrow3 > 0)
@@ -591,7 +591,7 @@ int TEMPLATE2 (CHOLMOD (gpu_updateC))
     }
 
 #ifdef BLAS_TIMER
-    Common->CHOLMOD_GPU_GEMM_TIME += SuiteSparse_time() - tstart;
+    Common->CHOLMOD_GPU_GEMM_TIME += SUITESPARSE_TIME - tstart;
 #endif
 
     /* ------------------------------------------------------------------ */
@@ -812,7 +812,7 @@ int TEMPLATE2 (CHOLMOD (gpu_lower_potrf))
     }
 
 #ifdef BLAS_TIMER
-    tstart = SuiteSparse_time ( ) ;
+    tstart = SUITESPARSE_TIME ;
     Common->CHOLMOD_GPU_POTRF_CALLS++ ;
 #endif
 
@@ -1130,7 +1130,7 @@ int TEMPLATE2 (CHOLMOD (gpu_lower_potrf))
     }
 
 #ifdef BLAS_TIMER
-    Common->CHOLMOD_GPU_POTRF_TIME += SuiteSparse_time ( ) - tstart ;
+    Common->CHOLMOD_GPU_POTRF_TIME += SUITESPARSE_TIME - tstart ;
 #endif
 
     return (1) ;
@@ -1193,7 +1193,7 @@ int TEMPLATE2 (CHOLMOD (gpu_triangular_solve))
     }
 
 #ifdef BLAS_TIMER
-    tstart = SuiteSparse_time ( ) ;
+    tstart = SUITESPARSE_TIME ;
     Common->CHOLMOD_GPU_TRSM_CALLS++ ;
 #endif
 
@@ -1388,7 +1388,7 @@ int TEMPLATE2 (CHOLMOD (gpu_triangular_solve))
     /* ---------------------------------------------------------------------- */
 
 #ifdef BLAS_TIMER
-    Common->CHOLMOD_GPU_TRSM_TIME += SuiteSparse_time ( ) - tstart ;
+    Common->CHOLMOD_GPU_TRSM_TIME += SUITESPARSE_TIME - tstart ;
 #endif
 
     return (1) ;

--- a/CHOLMOD/Supernodal/t_cholmod_super_numeric_worker.c
+++ b/CHOLMOD/Supernodal/t_cholmod_super_numeric_worker.c
@@ -762,7 +762,7 @@ static int TEMPLATE (cholmod_super_numeric_worker)
 
                 #ifdef BLAS_TIMER
                 Common->CHOLMOD_CPU_SYRK_CALLS++ ;
-                tstart = SuiteSparse_time () ;
+                tstart = SUITESPARSE_TIME ;
                 #endif
 
                 #if (defined (DOUBLE) && defined (REAL))
@@ -803,7 +803,7 @@ static int TEMPLATE (cholmod_super_numeric_worker)
                 #endif
 
                 #ifdef BLAS_TIMER
-                blas_time = SuiteSparse_time () - tstart ;
+                blas_time = SUITESPARSE_TIME - tstart ;
                 Common->CHOLMOD_CPU_SYRK_TIME += blas_time ;
                 BLAS_DUMP_TO_FILE (0,           // dsyrk ("L", "N", ...)
                     ndrow1, ndcol, 0,           // N, K, 0
@@ -817,7 +817,7 @@ static int TEMPLATE (cholmod_super_numeric_worker)
 
                     #ifdef BLAS_TIMER
                     Common->CHOLMOD_CPU_GEMM_CALLS++ ;
-                    tstart = SuiteSparse_time () ;
+                    tstart = SUITESPARSE_TIME ;
                     #endif
 
                     #if (defined (DOUBLE) && defined (REAL))
@@ -874,7 +874,7 @@ static int TEMPLATE (cholmod_super_numeric_worker)
                     #endif
 
                     #ifdef BLAS_TIMER
-                    blas_time = SuiteSparse_time () - tstart ;
+                    blas_time = SUITESPARSE_TIME - tstart ;
                     Common->CHOLMOD_CPU_GEMM_TIME += blas_time ;
                     BLAS_DUMP_TO_FILE (4,           // dgemm ("N", "C", ...)
                         ndrow3, ndrow1, ndcol,      // M, N, K
@@ -1016,7 +1016,7 @@ static int TEMPLATE (cholmod_super_numeric_worker)
             #endif
             #ifdef BLAS_TIMER
             Common->CHOLMOD_CPU_POTRF_CALLS++ ;
-            tstart = SuiteSparse_time () ;
+            tstart = SUITESPARSE_TIME ;
             #endif
 
             #if (defined (DOUBLE) && defined (REAL))
@@ -1049,7 +1049,7 @@ static int TEMPLATE (cholmod_super_numeric_worker)
             #endif
 
             #ifdef BLAS_TIMER
-            blas_time = SuiteSparse_time () - tstart ;
+            blas_time = SUITESPARSE_TIME - tstart ;
             Common->CHOLMOD_CPU_POTRF_TIME += blas_time ;
             BLAS_DUMP_TO_FILE (8,           // dpotrf ("L", ... )
                 nscol2, 0, 0,               // N, 0, 0
@@ -1168,7 +1168,7 @@ static int TEMPLATE (cholmod_super_numeric_worker)
             {
                 #ifdef BLAS_TIMER
                 Common->CHOLMOD_CPU_TRSM_CALLS++ ;
-                tstart = SuiteSparse_time () ;
+                tstart = SUITESPARSE_TIME ;
                 #endif
 
                 #if (defined (DOUBLE) && defined (REAL))
@@ -1209,7 +1209,7 @@ static int TEMPLATE (cholmod_super_numeric_worker)
                 #endif
 
                 #ifdef BLAS_TIMER
-                blas_time = SuiteSparse_time () - tstart ;
+                blas_time = SUITESPARSE_TIME - tstart ;
                 Common->CHOLMOD_CPU_TRSM_TIME += blas_time ;
                 BLAS_DUMP_TO_FILE (12,          // dtrsm ("R", "L", "C", "N"...)
                     nsrow2, nscol2, 0,          // M, N

--- a/ChangeLog
+++ b/ChangeLog
@@ -21,7 +21,8 @@ Dec 30, 2023: version 7.4.0
         bug fixes in the GPU Module.
     * AMD 3.3.0: minor change for CHOLMOD 5.1.0 tests
     * CAMD 3.3.0: minor change for CHOLMOD 5.1.0 tests
-    * SuiteSparse_config 7.4.0: added wrappers for single-precision BLAS/LAPACK
+    * SuiteSparse_config 7.4.0: added wrappers for single-precision BLAS/LAPACK,
+        added SUITESPARSE_TIME macro.
     * *_version: added methods to all package that didn't have them:
         AMD, CAMD, COLAMD, CCOLAMD, BTF, CSparse, CXSparse, KLU, BTF, RBio,
         SPEX, SPQR, and UMFPACK.

--- a/Mongoose/Demo/demo.cpp
+++ b/Mongoose/Demo/demo.cpp
@@ -53,7 +53,7 @@ int main(int argn, const char **argv)
     cout << "Mongoose is licensed under Version 3 of the GNU General Public License." << endl;
     cout << "Mongoose is also available under other licenses; contact authors for details." << endl;
 
-    double start = SuiteSparse_time ();
+    double start = SUITESPARSE_TIME;
     double duration;
 
     for (int k = 0; k < NMAT; k++)
@@ -61,7 +61,7 @@ int main(int argn, const char **argv)
         cout << "********************************************************************************" << endl;
         cout << "Computing an edge cut for " << demo_files[k] << "..." << endl;
         
-        double trial_start = SuiteSparse_time ();
+        double trial_start = SUITESPARSE_TIME;
         EdgeCut_Options *options = EdgeCut_Options::create();
         if (!options) return EXIT_FAILURE; // Return an error if we failed.
 
@@ -87,7 +87,7 @@ int main(int argn, const char **argv)
             cout << "Cut Imbalance:  " << setprecision(2) << 100*(result->imbalance) << "%" << endl;
         }
 
-        double trial_duration = (SuiteSparse_time() - trial_start) ;
+        double trial_duration = (SUITESPARSE_TIME - trial_start) ;
         cout << "Trial Time:     " << trial_duration*1000 << "ms" << endl;
 
         options->~EdgeCut_Options();
@@ -95,7 +95,7 @@ int main(int argn, const char **argv)
         result->~EdgeCut();
     }
 
-    duration = (SuiteSparse_time() - start) ;
+    duration = (SUITESPARSE_TIME - start) ;
 
     cout << "********************************************************************************" << endl;
     cout << "Total Demo Time:  " << setprecision(2) << duration << "s" << endl;

--- a/Mongoose/Executable/mongoose.cpp
+++ b/Mongoose/Executable/mongoose.cpp
@@ -83,9 +83,9 @@ int main(int argn, const char **argv)
     std::cout << "********************************************************************************" << std::endl;
 
     // An edge separator should be computed with default options
-    t = SuiteSparse_time ();
+    t = SUITESPARSE_TIME;
     EdgeCut *result = edge_cut(graph, options);
-    t = SuiteSparse_time () - t;
+    t = SUITESPARSE_TIME - t;
 
     if (!result)
     {

--- a/Mongoose/Include/Mongoose_Logger.hpp
+++ b/Mongoose/Include/Mongoose_Logger.hpp
@@ -134,7 +134,7 @@ inline void Logger::tic(TimingType timingType)
 {
     if (timingOn)
     {
-        clocks[timingType] = SuiteSparse_time ();
+        clocks[timingType] = SUITESPARSE_TIME;
     }
 }
 
@@ -157,7 +157,7 @@ inline void Logger::toc(TimingType timingType)
     if (timingOn)
     {
         times[timingType]
-            += (float) (SuiteSparse_time () - clocks[timingType]) ;
+            += (float) (SUITESPARSE_TIME - clocks[timingType]) ;
     }
 }
 

--- a/Mongoose/Tests/Mongoose_Test_Performance.cpp
+++ b/Mongoose/Tests/Mongoose_Test_Performance.cpp
@@ -43,9 +43,9 @@ int runPerformanceTest(const std::string &inputFile, const std::string &outputFi
     }
 
     // An edge separator should be computed with default options
-    t = SuiteSparse_time ();
+    t = SUITESPARSE_TIME;
     EdgeCut *result = edge_cut(graph, options);
-    t = SuiteSparse_time () - t;
+    t = SUITESPARSE_TIME - t;
 
     if (!result)
     {

--- a/Mongoose/Tests/Mongoose_Test_Reference.cpp
+++ b/Mongoose/Tests/Mongoose_Test_Reference.cpp
@@ -43,9 +43,9 @@ int runReferenceTest(const std::string &inputFile)
     }
 
     // An edge separator should be computed with default options
-    t = SuiteSparse_time ();
+    t = SUITESPARSE_TIME;
     EdgeCut *result = edge_cut(graph, options);
-    t = SuiteSparse_time () - t;
+    t = SUITESPARSE_TIME - t;
 
     if (!result)
     {

--- a/SPQR/Demo/qrdemo_gpu.cpp
+++ b/SPQR/Demo/qrdemo_gpu.cpp
@@ -33,10 +33,10 @@ int main (int argc, char **argv)
     // warmup the GPU.  This can take some time, but only needs
     // to be done once
     cc->useGPU = true ;
-    t = SuiteSparse_time ( ) ;
+    t = SUITESPARSE_TIME ;
     cholmod_l_gpu_memorysize (&total_mem, &available_mem, cc) ;
     cc->gpuMemorySize = available_mem ;
-    t = SuiteSparse_time ( ) - t ;
+    t = SUITESPARSE_TIME - t ;
     if (cc->gpuMemorySize <= 1)
     {
         printf ("no GPU available\n") ;

--- a/SPQR/Demo/qrdemo_gpu2.cpp
+++ b/SPQR/Demo/qrdemo_gpu2.cpp
@@ -35,10 +35,10 @@ int main (int argc, char **argv)
     // warmup the GPU.  This can take some time, but only needs
     // to be done once
     cc->useGPU = true ;
-    t = SuiteSparse_time ( ) ;
+    t = SUITESPARSE_TIME ;
     cholmod_l_gpu_memorysize (&total_mem, &available_mem, cc) ;
     cc->gpuMemorySize = available_mem ;
-    t = SuiteSparse_time ( ) - t ;
+    t = SUITESPARSE_TIME - t ;
     if (cc->gpuMemorySize <= 1)
     {
         printf ("no GPU available\n") ;

--- a/SPQR/Demo/qrdemo_gpu3.cpp
+++ b/SPQR/Demo/qrdemo_gpu3.cpp
@@ -37,10 +37,10 @@ int main (int argc, char **argv)
     // warmup the GPU.  This can take some time, but only needs
     // to be done once
     cc->useGPU = false ;
-    t = SuiteSparse_time ( ) ;
+    t = SUITESPARSE_TIME ;
     cholmod_l_gpu_memorysize (&total_mem, &available_mem, cc) ;
     cc->gpuMemorySize = available_mem ;
-    t = SuiteSparse_time ( ) - t ;
+    t = SUITESPARSE_TIME - t ;
     if (cc->gpuMemorySize <= 1)
     {
         printf ("no GPU available\n") ;

--- a/SPQR/GPUQREngine/Demo/gpuqrengine_demo.cpp
+++ b/SPQR/GPUQREngine/Demo/gpuqrengine_demo.cpp
@@ -309,10 +309,10 @@ int main(int argn, char **argv)
     // warmup the GPU.  This can take some time, but only needs
     // to be done once
     cc->useGPU = true ;
-    t = SuiteSparse_time ( ) ;
+    t = SUITESPARSE_TIME ;
     cholmod_l_gpu_memorysize (&total_mem, &available_mem, cc) ;
     cc->gpuMemorySize = available_mem ;
-    t = SuiteSparse_time ( ) - t ;
+    t = SUITESPARSE_TIME - t ;
     if (cc->gpuMemorySize <= 1)
     {
         printf ("no GPU available\n") ;

--- a/SPQR/MATLAB/spqr.cpp
+++ b/SPQR/MATLAB/spqr.cpp
@@ -48,7 +48,7 @@ void mexFunction
     cholmod_dense *Cdense, Bdmatrix, *Bdense, *HTau ;
     cholmod_common Common, *cc ;
 
-    double t0 = (nargout > 3) ? SuiteSparse_time ( ) : 0 ;
+    double t0 = (nargout > 3) ? SUITESPARSE_TIME : 0 ;
 
     // -------------------------------------------------------------------------
     // start CHOLMOD and set parameters
@@ -484,7 +484,7 @@ void mexFunction
     if (nargout > 3)
     {
         double flops = cc->SPQR_flopcount ;
-        double t = SuiteSparse_time ( ) - t0 ;
+        double t = SUITESPARSE_TIME - t0 ;
         pargout [3] = spqr_mx_info (cc, t, flops) ;
     }
 

--- a/SPQR/MATLAB/spqr_solve.cpp
+++ b/SPQR/MATLAB/spqr_solve.cpp
@@ -70,7 +70,7 @@ void mexFunction
     cholmod_common Common, *cc ;
     char msg [LEN+1] ;
 
-    double t0 = (nargout > 1) ? SuiteSparse_time ( ) : 0 ;
+    double t0 = (nargout > 1) ? SUITESPARSE_TIME : 0 ;
 
     // -------------------------------------------------------------------------
     // start CHOLMOD and set parameters
@@ -272,7 +272,7 @@ void mexFunction
     if (nargout > 1)
     {
         double flops = cc->SPQR_flopcount ;
-        double t = SuiteSparse_time ( ) - t0 ;
+        double t = SUITESPARSE_TIME - t0 ;
         pargout [1] = spqr_mx_info (cc, t, flops) ;
     }
 

--- a/SPQR/SPQRGPU/spqrgpu_kernel.cpp
+++ b/SPQR/SPQRGPU/spqrgpu_kernel.cpp
@@ -16,8 +16,8 @@
 
 #ifdef SUITESPARSE_TIMER_ENANBLED
 #define INIT_TIME(x)    double x = 0.0; double time_ ## x;
-#define TIC(x)          time_ ## x = SuiteSparse_time();
-#define TOC(x)          x += SuiteSparse_time() - time_ ## x;
+#define TIC(x)          time_ ## x = SUITESPARSE_TIME;
+#define TOC(x)          x += SUITESPARSE_TIME - time_ ## x;
 #else
 #define INIT_TIME(x)
 #define TIC(x)

--- a/SPQR/Source/SuiteSparseQR.cpp
+++ b/SPQR/Source/SuiteSparseQR.cpp
@@ -340,7 +340,7 @@ template <typename Entry, typename Int> Int SuiteSparseQR
     cholmod_sparse *Xsparse, *Zsparse, *R, *H ;
     cholmod_dense *Zdense, *HTau ;
 
-    double t0 = SuiteSparse_time ( ) ;
+    double t0 = SUITESPARSE_TIME ;
 
     int ok = TRUE ;
 
@@ -1205,7 +1205,7 @@ template <typename Entry, typename Int> Int SuiteSparseQR
         *p_E = E ;
     }
 
-    double t3 = SuiteSparse_time ( ) ;
+    double t3 = SUITESPARSE_TIME ;
     double total_time = t3 - t0 ;
     cc->SPQR_solve_time =
         total_time - cc->SPQR_analyze_time - cc->SPQR_factorize_time ;

--- a/SPQR/Source/SuiteSparseQR_expert.cpp
+++ b/SPQR/Source/SuiteSparseQR_expert.cpp
@@ -60,7 +60,7 @@ SuiteSparseQR_factorization <Entry, Int> *SuiteSparseQR_symbolic
     cholmod_common *cc      // workspace and parameters
 )
 {
-    double t0 = SuiteSparse_time ( ) ;
+    double t0 = SUITESPARSE_TIME ;
 
     RETURN_IF_NULL_COMMON (NULL) ;
     RETURN_IF_NULL (A, NULL) ;
@@ -149,7 +149,7 @@ SuiteSparseQR_factorization <Entry, Int> *SuiteSparseQR_symbolic
         }
     }
 
-    double t1 = SuiteSparse_time ( ) ;
+    double t1 = SUITESPARSE_TIME ;
     cc->SPQR_analyze_time = t1 - t0 ;
 
     return (QR) ;
@@ -222,7 +222,7 @@ template <typename Entry, typename Int> int SuiteSparseQR_numeric
     cholmod_common *cc      // workspace and parameters
 )
 {
-    double t0 = SuiteSparse_time ( ) ;
+    double t0 = SUITESPARSE_TIME ;
 
     RETURN_IF_NULL_COMMON (FALSE) ;
     RETURN_IF_NULL (A, FALSE) ;
@@ -297,7 +297,7 @@ template <typename Entry, typename Int> int SuiteSparseQR_numeric
     cc->SPQR_istat [4] = QR->rank ;         // estimated rank of A
     cc->SPQR_tol_used = tol ;               // tol used
 
-    double t1 = SuiteSparse_time ( ) ;
+    double t1 = SUITESPARSE_TIME ;
     cc->SPQR_factorize_time = t1 - t0 ;
 
     return (TRUE) ;
@@ -1751,7 +1751,7 @@ template <typename Entry, typename Int> cholmod_dense *SuiteSparseQR_min2norm
     if (A->nrow < A->ncol)
     {
 
-        double t0 = SuiteSparse_time ( ) ;
+        double t0 = SUITESPARSE_TIME ;
 
         // x=A\B, using a QR factorization of A'
         SuiteSparseQR_factorization <Entry, Int> *QR ;
@@ -1768,7 +1768,7 @@ template <typename Entry, typename Int> cholmod_dense *SuiteSparseQR_min2norm
         spqr_free_dense <Int> (&Y, cc) ;
         spqr_freefac (&QR, cc) ;
 
-        double t3 = SuiteSparse_time ( ) ;
+        double t3 = SUITESPARSE_TIME ;
         double total_time = t3 - t0 ;
         cc->SPQR_solve_time =
             total_time - cc->SPQR_analyze_time - cc->SPQR_factorize_time ;
@@ -1841,7 +1841,7 @@ template <typename Entry, typename Int> cholmod_sparse *SuiteSparseQR_min2norm /
     cholmod_common *cc
 )
 {
-    double t0 = SuiteSparse_time ( ) ;
+    double t0 = SUITESPARSE_TIME ;
 
     cholmod_dense *Bdense, *Xdense ;
     cholmod_sparse *Xsparse = NULL ;
@@ -1864,7 +1864,7 @@ template <typename Entry, typename Int> cholmod_sparse *SuiteSparseQR_min2norm /
         cc->status = CHOLMOD_OUT_OF_MEMORY ;
     }
 
-    double t3 = SuiteSparse_time ( ) ;
+    double t3 = SUITESPARSE_TIME ;
     double total_time = t3 - t0 ;
     cc->SPQR_solve_time =
         total_time - cc->SPQR_analyze_time - cc->SPQR_factorize_time ;

--- a/SPQR/Source/spqr_1factor.cpp
+++ b/SPQR/Source/spqr_1factor.cpp
@@ -113,7 +113,7 @@ template <typename Entry, typename Int> SuiteSparseQR_factorization <Entry, Int>
         n1cols, n2, Bsparse, d, iold, inew, m, n ;
     cholmod_sparse *Y = NULL ;
 
-    double t0 = SuiteSparse_time ( ) ;
+    double t0 = SUITESPARSE_TIME ;
     double t1, t2 ;
 
     // -------------------------------------------------------------------------
@@ -632,7 +632,7 @@ template <typename Entry, typename Int> SuiteSparseQR_factorization <Entry, Int>
         // factorize A, with fill-reducing ordering already given in Q1fill
         QRsym = spqr_analyze (A, SPQR_ORDERING_GIVEN, Q1fill,
             tol >= 0, keepH, cc) ;
-        t1 = SuiteSparse_time ( ) ;
+        t1 = SUITESPARSE_TIME ;
         QRnum = spqr_factorize <Entry, Int> (&A, FALSE, tol, n, QRsym, cc) ;
     }
     else
@@ -640,7 +640,7 @@ template <typename Entry, typename Int> SuiteSparseQR_factorization <Entry, Int>
         // fill-reducing ordering is already applied to Y; free Y when loaded
         QRsym = spqr_analyze <Int> (Y, SPQR_ORDERING_FIXED, NULL,
             tol >= 0, keepH, cc) ;
-        t1 = SuiteSparse_time ( ) ;
+        t1 = SUITESPARSE_TIME ;
         QRnum = spqr_factorize <Entry, Int> (&Y, TRUE, tol, n2, QRsym, cc) ;
         // Y has been freed
         ASSERT (Y == NULL) ;
@@ -747,7 +747,7 @@ template <typename Entry, typename Int> SuiteSparseQR_factorization <Entry, Int>
     cc->SPQR_istat [6] = n1rows ;           // number of singleton rows
     cc->SPQR_tol_used = tol ;               // tol used
 
-    t2 = SuiteSparse_time ( ) ;
+    t2 = SUITESPARSE_TIME ;
     cc->SPQR_analyze_time = t1 - t0 ;   // analyze time, including singletons
     cc->SPQR_factorize_time = t2 - t1 ; // factorize time
 

--- a/SPQR/Tcov/qrtest_template.hpp
+++ b/SPQR/Tcov/qrtest_template.hpp
@@ -2655,9 +2655,9 @@ int do_matrix (int kind, FILE *file, cholmod_common *cc)
     cc->useGPU = TRUE ;
     // was 3.5 * ((size_t) 1024 * 1024 * 1024) ;
     size_t totmem, availmem ;
-    double t = SuiteSparse_time ( ) ;
+    double t = SUITESPARSE_TIME ;
     spqr_gpu_memorysize (&totmem, &availmem, cc) ;
-    t = SuiteSparse_time ( ) - t ;
+    t = SUITESPARSE_TIME - t ;
     cc->gpuMemorySize = availmem ;
     printf ("\nBeginning GPU tests, GPU memory %g MB warmup time %g[\n",
         (double) (cc->gpuMemorySize) / (1024*1024), t) ;

--- a/SuiteSparse_config/Config/SuiteSparse_config.h.in
+++ b/SuiteSparse_config/Config/SuiteSparse_config.h.in
@@ -368,13 +368,25 @@ int SuiteSparse_divcomplex
 
 // determine which timer to use, if any
 #ifndef NTIMER
+    // SuiteSparse_config itself can be compiled without OpenMP,
+    // but other packages can themselves use OpenMP.  In this case,
+    // those packages should use omp_get_wtime() directly.  This can
+    // be done via the SUITESPARSE_TIME macro, defined below:
     #if defined ( _OPENMP )
         #define SUITESPARSE_TIMER_ENABLED
+        #define SUITESPARSE_TIME (omp_get_wtime ( ))
     #elif defined ( _POSIX_C_SOURCE )
         #if _POSIX_C_SOURCE >= 199309L
         #define SUITESPARSE_TIMER_ENABLED
+        #define SUITESPARSE_TIME (SuiteSparse_time ( ))
         #endif
+    #else
+        // No timer is available
+        #define SUITESPARSE_TIME (0)
     #endif
+#else
+    // The timer is explictly disabled
+    #define SUITESPARSE_TIME (0)
 #endif
 
 // SuiteSparse printf macro

--- a/SuiteSparse_config/SuiteSparse_config.h
+++ b/SuiteSparse_config/SuiteSparse_config.h
@@ -368,13 +368,25 @@ int SuiteSparse_divcomplex
 
 // determine which timer to use, if any
 #ifndef NTIMER
+    // SuiteSparse_config itself can be compiled without OpenMP,
+    // but other packages can themselves use OpenMP.  In this case,
+    // those packages should use omp_get_wtime() directly.  This can
+    // be done via the SUITESPARSE_TIME macro, defined below:
     #if defined ( _OPENMP )
         #define SUITESPARSE_TIMER_ENABLED
+        #define SUITESPARSE_TIME (omp_get_wtime ( ))
     #elif defined ( _POSIX_C_SOURCE )
         #if _POSIX_C_SOURCE >= 199309L
         #define SUITESPARSE_TIMER_ENABLED
+        #define SUITESPARSE_TIME (SuiteSparse_time ( ))
         #endif
+    #else
+        // No timer is available
+        #define SUITESPARSE_TIME (0)
     #endif
+#else
+    // The timer is explictly disabled
+    #define SUITESPARSE_TIME (0)
 #endif
 
 // SuiteSparse printf macro

--- a/UMFPACK/MATLAB/umfpack_make.m
+++ b/UMFPACK/MATLAB/umfpack_make.m
@@ -169,7 +169,7 @@ generic = { 'timer', 'tictoc' } ;
 
 M = cell (0) ;
 
-% add the SuiteSparse_timer function
+% add the SuiteSparse_time function
 other_source = { '../../SuiteSparse_config/SuiteSparse_config' } ;
 
 % add CHOLMOD and its supporting libraries

--- a/UMFPACK/Source/umfpack_report_control.c
+++ b/UMFPACK/Source/umfpack_report_control.c
@@ -379,10 +379,15 @@ void UMFPACK_report_control
     PRINTF (("    compiled for ANSI C\n")) ;
 #endif
 
+    PRINTF (("    CPU timer: ")) ;
 #ifdef SUITESPARSE_TIMER_ENABLED
-    PRINTF (("    SuiteSparse_time ( )\n")) ;
+    #ifdef _OPENMP
+        PRINTF (("omp_get_wtime ( )\n")) ;
+    #else
+        PRINTF (("SuiteSparse_time ( )\n")) ;
+    #endif
 #else
-    PRINTF (("    no timer used.\n")) ;
+    PRINTF (("no timer used.\n")) ;
 #endif
 
 #ifdef NCHOLMOD

--- a/UMFPACK/Source/umfpack_report_info.c
+++ b/UMFPACK/Source/umfpack_report_info.c
@@ -147,7 +147,7 @@ void UMFPACK_report_info
 	(Int) (sizeof (SUITESPARSE_BLAS_INT)))) ;
 #endif
 
-    PRINTF (("    MATLAB:                           ")) ;
+    PRINTF (("    MATLAB: ")) ;
 #ifdef MATLAB_MEX_FILE
     PRINTF (("yes.\n")) ;
 #else
@@ -158,11 +158,15 @@ void UMFPACK_report_info
 #endif
 #endif
 
-    PRINTF (("    CPU timer:                        ")) ;
+    PRINTF (("    CPU timer: ")) ;
 #ifdef SUITESPARSE_TIMER_ENABLED
-    PRINTF (("SuiteSparse_time ( ) routine.\n")) ;
+    #ifdef _OPENMP
+        PRINTF (("omp_get_wtime ( )\n")) ;
+    #else
+        PRINTF (("SuiteSparse_time ( )\n")) ;
+    #endif
 #else
-    PRINTF (("none.\n")) ;
+    PRINTF (("no timer used.\n")) ;
 #endif
 
     /* ---------------------------------------------------------------------- */

--- a/UMFPACK/Source/umfpack_tictoc.c
+++ b/UMFPACK/Source/umfpack_tictoc.c
@@ -17,12 +17,12 @@
 
 void umfpack_tic (double stats [2])
 {
-    stats [0] = SuiteSparse_time ( ) ;
+    stats [0] = SUITESPARSE_TIME ;
     stats [1] = stats [0] ;
 }
 
 void umfpack_toc (double stats [2])
 {
-    stats [0] = SuiteSparse_time ( ) - stats [0] ;
+    stats [0] = SUITESPARSE_TIME - stats [0] ;
     stats [1] = stats [0] ;
 }

--- a/UMFPACK/Source/umfpack_timer.c
+++ b/UMFPACK/Source/umfpack_timer.c
@@ -18,5 +18,5 @@
 
 double umfpack_timer ( void )
 {
-    return (SuiteSparse_time ( )) ;
+    return (SUITESPARSE_TIME) ;
 }


### PR DESCRIPTION
SuiteSparse_config can itself be compiled without OpenMP, but the package that #include's it might have OpenMP available.  If that's the case, the SuiteSparse_time() function defined in SuiteSparse_config.c will use the POSIX timer instead.

If the Package wants omp_get_wtime(), it can use the new SUITESPARSE_TIME macro, which becomes omp_get_wtime() if _OPENMP is #define'd, or SuiteSparse_time otherwise.  Or it is zero if the timer is entirely disabled.
