### PR TITLE
readme for openmp; remove "set ( CMAKE_MACOSX_RPATH TRUE )" from all cmake scripts

### DIFF
--- a/CSparse/CMakeLists.txt
+++ b/CSparse/CMakeLists.txt
@@ -48,7 +48,6 @@ if ( WIN32 )
     add_compile_definitions ( _CRT_SECURE_NO_WARNINGS )
 endif ( )
 
-set ( CMAKE_MACOSX_RPATH TRUE )
 include ( GNUInstallDirs )
 
 if ( NOT CMAKE_BUILD_TYPE )

--- a/Example/CMakeLists.txt
+++ b/Example/CMakeLists.txt
@@ -71,8 +71,6 @@ if ( WIN32 )
     set ( CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS true )
 endif ( )
 
-set ( CMAKE_MACOSX_RPATH TRUE )
-
 option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
 option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
 

--- a/GraphBLAS/cmake_modules/SuiteSparsePolicy.cmake
+++ b/GraphBLAS/cmake_modules/SuiteSparsePolicy.cmake
@@ -112,7 +112,6 @@ if ( WIN32 )
     add_compile_definitions ( _CRT_SECURE_NO_WARNINGS )
 endif ( )
 
-set ( CMAKE_MACOSX_RPATH TRUE )
 enable_language ( C )
 include ( GNUInstallDirs )
 

--- a/LAGraph/CMakeLists.txt
+++ b/LAGraph/CMakeLists.txt
@@ -38,8 +38,6 @@
 
 cmake_minimum_required ( VERSION 3.20 ) # LAGraph can be built stand-alone
 
-set ( CMAKE_MACOSX_RPATH TRUE )
-
 # version of LAGraph
 set ( LAGraph_DATE "Dec 30, 2023" )
 set ( LAGraph_VERSION_MAJOR 1 CACHE STRING "" FORCE )

--- a/LAGraph/cmake_modules/SuiteSparsePolicy.cmake
+++ b/LAGraph/cmake_modules/SuiteSparsePolicy.cmake
@@ -112,7 +112,6 @@ if ( WIN32 )
     add_compile_definitions ( _CRT_SECURE_NO_WARNINGS )
 endif ( )
 
-set ( CMAKE_MACOSX_RPATH TRUE )
 enable_language ( C )
 include ( GNUInstallDirs )
 

--- a/README.md
+++ b/README.md
@@ -811,34 +811,42 @@ build type).  The static libraries will not be built (since
 
   If `ON`, OpenMP is used if it is available.  Default: `OFF`.
 
-  UMFPACK, CHOLMOD, SPQR, and GraphBLAS will be slow if OpenMP is not used.
+  GraphBLAS, LAGraph, and ParU will be slow if OpenMP is not used.
+  Other packages (UMFPACK, CHOLMOD, SPQR) may use OpenMP in the BLAS/LAPACK,
+  which is essential for performance.
 
   Note that BLAS and LAPACK may still use OpenMP internally; if you wish to
   disable OpenMP in an entire application, select a single-threaded
   BLAS/LAPACK.
 
-  WARNING: GraphBLAS may not be thread-safe if built without OpenMP (see the
-  User Guide for details).
+  WARNING: GraphBLAS may not be thread-safe if built without OpenMP or pthreads
+  (see the User Guide for details).
+
+* `SUITESPARSE_CONFIG_USE_OPENMP`:
+
+  If `ON`, `SuiteSparse_config` uses OpenMP is used if it is available.
+  Default: `SUITESPARSE_USE_OPENMP`.
+  It is not essential and only used to let `SuiteSparse_time` call `omp_get_wtime`.
 
 * `CHOLMOD_USE_OPENMP`:
 
-  If `ON`, OpenMP is used in CHOLMOD if it is available.  Default:
-  `SUITESPARSE_USE_OPENMP`.
+  If `ON`, OpenMP is used in CHOLMOD if it is available.
+  Default: `SUITESPARSE_USE_OPENMP`.
 
 * `GRAPHBLAS_USE_OPENMP`:
 
-  If `ON`, OpenMP is used in GraphBLAS if it is available.  Default:
-  `SUITESPARSE_USE_OPENMP`.
+  If `ON`, OpenMP is used in GraphBLAS if it is available.
+  Default: `SUITESPARSE_USE_OPENMP`.
 
 * `LAGRAPH_USE_OPENMP`:
 
-  If `ON`, OpenMP is used in LAGraph if it is available.  Default:
-  `SUITESPARSE_USE_OPENMP`.
+  If `ON`, OpenMP is used in LAGraph if it is available.
+  Default: `SUITESPARSE_USE_OPENMP`.
 
 * `PARU_USE_OPENMP`:
 
-  If `ON`, OpenMP is used in ParU if it is available.  Default:
-  `SUITESPARSE_USE_OPENMP`.
+  If `ON`, OpenMP is used in ParU if it is available.
+  Default: `SUITESPARSE_USE_OPENMP`.
 
 * `SUITESPARSE_DEMOS`:
 

--- a/SuiteSparse_config/Config/README.md.in
+++ b/SuiteSparse_config/Config/README.md.in
@@ -811,34 +811,42 @@ build type).  The static libraries will not be built (since
 
   If `ON`, OpenMP is used if it is available.  Default: `OFF`.
 
-  UMFPACK, CHOLMOD, SPQR, and GraphBLAS will be slow if OpenMP is not used.
+  GraphBLAS, LAGraph, and ParU will be slow if OpenMP is not used.
+  Other packages (UMFPACK, CHOLMOD, SPQR) may use OpenMP in the BLAS/LAPACK,
+  which is essential for performance.
 
   Note that BLAS and LAPACK may still use OpenMP internally; if you wish to
   disable OpenMP in an entire application, select a single-threaded
   BLAS/LAPACK.
 
-  WARNING: GraphBLAS may not be thread-safe if built without OpenMP (see the
-  User Guide for details).
+  WARNING: GraphBLAS may not be thread-safe if built without OpenMP or pthreads
+  (see the User Guide for details).
+
+* `SUITESPARSE_CONFIG_USE_OPENMP`:
+
+  If `ON`, `SuiteSparse_config` uses OpenMP is used if it is available.
+  Default: `SUITESPARSE_USE_OPENMP`.
+  It is not essential and only used to let `SuiteSparse_time` call `omp_get_wtime`.
 
 * `CHOLMOD_USE_OPENMP`:
 
-  If `ON`, OpenMP is used in CHOLMOD if it is available.  Default:
-  `SUITESPARSE_USE_OPENMP`.
+  If `ON`, OpenMP is used in CHOLMOD if it is available.
+  Default: `SUITESPARSE_USE_OPENMP`.
 
 * `GRAPHBLAS_USE_OPENMP`:
 
-  If `ON`, OpenMP is used in GraphBLAS if it is available.  Default:
-  `SUITESPARSE_USE_OPENMP`.
+  If `ON`, OpenMP is used in GraphBLAS if it is available.
+  Default: `SUITESPARSE_USE_OPENMP`.
 
 * `LAGRAPH_USE_OPENMP`:
 
-  If `ON`, OpenMP is used in LAGraph if it is available.  Default:
-  `SUITESPARSE_USE_OPENMP`.
+  If `ON`, OpenMP is used in LAGraph if it is available.
+  Default: `SUITESPARSE_USE_OPENMP`.
 
 * `PARU_USE_OPENMP`:
 
-  If `ON`, OpenMP is used in ParU if it is available.  Default:
-  `SUITESPARSE_USE_OPENMP`.
+  If `ON`, OpenMP is used in ParU if it is available.
+  Default: `SUITESPARSE_USE_OPENMP`.
 
 * `SUITESPARSE_DEMOS`:
 

--- a/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
+++ b/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
@@ -112,7 +112,6 @@ if ( WIN32 )
     add_compile_definitions ( _CRT_SECURE_NO_WARNINGS )
 endif ( )
 
-set ( CMAKE_MACOSX_RPATH TRUE )
 enable_language ( C )
 include ( GNUInstallDirs )
 


### PR DESCRIPTION
`CMAKE_MACOSX_RPATH` defaults to `ON` for cmake 3.0 and later, so this is no longer needed in any cmake script of SuiteSparse (MacPorts prefers to set this `OFF`), all of which require at least 3.13 (CSparse), or 3.20 or higher (the rest of SuiteSparse).  Note that there are some cmake scripts in dependent packages with 2.x requirements, but those cmake scripts are not used to build those packages; SuiteSparse uses its own cmake scripts to build them.

Also added more discussion of `*_USE_OPENMP` cmake options in the top level README.

See https://cmake.org/cmake/help/latest/prop_tgt/MACOSX_RPATH.html 