### PR TITLE
[ParU] Replace C-style casts by static_cast's

### DIFF
--- a/ParU/Source/paru_analyze.cpp
+++ b/ParU/Source/paru_analyze.cpp
@@ -947,7 +947,7 @@ ParU_Ret ParU_Analyze(cholmod_sparse *A, ParU_Symbolic **S_handle,
     // Making Children list and computing the bound sizes
     if (nf > 0)
     {
-        Childp = (int64_t *)paru_calloc((nf + 2), sizeof(int64_t));
+        Childp = static_cast<int64_t*>(paru_calloc(nf + 2, sizeof(int64_t)));
         Sym->Childp = Childp;
         if (Childp == NULL)
         {
@@ -1001,7 +1001,7 @@ ParU_Ret ParU_Analyze(cholmod_sparse *A, ParU_Symbolic **S_handle,
 #endif
     if (nf > 0)
     {
-        Child = (int64_t *)paru_calloc((nf + 1), sizeof(int64_t));
+        Child = static_cast<int64_t*>(paru_calloc(nf + 1, sizeof(int64_t)));
         Sym->Child = Child;
         if (Child == NULL)
         {
@@ -1012,7 +1012,7 @@ ParU_Ret ParU_Analyze(cholmod_sparse *A, ParU_Symbolic **S_handle,
         }
     }
     // copy of Childp using Work for other places also
-    Work = (int64_t *)paru_alloc(std::max(m, n) + 2, sizeof(int64_t));
+    Work = static_cast<int64_t*>(paru_alloc(std::max(m, n) + 2, sizeof(int64_t)));
     int64_t *cChildp = Work;
     if (cChildp == NULL)
     {
@@ -1045,9 +1045,9 @@ ParU_Ret ParU_Analyze(cholmod_sparse *A, ParU_Symbolic **S_handle,
     /*                   computing the Staircase structures                   */
     /* ---------------------------------------------------------------------- */
 
-    Sp = Sym->Sp = (int64_t *)paru_calloc(m + 1 - n1, sizeof(int64_t));
-    Sleft = Sym->Sleft = (int64_t *)paru_alloc(n + 2 - n1, sizeof(int64_t));
-    Pinv = (int64_t *)paru_alloc(m + 1, sizeof(int64_t));
+    Sp = Sym->Sp = static_cast<int64_t*>(paru_calloc(m + 1 - n1, sizeof(int64_t)));
+    Sleft = Sym->Sleft = static_cast<int64_t*>(paru_alloc(n + 2 - n1, sizeof(int64_t)));
+    Pinv = static_cast<int64_t*>(paru_alloc(m + 1, sizeof(int64_t)));
 
     if (Sp == NULL || Sleft == NULL || Pinv == NULL)
     {

--- a/ParU/Source/paru_c.cpp
+++ b/ParU/Source/paru_c.cpp
@@ -102,7 +102,7 @@ ParU_Ret ParU_C_Analyze(
     ParU_Control Control;
     paru_cp_control (&Control, Control_C);
     ParU_C_Symbolic *Sym_C =
-        (ParU_C_Symbolic *)paru_alloc(1, sizeof(ParU_C_Symbolic));
+        static_cast<ParU_C_Symbolic*>(paru_alloc(1, sizeof(ParU_C_Symbolic)));
     if (!Sym_C)
     {
         return PARU_OUT_OF_MEMORY;
@@ -112,7 +112,7 @@ ParU_Ret ParU_C_Analyze(
     info = ParU_Analyze(A, &Sym, &Control);
     if (info != PARU_SUCCESS)
         return info; //To avoid playing with wrong ponters
-    Sym_C->sym_handle = (void*) Sym;
+    Sym_C->sym_handle = static_cast<void*>(Sym);
     *Sym_handle_C = Sym_C;
     Sym_C->m = Sym->m;
     Sym_C->n = Sym->n;
@@ -137,9 +137,9 @@ ParU_Ret ParU_C_Factorize (
 { 
     ParU_Control Control;
     paru_cp_control (&Control, Control_C);
-    ParU_Symbolic *Sym = (ParU_Symbolic *) Sym_C->sym_handle;
+    ParU_Symbolic *Sym = static_cast<ParU_Symbolic*>(Sym_C->sym_handle);
     ParU_C_Numeric *Num_C = 
-        (ParU_C_Numeric *)paru_alloc(1, sizeof(ParU_C_Numeric));
+        static_cast<ParU_C_Numeric*>(paru_alloc(1, sizeof(ParU_C_Numeric)));
     if (!Num_C)
     {
         return PARU_OUT_OF_MEMORY;
@@ -150,7 +150,7 @@ ParU_Ret ParU_C_Factorize (
     info = ParU_Factorize(A, Sym, &Num, &Control);
     if (info != PARU_SUCCESS)
         return info;
-    Num_C->num_handle = (void *) Num;
+    Num_C->num_handle = static_cast<void*>(Num);
     *Num_handle_C = Num_C;
     Num_C->rcond = Num->rcond;
     return info;
@@ -174,8 +174,9 @@ ParU_Ret ParU_C_Solve_Axx (
 {
     ParU_Control Control;
     paru_cp_control (&Control, Control_C);
-    return ParU_Solve ((ParU_Symbolic *) Sym_C->sym_handle, 
-            (ParU_Numeric *) Num_C->num_handle, b, &Control);
+    return ParU_Solve (static_cast<ParU_Symbolic*>(Sym_C->sym_handle),
+                       static_cast<ParU_Numeric*>(Num_C->num_handle),
+                       b, &Control);
 }
 
 //-------- Ax = b --------------------------------------------------------------
@@ -189,8 +190,9 @@ ParU_Ret ParU_C_Solve_Axb (
 { 
     ParU_Control Control;
     paru_cp_control (&Control, Control_C);
-    return ParU_Solve ((ParU_Symbolic *) Sym_C->sym_handle,
-            (ParU_Numeric *)Num_C->num_handle, b, x, &Control);
+    return ParU_Solve (static_cast<ParU_Symbolic*>(Sym_C->sym_handle),
+                       static_cast<ParU_Numeric*>(Num_C->num_handle),
+                       b, x, &Control);
 }
 
 //-------- AX = B  (X is overwritten on B, multiple rhs)------------------------
@@ -204,8 +206,9 @@ ParU_Ret ParU_C_Solve_AXX (
 { 
     ParU_Control Control;
     paru_cp_control (&Control, Control_C);
-    return ParU_Solve ((ParU_Symbolic *) Sym_C->sym_handle,
-            (ParU_Numeric *)Num_C->num_handle, B, &Control);
+    return ParU_Solve (static_cast<ParU_Symbolic*>(Sym_C->sym_handle),
+                       static_cast<ParU_Numeric*>(Num_C->num_handle),
+                       B, &Control);
 }
 
 //-------- AX = B  (multiple rhs)-----------------------------------------------
@@ -219,8 +222,9 @@ ParU_Ret ParU_C_Solve_AXB (
 { 
     ParU_Control Control;
     paru_cp_control (&Control, Control_C);
-    return ParU_Solve ((ParU_Symbolic *) Sym_C->sym_handle,
-            (ParU_Numeric *)Num_C->num_handle, nrhs, B, X, &Control);
+    return ParU_Solve (static_cast<ParU_Symbolic*>(Sym_C->sym_handle),
+                       static_cast<ParU_Numeric*>(Num_C->num_handle),
+                       nrhs, B, X, &Control);
 }
 
 //------------------------------------------------------------------------------
@@ -280,7 +284,7 @@ ParU_Ret ParU_C_Freenum (
     ParU_Control Control;
     paru_cp_control (&Control, Control_C);
     ParU_C_Numeric *Num_C = *Num_handle_C;
-    ParU_Numeric *Num = (ParU_Numeric *) (Num_C->num_handle);
+    ParU_Numeric *Num = static_cast<ParU_Numeric*>(Num_C->num_handle);
     ParU_Ret info;
     info = ParU_Freenum(&Num, &Control);
     paru_free(1, sizeof(ParU_C_Numeric), *Num_handle_C);
@@ -293,7 +297,7 @@ ParU_Ret ParU_C_Freesym (
     ParU_Control Control;
     paru_cp_control (&Control, Control_C);
     ParU_C_Symbolic *Sym_C = *Sym_handle_C;
-    ParU_Symbolic *Sym = (ParU_Symbolic *)(Sym_C->sym_handle);
+    ParU_Symbolic *Sym = static_cast<ParU_Symbolic*>(Sym_C->sym_handle);
     ParU_Ret info;
     info = ParU_Freesym(&Sym, &Control);
     paru_free(1, sizeof(ParU_C_Symbolic), *Sym_handle_C);

--- a/ParU/Source/paru_finalize_perm.cpp
+++ b/ParU/Source/paru_finalize_perm.cpp
@@ -25,8 +25,8 @@ ParU_Ret paru_finalize_perm(ParU_Symbolic *Sym, ParU_Numeric *Num)
     int64_t *Ps = NULL;
     int64_t *Pinit = Sym->Pinit;
 
-    Num->Pfin = Pfin = (int64_t *)paru_alloc(m, sizeof(int64_t));
-    Num->Ps = Ps = (int64_t *)paru_alloc(m, sizeof(int64_t));
+    Num->Pfin = Pfin = static_cast<int64_t*>(paru_alloc(m, sizeof(int64_t)));
+    Num->Ps = Ps = static_cast<int64_t*>(paru_alloc(m, sizeof(int64_t)));
 
     PRLEVEL(1, ("%% Inside Perm\n"));
     if (Pfin == NULL || Ps == NULL)

--- a/ParU/Source/paru_front.cpp
+++ b/ParU/Source/paru_front.cpp
@@ -69,7 +69,7 @@ ParU_Ret paru_front(int64_t f,  // front need to be assembled
 
         int64_t fm = Sym->Fm[f]; /* Upper bound number of rows of F */
         PRLEVEL(1, ("%% the size of fm is " LD "\n", fm));
-        int64_t *frowList = (int64_t *)paru_alloc(fm, sizeof(int64_t));
+        int64_t *frowList = static_cast<int64_t*>(paru_alloc(fm, sizeof(int64_t)));
         if (frowList == NULL)
         {
             PRLEVEL(1, ("ParU: out of memory when tried to allocate"
@@ -263,7 +263,7 @@ ParU_Ret paru_front(int64_t f,  // front need to be assembled
         if (fn != 0)
         {
             PRLEVEL(1, ("%% fp=" LD " fn=" LD " \n", fp, fn));
-            fcolList = (int64_t *)paru_calloc(stl_colSet.size(), sizeof(int64_t));
+            fcolList = static_cast<int64_t*>(paru_calloc(stl_colSet.size(), sizeof(int64_t)));
 
             if (fcolList == NULL)
             {
@@ -346,7 +346,7 @@ ParU_Ret paru_front(int64_t f,  // front need to be assembled
         /**** 5 ** assemble U part         Row by Row                      ****/
 
         // consider a parallel calloc
-        double *uPart = (double *)paru_calloc(fp * colCount, sizeof(double));
+        double *uPart = static_cast<double*>(paru_calloc(fp * colCount, sizeof(double)));
         if (uPart == NULL)
         {
             PRLEVEL(1, ("ParU: out of memory when tried to"

--- a/ParU/Source/paru_pivotal.cpp
+++ b/ParU/Source/paru_pivotal.cpp
@@ -354,7 +354,7 @@ ParU_Ret paru_pivotal(std::vector<int64_t> &pivotal_elements,
     if (rowCount != fm)
     {
         frowList = 
-            (int64_t *)paru_realloc(rowCount, sizeof(int64_t), frowList, &sz);
+            static_cast<int64_t*>(paru_realloc(rowCount, sizeof(int64_t), frowList, &sz));
     }
     if (sz != (size_t) rowCount)
     {
@@ -364,7 +364,7 @@ ParU_Ret paru_pivotal(std::vector<int64_t> &pivotal_elements,
     }
 
     Num->frowList[f] = frowList ;
-    double *pivotalFront = (double *)paru_calloc(rowCount * fp, sizeof(double));
+    double *pivotalFront = static_cast<double*>(paru_calloc(rowCount * fp, sizeof(double)));
 
     if (pivotalFront == NULL)
     {


### PR DESCRIPTION
I tried to use `reinterpret_cast`, too. Cppcheck warns that these could be potentially not portable (casting between `long` and `double`) and GCC does not accept these casts within `constexpr` functions.
Thus, I retract my changes to introduce `constexpr` and `reinterpret_cast`. Probably C++20's provides a portable solution by `std::bit_cast`.