### PR TITLE
Re-enable CI for MSVC with CUDA

### DIFF
--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -234,6 +234,11 @@ jobs:
         include:
           - openmp: without
             openmp-cmake-flags: "-DSUITESPARSE_USE_OPENMP=OFF"
+          - openmp: with
+            cuda: with
+            cuda-cmake-flags:
+              -DSUITESPARSE_USE_CUDA=ON
+              -DCMAKE_CUDA_COMPILER_LAUNCHER="ccache"
 
     env:
       CHERE_INVOKING: 1

--- a/README.md
+++ b/README.md
@@ -910,9 +910,9 @@ build type).  The static libraries will not be built (since
   If set to `ON`, CUDA is enabled for all of SuiteSparse.  Default: `ON`,
 
   CUDA on Windows with MSVC appears to be working with this release, but it
-  should be consider as a prototype and may not be fully functional.  I have
+  should be considered as a prototype and may not be fully functional.  I have
   limited resources for testing CUDA on Windows.  If you encounter issues,
-  disable CUDA and post this as an issue on github.
+  disable CUDA and post this as an issue on GitHub.
 
 * `CHOLMOD_USE_CUDA`:
 

--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -58,7 +58,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( SUITESPARSE_HAS_CUDA AND MSVC )
-    message ( WARNING "NOTE: CUDA on MSVC has only recently been revised.  It appears to be functional but has not been as rigorously tested as I would like (I have limited resources for testing CUDA on Windows).  If you encounter issues, set the cmake option SUITESPARSE_USE_CUDA to OFF and post an issue on github." )
+    message ( WARNING "NOTE: CUDA on MSVC has only recently been revised.  It appears to be functional but has not been as rigorously tested as I would like (I have limited resources for testing CUDA on Windows).  If you encounter issues, set the cmake option SUITESPARSE_USE_CUDA to OFF and post an issue on GitHub." )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/SuiteSparse_config/Config/README.md.in
+++ b/SuiteSparse_config/Config/README.md.in
@@ -910,9 +910,9 @@ build type).  The static libraries will not be built (since
   If set to `ON`, CUDA is enabled for all of SuiteSparse.  Default: `ON`,
 
   CUDA on Windows with MSVC appears to be working with this release, but it
-  should be consider as a prototype and may not be fully functional.  I have
+  should be considered as a prototype and may not be fully functional.  I have
   limited resources for testing CUDA on Windows.  If you encounter issues,
-  disable CUDA and post this as an issue on github.
+  disable CUDA and post this as an issue on GitHub.
 
 * `CHOLMOD_USE_CUDA`:
 


### PR DESCRIPTION
Even if this configuration isn't completely supported yet, at least make sure that building doesn't break.
