### PR TITLE
Display CMake report for each subproject

### DIFF
--- a/AMD/CMakeLists.txt
+++ b/AMD/CMakeLists.txt
@@ -26,7 +26,7 @@ message ( STATUS "Building AMD version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( amd
+project ( AMD
     VERSION "${AMD_VERSION_MAJOR}.${AMD_VERSION_MINOR}.${AMD_VERSION_SUB}"
     LANGUAGES C )
 
@@ -305,6 +305,4 @@ endif ( )
 # report status
 #-------------------------------------------------------------------------------
 
-if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
-    include ( SuiteSparseReport )
-endif ( )
+include ( SuiteSparseReport )

--- a/BTF/CMakeLists.txt
+++ b/BTF/CMakeLists.txt
@@ -26,7 +26,7 @@ message ( STATUS "Building BTF version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( btf
+project ( BTF
     VERSION "${BTF_VERSION_MAJOR}.${BTF_VERSION_MINOR}.${BTF_VERSION_SUB}"
     LANGUAGES C )
 
@@ -239,6 +239,4 @@ endif ( )
 # report status
 #-------------------------------------------------------------------------------
 
-if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
-    include ( SuiteSparseReport )
-endif ( )
+include ( SuiteSparseReport )

--- a/CAMD/CMakeLists.txt
+++ b/CAMD/CMakeLists.txt
@@ -25,7 +25,7 @@ message ( STATUS "Building CAMD version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( camd
+project ( CAMD
     VERSION "${CAMD_VERSION_MAJOR}.${CAMD_VERSION_MINOR}.${CAMD_VERSION_SUB}"
     LANGUAGES C )
 
@@ -285,6 +285,4 @@ endif ( )
 # report status
 #-------------------------------------------------------------------------------
 
-if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
-    include ( SuiteSparseReport )
-endif ( )
+include ( SuiteSparseReport )

--- a/CCOLAMD/CMakeLists.txt
+++ b/CCOLAMD/CMakeLists.txt
@@ -25,7 +25,7 @@ message ( STATUS "Building CCOLAMD version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( ccolamd
+project ( CCOLAMD
     VERSION "${CCOLAMD_VERSION_MAJOR}.${CCOLAMD_VERSION_MINOR}.${CCOLAMD_VERSION_SUB}"
     LANGUAGES C )
 
@@ -276,6 +276,4 @@ endif ( )
 # report status
 #-------------------------------------------------------------------------------
 
-if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
-    include ( SuiteSparseReport )
-endif ( )
+include ( SuiteSparseReport )

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -26,7 +26,7 @@ message ( STATUS "Building CHOLMOD version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( cholmod
+project ( CHOLMOD
         VERSION "${CHOLMOD_VERSION_MAJOR}.${CHOLMOD_VERSION_MINOR}.${CHOLMOD_VERSION_SUB}"
         LANGUAGES C )
 
@@ -837,6 +837,4 @@ endif ( )
 # report status
 #-------------------------------------------------------------------------------
 
-if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
-    include ( SuiteSparseReport )
-endif ( )
+include ( SuiteSparseReport )

--- a/COLAMD/CMakeLists.txt
+++ b/COLAMD/CMakeLists.txt
@@ -25,7 +25,7 @@ message ( STATUS "Building COLAMD version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( colamd
+project ( COLAMD
     VERSION "${COLAMD_VERSION_MAJOR}.${COLAMD_VERSION_MINOR}.${COLAMD_VERSION_SUB}"
     LANGUAGES C )
 
@@ -276,6 +276,4 @@ endif ( )
 # report status
 #-------------------------------------------------------------------------------
 
-if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
-    include ( SuiteSparseReport )
-endif ( )
+include ( SuiteSparseReport )

--- a/CXSparse/CMakeLists.txt
+++ b/CXSparse/CMakeLists.txt
@@ -25,7 +25,7 @@ message ( STATUS "Building CXSparse version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( cxsparse
+project ( CXSparse
     VERSION "${CXSPARSE_VERSION_MAJOR}.${CXSPARSE_VERSION_MINOR}.${CXSPARSE_VERSION_SUB}"
     LANGUAGES C )
 
@@ -394,6 +394,4 @@ endif ( )
 # report status
 #-------------------------------------------------------------------------------
 
-if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
-    include ( SuiteSparseReport )
-endif ( )
+include ( SuiteSparseReport )

--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -13,8 +13,7 @@ cmake_minimum_required ( VERSION 3.20 ) # GraphBLAS can be built stand-alone
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( graphblas
-        LANGUAGES C )
+project ( GraphBLAS LANGUAGES C )
 
 #-------------------------------------------------------------------------------
 # SuiteSparse policies
@@ -732,6 +731,4 @@ endif ( )
 # report status
 #-------------------------------------------------------------------------------
 
-if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
-    include ( GraphBLASReport )
-endif ( )
+include ( GraphBLASReport )

--- a/GraphBLAS/cmake_modules/GraphBLASReport.cmake
+++ b/GraphBLAS/cmake_modules/GraphBLASReport.cmake
@@ -10,7 +10,7 @@
 #-------------------------------------------------------------------------------
 
 message ( STATUS "------------------------------------------------------------------------" )
-message ( STATUS "CMAKE report for: ${CMAKE_PROJECT_NAME}" )
+message ( STATUS "CMAKE report for: ${PROJECT_NAME}" )
 message ( STATUS "------------------------------------------------------------------------" )
 if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
     message ( STATUS "inside common SuiteSparse root:  ${INSIDE_SUITESPARSE}" )

--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -26,7 +26,7 @@ message ( STATUS "Building KLU version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( klu
+project ( KLU
     VERSION "${KLU_VERSION_MAJOR}.${KLU_VERSION_MINOR}.${KLU_VERSION_SUB}"
     LANGUAGES C )
 #-------------------------------------------------------------------------------
@@ -567,6 +567,4 @@ endif ( )
 # report status
 #-------------------------------------------------------------------------------
 
-if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
-    include ( SuiteSparseReport )
-endif ( )
+include ( SuiteSparseReport )

--- a/LAGraph/CMakeLists.txt
+++ b/LAGraph/CMakeLists.txt
@@ -44,6 +44,11 @@ set ( LAGraph_VERSION_MAJOR 1 CACHE STRING "" FORCE )
 set ( LAGraph_VERSION_MINOR 1 CACHE STRING "" FORCE )
 set ( LAGraph_VERSION_SUB   0 CACHE STRING "" FORCE )
 
+message ( STATUS "Building LAGraph version: v"
+    ${LAGraph_VERSION_MAJOR}.
+    ${LAGraph_VERSION_MINOR}.
+    ${LAGraph_VERSION_SUB} " (" ${LAGraph_DATE} ")" )
+
 #-------------------------------------------------------------------------------
 # define the project
 #-------------------------------------------------------------------------------

--- a/LDL/CMakeLists.txt
+++ b/LDL/CMakeLists.txt
@@ -25,7 +25,7 @@ message ( STATUS "Building LDL version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( ldl
+project ( LDL
     VERSION "${LDL_VERSION_MAJOR}.${LDL_VERSION_MINOR}.${LDL_VERSION_SUB}"
     LANGUAGES C )
 
@@ -307,6 +307,4 @@ endif ( )
 # report status
 #-------------------------------------------------------------------------------
 
-if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
-    include ( SuiteSparseReport )
-endif ( )
+include ( SuiteSparseReport )

--- a/Mongoose/CMakeLists.txt
+++ b/Mongoose/CMakeLists.txt
@@ -50,9 +50,9 @@ message ( STATUS "Building Mongoose version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project(Mongoose
-        VERSION "${Mongoose_VERSION_MAJOR}.${Mongoose_VERSION_MINOR}.${Mongoose_VERSION_PATCH}"
-        LANGUAGES CXX C)
+project ( Mongoose
+    VERSION "${Mongoose_VERSION_MAJOR}.${Mongoose_VERSION_MINOR}.${Mongoose_VERSION_PATCH}"
+    LANGUAGES CXX C )
 
 #-------------------------------------------------------------------------------
 # SuiteSparse policies
@@ -640,6 +640,4 @@ endif ( )
 # report status
 #-------------------------------------------------------------------------------
 
-if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
-    include ( SuiteSparseReport )
-endif ( )
+include ( SuiteSparseReport )

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -27,7 +27,7 @@ message ( STATUS "Building PARU version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( paru
+project ( ParU
     VERSION "${PARU_VERSION_MAJOR}.${PARU_VERSION_MINOR}.${PARU_VERSION_UPDATE}" )
 
 #-------------------------------------------------------------------------------
@@ -467,6 +467,4 @@ endif ( )
 # report status
 #-------------------------------------------------------------------------------
 
-if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
-    include ( SuiteSparseReport )
-endif ( )
+include ( SuiteSparseReport )

--- a/RBio/CMakeLists.txt
+++ b/RBio/CMakeLists.txt
@@ -16,7 +16,7 @@ set ( RBIO_VERSION_MAJOR 4 CACHE STRING "" FORCE )
 set ( RBIO_VERSION_MINOR 3 CACHE STRING "" FORCE )
 set ( RBIO_VERSION_SUB   0 CACHE STRING "" FORCE )
 
-message ( STATUS "Building RBIO version: v"
+message ( STATUS "Building RBio version: v"
     ${RBIO_VERSION_MAJOR}.
     ${RBIO_VERSION_MINOR}.
     ${RBIO_VERSION_SUB} " (" ${RBIO_DATE} ")" )
@@ -25,7 +25,7 @@ message ( STATUS "Building RBIO version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( rbio
+project ( RBio
     VERSION "${RBIO_VERSION_MAJOR}.${RBIO_VERSION_MINOR}.${RBIO_VERSION_SUB}"
     LANGUAGES C )
 
@@ -274,6 +274,4 @@ endif ( )
 # report status
 #-------------------------------------------------------------------------------
 
-if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
-    include ( SuiteSparseReport )
-endif ( )
+include ( SuiteSparseReport )

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -26,7 +26,7 @@ message ( STATUS "Building SPEX version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( spex
+project ( SPEX
     VERSION "${SPEX_VERSION_MAJOR}.${SPEX_VERSION_MINOR}.${SPEX_VERSION_SUB}"
     LANGUAGES C )
 
@@ -379,6 +379,4 @@ endif ( )
 # report status
 #-------------------------------------------------------------------------------
 
-if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
-    include ( SuiteSparseReport )
-endif ( )
+include ( SuiteSparseReport )

--- a/SPQR/CMakeLists.txt
+++ b/SPQR/CMakeLists.txt
@@ -27,7 +27,7 @@ message ( STATUS "Building SPQR version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( spqr
+project ( SPQR
     VERSION "${SPQR_VERSION_MAJOR}.${SPQR_VERSION_MINOR}.${SPQR_VERSION_SUB}"
     LANGUAGES C CXX )
 
@@ -456,6 +456,4 @@ endif ( )
 # report status
 #-------------------------------------------------------------------------------
 
-if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
-    include ( SuiteSparseReport )
-endif ( )
+include ( SuiteSparseReport )

--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -300,6 +300,4 @@ endif ( )
 # report status
 #-------------------------------------------------------------------------------
 
-if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
-    include ( SuiteSparseReport )
-endif ( )
+include ( SuiteSparseReport )

--- a/SuiteSparse_config/cmake_modules/SuiteSparseReport.cmake
+++ b/SuiteSparse_config/cmake_modules/SuiteSparseReport.cmake
@@ -10,7 +10,7 @@
 #-------------------------------------------------------------------------------
 
 message ( STATUS "------------------------------------------------------------------------" )
-message ( STATUS "SuiteSparse CMAKE report for: ${CMAKE_PROJECT_NAME}" )
+message ( STATUS "SuiteSparse CMAKE report for: ${PROJECT_NAME}" )
 message ( STATUS "------------------------------------------------------------------------" )
 if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
     message ( STATUS "inside common SuiteSparse root:  ${INSIDE_SUITESPARSE}" )

--- a/UMFPACK/CMakeLists.txt
+++ b/UMFPACK/CMakeLists.txt
@@ -26,7 +26,7 @@ message ( STATUS "Building UMFPACK version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( umfpack
+project ( UMFPACK
     VERSION "${UMFPACK_VERSION_MAJOR}.${UMFPACK_VERSION_MINOR}.${UMFPACK_VERSION_SUB}"
     LANGUAGES C )
 
@@ -456,6 +456,4 @@ endif ( )
 # report status
 #-------------------------------------------------------------------------------
 
-if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
-    include ( SuiteSparseReport )
-endif ( )
+include ( SuiteSparseReport )


### PR DESCRIPTION
Even if this repeats some of the information multiple times, it is a nice way to display a summary of the most important settings of each subproject. Additionally, the CMake summary can serve as a visible divisor in the configuration steps of each respective subproject.
