### PR TITLE
KLU: Check for dependencies before including target file

### DIFF
--- a/KLU/Config/KLUConfig.cmake.in
+++ b/KLU/Config/KLUConfig.cmake.in
@@ -35,8 +35,6 @@ set ( KLU_VERSION_MINOR @KLU_VERSION_MINOR@ )
 set ( KLU_VERSION_PATCH @KLU_VERSION_SUB@ )
 set ( KLU_VERSION "@KLU_VERSION_MAJOR@.@KLU_VERSION_MINOR@.@KLU_VERSION_SUB@" )
 
-include ( ${CMAKE_CURRENT_LIST_DIR}/KLUTargets.cmake )
-
 # Check for dependent targets
 include ( CMakeFindDependencyMacro )
 
@@ -102,6 +100,9 @@ if ( NOT SuiteSparse_config_FOUND OR NOT BTF_FOUND OR NOT AMD_FOUND OR NOT COLAM
     return ( )
 endif ( )
 
+
+# Import target
+include ( ${CMAKE_CURRENT_LIST_DIR}/KLUTargets.cmake )
 
 # The following is only for backward compatibility with FindKLU.
 

--- a/SuiteSparse_config/Config/SuiteSparse_configConfig.cmake.in
+++ b/SuiteSparse_config/Config/SuiteSparse_configConfig.cmake.in
@@ -53,6 +53,7 @@ if ( NOT _dependencies_found )
 endif ( )
 
 
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/SuiteSparse_configTargets.cmake )
 
 if ( @SUITESPARSE_HAS_OPENMP@ )
@@ -79,6 +80,7 @@ if ( @SUITESPARSE_HAS_OPENMP@ )
         endif ( )
     endif ( )
 endif ( )
+
 
 # The following is only for backward compatibility with FindSuiteSparse_config.
 

--- a/UMFPACK/Config/UMFPACKConfig.cmake.in
+++ b/UMFPACK/Config/UMFPACKConfig.cmake.in
@@ -92,6 +92,8 @@ if ( NOT SuiteSparse_config_FOUND OR NOT AMD_FOUND
     return ( )
 endif ( )
 
+
+# Import target
 include ( ${CMAKE_CURRENT_LIST_DIR}/UMFPACKTargets.cmake )
 
 # The following is only for backward compatibility with FindUMFPACK.


### PR DESCRIPTION
Afaict, most CMake config files look for dependencies before including the Target file.
Do the same also for KLUConfig.cmake. Otherwise, there could be odd behavior in some circumstances.
