### PR TITLE
GraphBLAS: Store output name in imported target

### DIFF
--- a/GraphBLAS/Config/GraphBLASConfig.cmake.in
+++ b/GraphBLAS/Config/GraphBLASConfig.cmake.in
@@ -111,6 +111,7 @@ set ( _var_prefix "GRAPHBLAS" )
 if ( NOT @BUILD_SHARED_LIBS@ AND NOT TARGET ${_target_shared} )
     # make sure there is always an import target without suffix )
     add_library ( ${_target_shared} ALIAS ${_target_static} )
+    set ( _shared_is_aliased ON )
 endif ( )
 
 get_target_property ( ${_var_prefix}_INCLUDE_DIR ${_target_shared} INTERFACE_INCLUDE_DIRECTORIES )
@@ -189,3 +190,63 @@ message ( STATUS "GraphBLAS version: ${GRAPHBLAS_VERSION}" )
 message ( STATUS "GraphBLAS include: ${GRAPHBLAS_INCLUDE_DIR}" )
 message ( STATUS "GraphBLAS library: ${GRAPHBLAS_LIBRARY}" )
 message ( STATUS "GraphBLAS static:  ${GRAPHBLAS_STATIC}" )
+
+if ( NOT _shared_is_aliased AND GRAPHBLAS_LIBRARY )
+    # Get library name from filename of library
+    # This might be something like:
+    #   /usr/lib/libgraphblas.so or /usr/lib/libgraphblas.a or graphblas64
+    # convert to library name that can be used with -l flags for pkg-config
+    set ( GRAPHBLAS_LIBRARY_TMP ${GRAPHBLAS_LIBRARY} )
+    string ( FIND ${GRAPHBLAS_LIBRARY} "." _pos REVERSE )
+    if ( ${_pos} EQUAL "-1" )
+        set ( _graphblas_library_name ${GRAPHBLAS_LIBRARY} )
+    else ( )
+      set ( _kinds "SHARED" "STATIC" )
+      if ( WIN32 )
+          list ( PREPEND _kinds "IMPORT" )
+      endif ( )
+      foreach ( _kind IN LISTS _kinds )
+          set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
+          if ( ${GRAPHBLAS_LIBRARY} MATCHES ${_regex} )
+              string ( REGEX REPLACE ${_regex} "\\2" _libname ${GRAPHBLAS_LIBRARY} )
+              if ( NOT "${_libname}" STREQUAL "" )
+                  set ( _graphblas_library_name ${_libname} )
+                  break ()
+              endif ( )
+          endif ( )
+      endforeach ( )
+    endif ( )
+
+    set_target_properties ( SuiteSparse::GraphBLAS PROPERTIES
+        OUTPUT_NAME ${_graphblas_library_name} )
+endif ( )
+
+if ( GRAPHBLAS_STATIC )
+    # Get library name from filename of library
+    # This might be something like:
+    #   /usr/lib/libgraphblas.so or /usr/lib/libgraphblas.a or graphblas64
+    # convert to library name that can be used with -l flags for pkg-config
+    set ( GRAPHBLAS_LIBRARY_TMP ${GRAPHBLAS_STATIC} )
+    string ( FIND ${GRAPHBLAS_STATIC} "." _pos REVERSE )
+    if ( ${_pos} EQUAL "-1" )
+        set ( _graphblas_library_name ${GRAPHBLAS_STATIC} )
+    else ( )
+      set ( _kinds "SHARED" "STATIC" )
+      if ( WIN32 )
+          list ( PREPEND _kinds "IMPORT" )
+      endif ( )
+      foreach ( _kind IN LISTS _kinds )
+          set ( _regex ".*\\/(lib)?([^\\.]*)(${CMAKE_${_kind}_LIBRARY_SUFFIX})" )
+          if ( ${GRAPHBLAS_STATIC} MATCHES ${_regex} )
+              string ( REGEX REPLACE ${_regex} "\\2" _libname ${GRAPHBLAS_STATIC} )
+              if ( NOT "${_libname}" STREQUAL "" )
+                  set ( _graphblas_library_name ${_libname} )
+                  break ()
+              endif ( )
+          endif ( )
+      endforeach ( )
+    endif ( )
+
+    set_target_properties ( SuiteSparse::GraphBLAS_static PROPERTIES
+        OUTPUT_NAME ${_graphblas_library_name} )
+endif ( )


### PR DESCRIPTION
This fixes #656 for me.

It turns out the imported targets for GraphBLAS didn't hold enough information for the `FindGraphBLAS` module of LAGraph to extract the base library name. That base library name is needed to generate the static linker flag for `LAGraph.pc`.

Add that information to the imported targets.

Maybe, we should add some steps to the CI that check whether the generated pkg-config files actually work.
I'll try to look into that...
