### PR TITLE
Example: Add tests that use each sub-project separately

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -14,6 +14,8 @@ env:
   BUILD_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:ParU:RBio:SPQR:SPEX"
   # string with name of libraries to be checked
   CHECK_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:ParU:RBio:SPQR:SPEX"
+  # string with name of libraries that are installed
+  INSTALLED_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CXSparse:LDL:KLU:UMFPACK:ParU:RBio:SPQR:SPEX"
 
 
 jobs:
@@ -195,6 +197,18 @@ jobs:
           printf "\033[1;35m  C++ binary with statically linked libraries\033[0m\n"
           ./my_cxx_demo_static
           echo "::endgroup::"
+          IFS=:
+          INSTALLED_LIBS="${INSTALLED_LIBS}${{ matrix.extra-build-libs }}"
+          for lib in ${INSTALLED_LIBS}; do
+            printf "::group::   \033[0;32m==>\033[0m Building test with library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/Example/${lib}
+            mkdir build && cd build
+            cmake \
+              -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/lib/cmake" \
+              ..
+            cmake --build . --config Release
+            echo "::endgroup::"
+          done
 
       - name: build example using autotools
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,8 @@ env:
   BUILD_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:ParU:RBio:SPQR:SPEX:GraphBLAS:LAGraph"
   # string with name of libraries to be checked
   CHECK_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:ParU:RBio:SPQR:SPEX:GraphBLAS:LAGraph"
+  # string with name of libraries that are installed
+  INSTALLED_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CXSparse:LDL:KLU:UMFPACK:ParU:RBio:SPQR:SPEX:GraphBLAS:LAGraph"
 
 
 jobs:
@@ -227,6 +229,17 @@ jobs:
           printf "\033[1;35m  C++ binary with statically linked libraries\033[0m\n"
           ./my_cxx_demo_static
           echo "::endgroup::"
+          IFS=':' read -r -a libs <<< "${INSTALLED_LIBS}"
+          for lib in "${libs[@]}"; do
+            printf "::group::   \033[0;32m==>\033[0m Building test with library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/Example/${lib}
+            mkdir build && cd build
+            cmake \
+              -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/lib/cmake" \
+              ..
+            cmake --build . --config Release
+            echo "::endgroup::"
+          done
 
       - name: build example using autotools
         run: |
@@ -424,6 +437,17 @@ jobs:
           PATH="${GITHUB_WORKSPACE}/bin:${PATH}" \
             ./my_cxx_demo_static
           echo "::endgroup::"
+          IFS=':' read -r -a libs <<< "${INSTALLED_LIBS}"
+          for lib in "${libs[@]}"; do
+            printf "::group::   \033[0;32m==>\033[0m Building test with library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/Example/${lib}
+            mkdir build && cd build
+            cmake \
+              -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/lib/cmake" \
+              ..
+            cmake --build . --config Release
+            echo "::endgroup::"
+          done
 
       - name: build example using autotools
         run: |

--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -12,6 +12,10 @@ on:
 
 concurrency: ci-root-cmakelists-${{ github.ref }}
 
+env:
+  # string with name of libraries that are installed
+  INSTALLED_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CXSparse:LDL:KLU:UMFPACK:ParU:RBio:SPQR:SPEX:GraphBLAS:LAGraph"
+
 jobs:
 
   ubuntu:
@@ -210,6 +214,17 @@ jobs:
           printf "\033[1;35m  C++ binary with statically linked libraries\033[0m\n"
           ./my_cxx_demo_static
           echo "::endgroup::"
+          IFS=':' read -r -a libs <<< "${INSTALLED_LIBS}"
+          for lib in "${libs[@]}"; do
+            printf "::group::   \033[0;32m==>\033[0m Building test with library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/Example/${lib}
+            mkdir build && cd build
+            cmake \
+              -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/lib/cmake" \
+              ..
+            cmake --build . --config Release
+            echo "::endgroup::"
+          done
 
       - name: build example using autotools
         run: |
@@ -478,3 +493,14 @@ jobs:
           PATH="${GITHUB_WORKSPACE}/bin;${GITHUB_WORKSPACE}/dependencies/bin;${PATH}" \
             ./Release/my_cxx_demo_static
           echo "::endgroup::"
+          IFS=':' read -r -a libs <<< "${INSTALLED_LIBS}"
+          for lib in "${libs[@]}"; do
+            printf "::group::   \033[0;32m==>\033[0m Building test with library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/Example/${lib}
+            mkdir build && cd build
+            cmake \
+              -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/lib/cmake;C:/Miniconda/envs/test/Library;${GITHUB_WORKSPACE}/dependencies" \
+              ..
+            cmake --build . --config Release
+            echo "::endgroup::"
+          done

--- a/Example/AMD/CMakeLists.txt
+++ b/Example/AMD/CMakeLists.txt
@@ -1,0 +1,91 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/CAMD/CMakeLists.txt:  cmake for project linking to CAMD
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME amd_demo )
+set ( TEST_PACKAGE_NAME AMD )
+set ( TEST_SHARED_BIN amd_demo )
+set ( TEST_STATIC_BIN amd_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::AMD )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::AMD_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/AMD/demo.cc
+++ b/Example/AMD/demo.cc
@@ -1,0 +1,38 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/AMD/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+
+#include "amd.h"
+
+int main (void)
+{
+    #define N 2
+    #define NNZ 4
+    int64_t n = N;
+    int64_t nzmax = NNZ;
+    int64_t Ap[N+1];
+    int64_t Ai[NNZ];
+    Ap [0] = 0;
+    Ap [1] = 2;
+    Ap [2] = NNZ;
+    Ai [0] = 0;
+    Ai [1] = 1;
+    Ai [2] = 0;
+    Ai [3] = 1;
+
+    int64_t P [N];
+    amd_l_order (n, Ap, Ai, P, nullptr, nullptr);
+    for (int k = 0; k < n; k++)
+      std::cout << "P [" << k << "] = " << P [k] << std::endl;
+
+    return 0;
+}

--- a/Example/BTF/CMakeLists.txt
+++ b/Example/BTF/CMakeLists.txt
@@ -1,0 +1,91 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/BTF/CMakeLists.txt:  cmake for project linking to BTF
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME btf_demo )
+set ( TEST_PACKAGE_NAME BTF )
+set ( TEST_SHARED_BIN btf_demo )
+set ( TEST_STATIC_BIN btf_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::BTF )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::BTF_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/BTF/demo.cc
+++ b/Example/BTF/demo.cc
@@ -1,0 +1,44 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/BTF/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+
+#include "btf.h"
+
+int main (void)
+{
+    #define N 2
+    #define NNZ 4
+    int64_t n = N;
+    int64_t nzmax = NNZ;
+    int64_t Ap[N+1];
+    int64_t Ai[NNZ];
+    Ap [0] = 0;
+    Ap [1] = 2;
+    Ap [2] = NNZ;
+    Ai [0] = 0;
+    Ai [1] = 1;
+    Ai [2] = 0;
+    Ai [3] = 1;
+
+    int64_t P [N];
+    double work;
+    int64_t nmatch;
+    int64_t Q [N], R [N+1], Work [5*N];
+    int64_t nblocks = btf_l_order (n, Ap, Ai, -1, &work, P, Q, R, &nmatch, Work);
+    for (int k = 0; k < n; k++)
+      std::cout << "P [" << k << "] = " << P [k] << std::endl;
+    for (int k = 0; k < n; k++)
+      std::cout << "Q [" << k << "] = " << Q [k] << std::endl;
+    std::cout << "nblocks " << nblocks << std::endl;
+
+    return 0;
+}

--- a/Example/CAMD/CMakeLists.txt
+++ b/Example/CAMD/CMakeLists.txt
@@ -1,0 +1,91 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/CAMD/CMakeLists.txt:  cmake for project linking to CAMD
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME camd_demo )
+set ( TEST_PACKAGE_NAME CAMD )
+set ( TEST_SHARED_BIN camd_demo )
+set ( TEST_STATIC_BIN camd_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::CAMD )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::CAMD_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/CAMD/demo.cc
+++ b/Example/CAMD/demo.cc
@@ -1,0 +1,41 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/CAMD/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+
+#include "camd.h"
+
+int main (void)
+{
+    #define N 2
+    #define NNZ 4
+    int64_t n = N;
+    int64_t nzmax = NNZ;
+    int64_t Ap[N+1];
+    int64_t Ai[NNZ];
+    Ap [0] = 0;
+    Ap [1] = 2;
+    Ap [2] = NNZ;
+    Ai [0] = 0;
+    Ai [1] = 1;
+    Ai [2] = 0;
+    Ai [3] = 1;
+
+    int64_t P [N];
+    int64_t Cmem [N] ;
+    for (int k = 0; k < n; k++)
+      Cmem [k] = 0;
+    camd_l_order (n, Ap, Ai, P, nullptr, nullptr, Cmem);
+    for (int k = 0; k < n; k++)
+      std::cout << "P [" << k << "] = " << P [k] << std::endl;
+
+    return 0;
+}

--- a/Example/CCOLAMD/CMakeLists.txt
+++ b/Example/CCOLAMD/CMakeLists.txt
@@ -1,0 +1,91 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/CCOLAMD/CMakeLists.txt:  cmake for project linking to CCOLAMD
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME ccolamd_demo )
+set ( TEST_PACKAGE_NAME CCOLAMD )
+set ( TEST_SHARED_BIN ccolamd_demo )
+set ( TEST_STATIC_BIN ccolamd_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::CCOLAMD )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::CCOLAMD_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/CCOLAMD/demo.cc
+++ b/Example/CCOLAMD/demo.cc
@@ -1,0 +1,45 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/CCOLAMD/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+
+#include "ccolamd.h"
+
+int main (void)
+{
+    #define N 2
+    #define NNZ 4
+    int64_t n = N;
+    int64_t nzmax = NNZ;
+    int64_t Ap[N+1];
+    int64_t Ai[NNZ];
+    Ap [0] = 0;
+    Ap [1] = 2;
+    Ap [2] = NNZ;
+    Ai [0] = 0;
+    Ai [1] = 1;
+    Ai [2] = 0;
+    Ai [3] = 1;
+
+    int64_t P [N];
+    int64_t Cmem [N] ;
+    for (int k = 0; k < n; k++)
+      Cmem [k] = 0;
+    int64_t Alen = ccolamd_l_recommended (NNZ, n, n);
+    int64_t *Awork = (int64_t *) malloc (Alen * sizeof (int64_t));
+    memcpy (Awork, Ai, NNZ * sizeof (int64_t));
+    ccolamd_l (n, n, Alen, Awork, P, nullptr, nullptr, Cmem);
+    for (int k = 0; k < n; k++)
+      std::cout << "P [" << k << "] = " << P [k] << std::endl;
+    free (Awork);
+
+    return 0;
+}

--- a/Example/CHOLMOD/CMakeLists.txt
+++ b/Example/CHOLMOD/CMakeLists.txt
@@ -1,0 +1,91 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/CHOLMOD/CMakeLists.txt:  cmake for project linking to CHOLMOD
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME cholmod_demo )
+set ( TEST_PACKAGE_NAME CHOLMOD )
+set ( TEST_SHARED_BIN cholmod_demo )
+set ( TEST_STATIC_BIN cholmod_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::CHOLMOD )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::CHOLMOD_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/CHOLMOD/demo.cc
+++ b/Example/CHOLMOD/demo.cc
@@ -1,0 +1,23 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/CHOLMOD/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+
+#include "cholmod.h"
+
+int main (void)
+{
+    cholmod_common cc;
+    cholmod_l_start (&cc);
+    cholmod_l_finish (&cc);
+
+    return 0;
+}

--- a/Example/COLAMD/CMakeLists.txt
+++ b/Example/COLAMD/CMakeLists.txt
@@ -1,0 +1,91 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/COLAMD/CMakeLists.txt:  cmake for project linking to COLAMD
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME colamd_demo )
+set ( TEST_PACKAGE_NAME COLAMD )
+set ( TEST_SHARED_BIN colamd_demo )
+set ( TEST_STATIC_BIN colamd_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::COLAMD )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::COLAMD_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/COLAMD/demo.cc
+++ b/Example/COLAMD/demo.cc
@@ -1,0 +1,42 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/COLAMD/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+
+#include "colamd.h"
+
+int main (void)
+{
+    #define N 2
+    #define NNZ 4
+    int64_t n = N;
+    int64_t nzmax = NNZ;
+    int64_t Ap[N+1];
+    int64_t Ai[NNZ];
+    Ap [0] = 0;
+    Ap [1] = 2;
+    Ap [2] = NNZ;
+    Ai [0] = 0;
+    Ai [1] = 1;
+    Ai [2] = 0;
+    Ai [3] = 1;
+
+    int64_t P [N];
+    int64_t Alen = colamd_l_recommended (NNZ, n, n);
+    int64_t *Awork = (int64_t *) malloc (Alen * sizeof (int64_t));
+    memcpy (Awork, Ai, NNZ * sizeof (int64_t));
+    colamd_l (n, n, Alen, Awork, P, nullptr, nullptr);
+    for (int k = 0; k < n; k++)
+      std::cout << "P [" << k << "] = " << P [k] << std::endl;
+    free (Awork);
+
+    return 0;
+}

--- a/Example/CXSparse/CMakeLists.txt
+++ b/Example/CXSparse/CMakeLists.txt
@@ -1,0 +1,91 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/CXSparse/CMakeLists.txt:  cmake for project linking to CXSparse
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME cxsparse_demo )
+set ( TEST_PACKAGE_NAME CXSparse )
+set ( TEST_SHARED_BIN cxsparse_demo )
+set ( TEST_STATIC_BIN cxsparse_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::CXSparse )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::CXSparse_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/CXSparse/demo.cc
+++ b/Example/CXSparse/demo.cc
@@ -1,0 +1,41 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/CXSparse/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+
+#include "cs.h"
+
+int main (void)
+{
+    #define N 2
+    #define NNZ 4
+    int64_t n = N;
+    int64_t nzmax = NNZ;
+    cs_dl *A = cs_dl_spalloc (n, n, nzmax, true, false);
+    int64_t *Ap = A->p;
+    int64_t *Ai = A->i;
+    double  *Ax = A->x;
+    Ap [0] = 0;
+    Ap [1] = 2;
+    Ap [2] = NNZ;
+    Ai [0] = 0;
+    Ai [1] = 1;
+    Ai [2] = 0;
+    Ai [3] = 1;
+    Ax [0] = 11.0;
+    Ax [1] = 21.0;
+    Ax [2] = 12.0;
+    Ax [3] = 22.0;
+
+    cs_dl_print (A, false);
+
+    return 0;
+}

--- a/Example/GraphBLAS/CMakeLists.txt
+++ b/Example/GraphBLAS/CMakeLists.txt
@@ -1,0 +1,91 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/GraphBLAS/CMakeLists.txt:  cmake for project linking to GraphBLAS
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME graphblas_demo )
+set ( TEST_PACKAGE_NAME GraphBLAS )
+set ( TEST_SHARED_BIN graphblas_demo )
+set ( TEST_STATIC_BIN graphblas_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::GraphBLAS )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::GraphBLAS_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/GraphBLAS/demo.cc
+++ b/Example/GraphBLAS/demo.cc
@@ -1,0 +1,24 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/GraphBLAS/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+
+#include "GraphBLAS.h"
+
+int main (void)
+{
+    int version [3];
+    GrB_init (GrB_NONBLOCKING);
+    GxB_Global_Option_get (GxB_LIBRARY_VERSION, version);
+    GrB_finalize ();
+
+    return 0;
+}

--- a/Example/KLU/CMakeLists.txt
+++ b/Example/KLU/CMakeLists.txt
@@ -1,0 +1,100 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/KLU/CMakeLists.txt:  cmake for project linking to KLU
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME klu_demo )
+set ( TEST_PACKAGE_NAME KLU )
+set ( TEST_SHARED_BIN klu_demo )
+set ( TEST_STATIC_BIN klu_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::KLU )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::KLU_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+# libm:
+include ( CheckSymbolExists )
+check_symbol_exists ( fmax "math.h" NO_LIBM )
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+    if ( NOT NO_LIBM )
+        target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE "m" )
+    endif ( )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+    if ( NOT NO_LIBM )
+        target_link_libraries ( ${TEST_STATIC_BIN} PRIVATE "m" )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/KLU/demo.cc
+++ b/Example/KLU/demo.cc
@@ -1,0 +1,61 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/KLU/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+#include <math.h>
+
+#include "klu.h"
+
+int main (void)
+{
+    #define N 2
+    #define NNZ 4
+    int64_t n = N;
+    int64_t nzmax = NNZ;
+    int64_t Ap[N+1];
+    int64_t Ai[NNZ];
+    double Ax[NNZ];
+    Ap [0] = 0;
+    Ap [1] = 2;
+    Ap [2] = NNZ;
+    Ai [0] = 0;
+    Ai [1] = 1;
+    Ai [2] = 0;
+    Ai [3] = 1;
+    Ax [0] = 11.0;
+    Ax [1] = 21.0;
+    Ax [2] = 12.0;
+    Ax [3] = 22.0;
+
+    double b [N] = {8., 45.};
+    double xgood [N] = {36.4, -32.7};
+    double x [N];
+
+    klu_l_symbolic *Symbolic;
+    klu_l_numeric *Numeric;
+    klu_l_common Common;
+    klu_l_defaults (&Common);
+    Symbolic = klu_l_analyze (n, Ap, Ai, &Common);
+    Numeric = klu_l_factor (Ap, Ai, Ax, Symbolic, &Common);
+    memcpy (x, b, N * sizeof (double));
+    klu_l_solve (Symbolic, Numeric, 5, 1, x, &Common);
+    klu_l_free_symbolic (&Symbolic, &Common);
+    klu_l_free_numeric (&Numeric, &Common);
+    double err = 0;
+    for (int i = 0; i < n; i++)
+    {
+      std::cout << "x [" << i << "] = " << x [i] << std::endl;
+      err = fmax (err, fabs (x [i] - xgood [i]));
+    }
+    std::cout << "error: " << err << std::endl;
+
+    return 0;
+}

--- a/Example/LAGraph/CMakeLists.txt
+++ b/Example/LAGraph/CMakeLists.txt
@@ -1,0 +1,91 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/LAGraph/CMakeLists.txt:  cmake for project linking to LAGraph
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME lagraph_demo )
+set ( TEST_PACKAGE_NAME LAGraph )
+set ( TEST_SHARED_BIN lagraph_demo )
+set ( TEST_STATIC_BIN lagraph_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::LAGraph )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::LAGraph_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/LAGraph/demo.cc
+++ b/Example/LAGraph/demo.cc
@@ -1,0 +1,25 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/LAGraph/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+
+#include "LAGraph.h"
+
+int main (void)
+{
+    int version [3];
+    char msg [LAGRAPH_MSG_LEN], verstring [LAGRAPH_MSG_LEN];
+    LAGraph_Init (msg);
+    LAGraph_Version (version, verstring, msg);
+    LAGraph_Finalize (msg);
+
+    return 0;
+}

--- a/Example/LDL/CMakeLists.txt
+++ b/Example/LDL/CMakeLists.txt
@@ -1,0 +1,100 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/LDL/CMakeLists.txt:  cmake for project linking to LDL
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME ldl_demo )
+set ( TEST_PACKAGE_NAME LDL )
+set ( TEST_SHARED_BIN ldl_demo )
+set ( TEST_STATIC_BIN ldl_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::LDL )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::LDL_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+# libm:
+include ( CheckSymbolExists )
+check_symbol_exists ( fmax "math.h" NO_LIBM )
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+    if ( NOT NO_LIBM )
+        target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE "m" )
+    endif ( )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+    if ( NOT NO_LIBM )
+        target_link_libraries ( ${TEST_STATIC_BIN} PRIVATE "m" )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/LDL/demo.cc
+++ b/Example/LDL/demo.cc
@@ -1,0 +1,37 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/LDL/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+#include <math.h>
+
+#include "ldl.h"
+
+int main (void)
+{
+    #define N 2
+    int64_t n = N;
+    int64_t P [N];
+
+    double xgood [N] = {36.4, -32.7};
+    double x [N];
+    P [0] = 0 ;
+    P [1] = 1 ;
+    ldl_l_perm (n, x, xgood, P);
+    double err = 0;
+    for (int i = 0; i < n; i++)
+    {
+      std::cout << "x2 [" << i << "] = " << x [i] << std::endl;
+      err = fmax (err, fabs (x [i] - xgood [i]));
+    }
+    std::cout << "error: " << err << std::endl;
+
+    return 0;
+}

--- a/Example/Mongoose/CMakeLists.txt
+++ b/Example/Mongoose/CMakeLists.txt
@@ -1,0 +1,91 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/Mongoose/CMakeLists.txt:  cmake for project linking to Mongoose
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME mongoose_demo )
+set ( TEST_PACKAGE_NAME SuiteSparse_Mongoose )
+set ( TEST_SHARED_BIN mongoose_demo )
+set ( TEST_STATIC_BIN mongoose_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::Mongoose )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::Mongoose_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/Mongoose/demo.cc
+++ b/Example/Mongoose/demo.cc
@@ -1,0 +1,23 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/Mongoose/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+
+#include "Mongoose.hpp"
+
+int main (void)
+{
+    // FIXME: Do something more meaningful
+    std::cout << "Mongoose::mongoose_version(): " <<
+        Mongoose::mongoose_version ( ) << std::endl;
+
+    return 0;
+}

--- a/Example/ParU/CMakeLists.txt
+++ b/Example/ParU/CMakeLists.txt
@@ -1,0 +1,91 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/ParU/CMakeLists.txt:  cmake for project linking to ParU
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME paru_demo )
+set ( TEST_PACKAGE_NAME ParU )
+set ( TEST_SHARED_BIN paru_demo )
+set ( TEST_STATIC_BIN paru_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::ParU )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::ParU_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/ParU/demo.cc
+++ b/Example/ParU/demo.cc
@@ -1,0 +1,21 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/ParU/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+
+#include "ParU.hpp"
+
+int main (void)
+{
+    // FIXME: Actually call a function from ParU
+
+    return 0;
+}

--- a/Example/RBio/CMakeLists.txt
+++ b/Example/RBio/CMakeLists.txt
@@ -1,0 +1,91 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/RBio/CMakeLists.txt:  cmake for project linking to RBio
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME rbio_demo )
+set ( TEST_PACKAGE_NAME RBio )
+set ( TEST_SHARED_BIN rbio_demo )
+set ( TEST_STATIC_BIN rbio_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::RBio )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::RBio_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/RBio/demo.cc
+++ b/Example/RBio/demo.cc
@@ -1,0 +1,63 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/RBio/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+
+#include "RBio.h"
+
+int main (void)
+{
+    #define N 2
+    #define NNZ 4
+    int64_t n = N;
+    int64_t nzmax = NNZ;
+    int64_t Ap[N+1];
+    int64_t Ai[NNZ];
+    double Ax[NNZ];
+    Ap [0] = 0;
+    Ap [1] = 2;
+    Ap [2] = NNZ;
+    Ai [0] = 0;
+    Ai [1] = 1;
+    Ai [2] = 0;
+    Ai [3] = 1;
+    Ax [0] = 11.0;
+    Ax [1] = 21.0;
+    Ax [2] = 12.0;
+    Ax [3] = 22.0;
+
+    char mtype [4];
+    std::string key {"simple"};
+    std::string title {"2-by-2 matrix"};
+    mtype [0] = '\0';
+    int64_t njumbled, nzeros;
+    int result = RBok (n, n, NNZ, Ap, Ai, Ax, nullptr, nullptr, 0, &njumbled, &nzeros);
+    std::cout << "njumbled " << njumbled << ", nzeros " << nzeros << std::endl;
+    std::string filename {"temp.rb"};
+    result = RBwrite (filename.c_str (), title.c_str (), key.c_str (), n, n,
+        Ap, Ai, Ax, nullptr, nullptr, nullptr, 0, mtype);
+    std::cout << "result " << result << std::endl;
+    std::cout << "mtype: " << mtype << std::endl;
+
+    // dump out the file
+    FILE *f = fopen ("temp.rb", "r");
+    int c;
+    while (1)
+    {
+        c = fgetc (f);
+        if (c == EOF)
+            break;
+        fputc (c, stdout);
+    }
+    fclose (f) ;
+
+    return 0;
+}

--- a/Example/SPEX/CMakeLists.txt
+++ b/Example/SPEX/CMakeLists.txt
@@ -1,0 +1,91 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/SPEX/CMakeLists.txt:  cmake for project linking to SPEX
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME spex_demo )
+set ( TEST_PACKAGE_NAME SPEX )
+set ( TEST_SHARED_BIN spex_demo )
+set ( TEST_STATIC_BIN spex_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::SPEX )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::SPEX_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/SPEX/demo.cc
+++ b/Example/SPEX/demo.cc
@@ -1,0 +1,22 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/SPEX/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+
+#include "SPEX.h"
+
+int main (void)
+{
+    SPEX_initialize ( );
+    SPEX_finalize ( );
+
+    return 0;
+}

--- a/Example/SPQR/CMakeLists.txt
+++ b/Example/SPQR/CMakeLists.txt
@@ -1,0 +1,92 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/SPQR/CMakeLists.txt:  cmake for project linking to SPQR
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME spqr_demo )
+set ( TEST_PACKAGE_NAME SPQR )
+set ( TEST_SHARED_BIN spqr_demo )
+set ( TEST_STATIC_BIN spqr_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::SPQR )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::SPQR_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE SuiteSparse::CHOLMOD )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/SPQR/demo.cc
+++ b/Example/SPQR/demo.cc
@@ -1,0 +1,81 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/SPQR/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+
+#include "SuiteSparseQR_C.h"
+
+int main (void)
+{
+    #define N 2
+    #define NNZ 4
+    int64_t n = N;
+    int64_t nzmax = NNZ;
+    int64_t Ap[N+1];
+    int64_t Ai[NNZ];
+    double Ax[NNZ];
+    Ap [0] = 0;
+    Ap [1] = 2;
+    Ap [2] = NNZ;
+    Ai [0] = 0;
+    Ai [1] = 1;
+    Ai [2] = 0;
+    Ai [3] = 1;
+    Ax [0] = 11.0;
+    Ax [1] = 21.0;
+    Ax [2] = 12.0;
+    Ax [3] = 22.0;
+
+    double b [N] = {8., 45.};
+
+    cholmod_sparse *A, A_struct;
+    cholmod_dense *B, B_struct;
+    cholmod_dense *X;
+
+    // make a shallow CHOLMOD copy of A
+    A = &A_struct;
+    A->nrow = n;
+    A->ncol = n;
+    A->p = Ap;
+    A->i = Ai;
+    A->x = Ax;
+    A->z = nullptr;
+    A->nzmax = NNZ;
+    A->packed = true;
+    A->sorted = true;
+    A->nz = nullptr;
+    A->itype = CHOLMOD_LONG;
+    A->dtype = CHOLMOD_DOUBLE;
+    A->xtype = CHOLMOD_REAL;
+    A->stype = 0;
+
+    // make a shallow CHOLMOD copy of b
+    B = &B_struct;
+    B->nrow = n;
+    B->ncol = 1;
+    B->x = b;
+    B->z = nullptr;
+    B->d = n;
+    B->nzmax = n;
+    B->dtype = CHOLMOD_DOUBLE;
+    B->xtype = CHOLMOD_REAL;
+
+    cholmod_common cc;
+    cholmod_l_start (&cc);
+
+    X = SuiteSparseQR_C_backslash_default (A, B, &cc);
+    cc.print = 5 ;
+    cholmod_l_print_dense (X, "X from QR", &cc);
+
+    cholmod_l_finish (&cc);
+
+    return 0;
+}

--- a/Example/SuiteSparse_config/CMakeLists.txt
+++ b/Example/SuiteSparse_config/CMakeLists.txt
@@ -1,0 +1,91 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/SuiteSparse_config/CMakeLists.txt:  cmake for project linking to SuiteSparse_config
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME config_demo )
+set ( TEST_PACKAGE_NAME SuiteSparse_config )
+set ( TEST_SHARED_BIN config_demo )
+set ( TEST_STATIC_BIN config_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::SuiteSparseConfig )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::SuiteSparseConfig_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/SuiteSparse_config/demo.cc
+++ b/Example/SuiteSparse_config/demo.cc
@@ -1,0 +1,24 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/SuiteSparse_config/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+
+#include "SuiteSparse_config.h"
+
+int main (void)
+{
+    int version [3];
+    SuiteSparse_version (version);
+    std::cout << "SuiteSparse_config version: " << version[0] << "."
+        << version[1] << "." << version[2] << std::endl;
+
+    return 0;
+}

--- a/Example/UMFPACK/CMakeLists.txt
+++ b/Example/UMFPACK/CMakeLists.txt
@@ -1,0 +1,91 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/UMFPACK/CMakeLists.txt:  cmake for project linking to UMFPACK
+#-------------------------------------------------------------------------------
+
+# Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-clause
+
+cmake_minimum_required ( VERSION 3.22 )
+
+#-------------------------------------------------------------------------------
+# configure options
+#-------------------------------------------------------------------------------
+
+option ( BUILD_SHARED_LIBS "OFF: do not build shared libraries.  ON (default): build shared libraries" ON )
+option ( BUILD_STATIC_LIBS "OFF: do not build static libraries.  ON (default): build static libraries" ON )
+
+#-------------------------------------------------------------------------------
+# variables
+#-------------------------------------------------------------------------------
+
+set ( TEST_PROJECT_NAME umfpack_demo )
+set ( TEST_PACKAGE_NAME UMFPACK )
+set ( TEST_SHARED_BIN umfpack_demo )
+set ( TEST_STATIC_BIN umfpack_demo_static )
+set ( TEST_IMPORT_TARGET SuiteSparse::UMFPACK )
+set ( TEST_IMPORT_TARGET_STATIC SuiteSparse::UMFPACK_static )
+
+#-------------------------------------------------------------------------------
+# define project
+#-------------------------------------------------------------------------------
+
+project ( ${TEST_PROJECT_NAME} LANGUAGES C CXX )
+
+#-------------------------------------------------------------------------------
+# find library dependencies
+#-------------------------------------------------------------------------------
+
+find_package ( ${TEST_PACKAGE_NAME} REQUIRED )
+
+#-------------------------------------------------------------------------------
+# dynamically linked executable properties
+#-------------------------------------------------------------------------------
+
+file ( GLOB MY_SOURCES "*.cc" )
+if ( BUILD_SHARED_LIBS )
+    add_executable ( ${TEST_SHARED_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_SHARED_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# staticcally linked executable properties
+#-------------------------------------------------------------------------------
+
+if ( BUILD_STATIC_LIBS )
+    add_executable ( ${TEST_STATIC_BIN} ${MY_SOURCES} )
+    set_target_properties ( ${TEST_STATIC_BIN} PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# add library dependency
+#-------------------------------------------------------------------------------
+
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( ${TEST_SHARED_BIN} PRIVATE ${TEST_IMPORT_TARGET} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    if ( TARGET ${TEST_IMPORT_TARGET_STATIC} )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET_STATIC} )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
+    endif ( )
+endif ( )
+
+#-------------------------------------------------------------------------------
+# installation location
+#-------------------------------------------------------------------------------
+
+include ( GNUInstallDirs )
+
+if ( BUILD_SHARED_LIBS )
+    install ( TARGETS ${TEST_SHARED_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )
+if ( BUILD_STATIC_LIBS )
+    install ( TARGETS ${TEST_STATIC_BIN}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+endif ( )

--- a/Example/UMFPACK/demo.cc
+++ b/Example/UMFPACK/demo.cc
@@ -1,0 +1,65 @@
+//------------------------------------------------------------------------------
+// SuiteSparse/Example/UMFPACK/demo.cc
+//------------------------------------------------------------------------------
+
+// Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+// SPDX-License-Identifier: BSD-3-clause
+
+//------------------------------------------------------------------------------
+
+// Example program
+
+#include <iostream>
+
+#include "umfpack.h"
+
+int main (void)
+{
+    #define N 2
+    #define NNZ 4
+    int64_t n = N;
+    int64_t nzmax = NNZ;
+    int64_t Ap[N+1];
+    int64_t Ai[NNZ];
+    double Ax[NNZ];
+    Ap [0] = 0;
+    Ap [1] = 2;
+    Ap [2] = NNZ;
+    Ai [0] = 0;
+    Ai [1] = 1;
+    Ai [2] = 0;
+    Ai [3] = 1;
+    Ax [0] = 11.0;
+    Ax [1] = 21.0;
+    Ax [2] = 12.0;
+    Ax [3] = 22.0;
+
+    double b [N] = {8., 45.};
+    double xgood [N] = {36.4, -32.7} ;
+    double x [N] ;
+
+    double Control [UMFPACK_CONTROL] ;
+    double Info [UMFPACK_INFO] ;
+    umfpack_dl_defaults (Control) ;
+    Control [UMFPACK_PRL] = 6 ;
+
+    void *Sym, *Num;
+    (void) umfpack_dl_symbolic (n, n, Ap, Ai, Ax, &Sym, Control, Info);
+    (void) umfpack_dl_numeric (Ap, Ai, Ax, Sym, &Num, Control, Info);
+    umfpack_dl_free_symbolic (&Sym);
+    int result = umfpack_dl_solve (UMFPACK_A, Ap, Ai, Ax, x, b, Num, Control, Info);
+    umfpack_dl_free_numeric (&Num);
+    for (int i = 0 ; i < n ; i++)
+      std::cout << "x [" << i << "] = " << x [i] << std::endl;
+    double err = 0;
+    for (int i = 0; i < n; i++)
+    {
+        err = fmax (err, fabs (x [i] - xgood [i]));
+    }
+    std::cout << "error: " << err << std::endl;
+
+    umfpack_dl_report_status (Control, result) ;
+    umfpack_dl_report_info (Control, Info) ;
+
+    return 0;
+}

--- a/LDL/Config/LDLConfig.cmake.in
+++ b/LDL/Config/LDLConfig.cmake.in
@@ -50,26 +50,12 @@ if ( @SUITESPARSE_IN_BUILD_TREE@ )
             find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
         endif ( )
     endif ( )
-
-    if ( NOT TARGET SuiteSparse::AMD )
-        # First check in a common build tree
-        find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@
-            PATHS ${CMAKE_SOURCE_DIR}/../AMD/build NO_DEFAULT_PATH )
-        # Then, check in the currently active CMAKE_MODULE_PATH
-        if ( NOT AMD_FOUND )
-            find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@ )
-        endif ( )
-    endif ( )
-
 else ( )
     if ( NOT TARGET SuiteSparse::SuiteSparseConfig )
         find_dependency ( SuiteSparse_config @SUITESPARSE_CONFIG_VERSION_MAJOR@.@SUITESPARSE_CONFIG_VERSION_MINOR@ )
     endif ( )
-    if ( NOT TARGET SuiteSparse::AMD )
-        find_dependency ( AMD @AMD_VERSION_MAJOR@.@AMD_VERSION_MINOR@ )
-    endif ( )
 endif ( )
-if ( NOT SuiteSparse_config_FOUND OR NOT AMD_FOUND )
+if ( NOT SuiteSparse_config_FOUND )
     set ( _dependencies_found OFF )
 endif ( )
 


### PR DESCRIPTION
This checks if each `*Config.make` file is really self-contained. 
Importing all targets (for the existing test, i.e., building the Example package) was hiding an issue in the `KLUConfig.cmake` file (#664). The new tests would probably have revealed that issue earlier.

These tests also showed an issue in `LDLConfig.cmake`.

The code in the new examples are mainly taken from the existing example package. That means that there are no "proper" tests yet for ParU (or Mongoose).

Eventually, we could probably extend that to check if each *.pc file separately contains sufficient information, too.
