### PR TITLE
Replace platform test for libm by feature test.

### DIFF
--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -475,7 +475,9 @@ else ( )
 endif ( )
 
 # libm:
-if ( NOT WIN32 )
+include ( CheckSymbolExists )
+check_symbol_exists ( fmax "math.h" NO_LIBM )
+if ( NOT NO_LIBM )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( CHOLMOD PRIVATE m )
     endif ( )

--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -367,11 +367,11 @@ endif ( )
 # cpu_features settings
 #-------------------------------------------------------------------------------
 
+include ( CheckSymbolExists )
 if ( NOT GBNCPUFEAT )
     if ( UNIX )
         # look for requirements for cpu_features/src/hwcaps.c
         include ( CheckIncludeFile )
-        include ( CheckSymbolExists )
         check_include_file ( dlfcn.h HAVE_DLFCN_H )
         if ( HAVE_DLFCN_H )
             message ( STATUS "cpu_feautures has dlfcn.h" )
@@ -404,7 +404,8 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 # libm:
-if ( NOT WIN32 )
+check_symbol_exists ( fmax "math.h" NO_LIBM )
+if ( NOT NO_LIBM )
     set ( GB_M "m" )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( GraphBLAS PRIVATE m )

--- a/LAGraph/CMakeLists.txt
+++ b/LAGraph/CMakeLists.txt
@@ -76,6 +76,9 @@ configure_file (
     "${PROJECT_SOURCE_DIR}/include/LAGraph.h"
     NEWLINE_STYLE LF )
 
+include ( CheckSymbolExists )
+check_symbol_exists ( fmax "math.h" NO_LIBM )
+
 #-------------------------------------------------------------------------------
 # code coverage and build type
 #-------------------------------------------------------------------------------
@@ -358,7 +361,7 @@ install ( FILES
 
 if ( NOT MSVC )
     if ( BUILD_STATIC_LIBS )
-        if ( NOT WIN32 )
+        if ( NOT NO_LIBM )
             list ( APPEND LAGRAPH_STATIC_LIBS "m" )
         endif ( )
     endif ( )

--- a/LAGraph/src/CMakeLists.txt
+++ b/LAGraph/src/CMakeLists.txt
@@ -17,12 +17,6 @@ include_directories ( utility )
 
 file ( GLOB LAGRAPH_LIB_SOURCES "utility/*.c" "algorithm/*.c" )
 
-if ( WIN32 )
-    set ( M_LIB "" )
-else ( )
-    set ( M_LIB "m" )
-endif ( )
-
 #-------------------------------------------------------------------------------
 # dynamic lagraph library properties
 #-------------------------------------------------------------------------------
@@ -42,7 +36,10 @@ if ( BUILD_SHARED_LIBS )
         set_target_properties ( LAGraph PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
-    target_link_libraries ( LAGraph PRIVATE GraphBLAS::GraphBLAS ${M_LIB} )
+    target_link_libraries ( LAGraph PRIVATE GraphBLAS::GraphBLAS )
+    if ( NOT NO_LIBM )
+        target_link_libraries ( LAGraph PRIVATE "m" )
+    endif ( )
 
     target_include_directories ( LAGraph PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
@@ -80,7 +77,9 @@ if ( BUILD_STATIC_LIBS )
     else ( )
         target_link_libraries ( LAGraph_static PUBLIC GraphBLAS::GraphBLAS )
     endif ( )
-    target_link_libraries ( LAGraph_static PUBLIC ${M_LIB} )
+    if ( NOT NO_LIBM )
+        target_link_libraries ( LAGraph_static PUBLIC "m" )
+    endif ( )
 
     target_include_directories ( LAGraph_static PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -205,7 +205,9 @@ if ( BUILD_STATIC_LIBS )
 endif ( )
 
 # libm:
-if ( NOT WIN32 )
+include ( CheckSymbolExists )
+check_symbol_exists ( fmax "math.h" NO_LIBM )
+if ( NOT NO_LIBM )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( SPEX PRIVATE m )
     endif ( )

--- a/SPQR/CMakeLists.txt
+++ b/SPQR/CMakeLists.txt
@@ -199,7 +199,9 @@ else ( )
 endif ( )
 
 # libm:
-if ( NOT WIN32 )
+include ( CheckSymbolExists )
+check_symbol_exists ( fmax "math.h" NO_LIBM )
+if ( NOT NO_LIBM )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( SPQR PRIVATE m )
     endif ( )

--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -175,7 +175,9 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 # libm:
-if ( NOT WIN32 )
+include ( CheckSymbolExists )
+check_symbol_exists ( fmax "math.h" NO_LIBM )
+if ( NOT NO_LIBM )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( SuiteSparseConfig PRIVATE m )
     endif ( )

--- a/UMFPACK/CMakeLists.txt
+++ b/UMFPACK/CMakeLists.txt
@@ -228,7 +228,9 @@ else ( )
 endif ( )
 
 # libm:
-if ( NOT WIN32 )
+include ( CheckSymbolExists )
+check_symbol_exists ( fmax "math.h" NO_LIBM )
+if ( NOT NO_LIBM )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( UMFPACK PRIVATE m )
     endif ( )


### PR DESCRIPTION
`libm` is also an empty dummy on Linux/musl.

The situation on Linux/musl is similar to the one on Windows/MinGW: There is an empty libm (so linking to it doesn't cause errors). But we don't need to link to it.

