### PR TITLE
Avoid non-POSIX flags for `diff` in `make demos` target

### DIFF
--- a/AMD/Makefile
+++ b/AMD/Makefile
@@ -53,19 +53,19 @@ all: library
 
 demos: library
 	( cd build && cmake $(CMAKE_OPTIONS) -DSUITESPARSE_DEMOS=1 .. && cmake --build . --config Release -j${JOBS} )
-	./build/amd_demo > build/amd_demo.out
-	- diff --strip-trailing-cr Demo/amd_demo.out build/amd_demo.out
-	./build/amd_l_demo > build/amd_l_demo.out
-	- diff --strip-trailing-cr Demo/amd_l_demo.out build/amd_l_demo.out
-	./build/amd_demo2 > build/amd_demo2.out
-	- diff --strip-trailing-cr Demo/amd_demo2.out build/amd_demo2.out
-	./build/amd_simple > build/amd_simple.out
-	- diff --strip-trailing-cr Demo/amd_simple.out build/amd_simple.out
+	./build/amd_demo > build/amd_demo.out && ( command -v d2u && d2u ./build/amd_demo.out || true )
+	- diff Demo/amd_demo.out build/amd_demo.out
+	./build/amd_l_demo > build/amd_l_demo.out && ( command -v d2u && d2u ./build/amd_l_demo.out || true )
+	- diff Demo/amd_l_demo.out build/amd_l_demo.out
+	./build/amd_demo2 > build/amd_demo2.out && ( command -v d2u && d2u ./build/amd_demo2.out || true )
+	- diff Demo/amd_demo2.out build/amd_demo2.out
+	./build/amd_simple > build/amd_simple.out && ( command -v d2u && d2u ./build/amd_simple.out || true )
+	- diff Demo/amd_simple.out build/amd_simple.out
 	# Fortran demos will fail if no Fortran compiler is available
-	- ./build/amd_f77simple > build/amd_f77simple.out
-	- diff --strip-trailing-cr Demo/amd_f77simple.out build/amd_f77simple.out
-	- ./build/amd_f77demo > build/amd_f77demo.out
-	- diff --strip-trailing-cr Demo/amd_f77demo.out build/amd_f77demo.out
+	- ./build/amd_f77simple > build/amd_f77simple.out && ( command -v d2u && d2u ./build/amd_f77simple.out || true )
+	- diff Demo/amd_f77simple.out build/amd_f77simple.out
+	- ./build/amd_f77demo > build/amd_f77demo.out && ( command -v d2u && d2u ./build/amd_f77demo.out || true )
+	- diff Demo/amd_f77demo.out build/amd_f77demo.out
 
 # just compile after running cmake; do not run cmake again
 remake:

--- a/CAMD/Makefile
+++ b/CAMD/Makefile
@@ -53,14 +53,14 @@ all: library
 
 demos: library
 	( cd build && cmake $(CMAKE_OPTIONS) -DSUITESPARSE_DEMOS=1 .. && cmake --build . --config Release -j${JOBS} )
-	./build/camd_demo > build/camd_demo.out
-	- diff --strip-trailing-cr Demo/camd_demo.out build/camd_demo.out
-	./build/camd_l_demo > build/camd_l_demo.out
-	- diff --strip-trailing-cr Demo/camd_l_demo.out build/camd_l_demo.out
-	./build/camd_demo2 > build/camd_demo2.out
-	- diff --strip-trailing-cr Demo/camd_demo2.out build/camd_demo2.out
-	./build/camd_simple > build/camd_simple.out
-	- diff --strip-trailing-cr Demo/camd_simple.out build/camd_simple.out
+	./build/camd_demo > build/camd_demo.out && ( command -v d2u && d2u ./build/amd_demo.out || true )
+	- diff Demo/camd_demo.out build/camd_demo.camd_demo
+	./build/camd_l_demo > build/camd_l_demo.out && ( command -v d2u && d2u ./build/camd_l_demo.out || true )
+	- diff Demo/camd_l_demo.out build/camd_l_demo.out
+	./build/camd_demo2 > build/camd_demo2.out && ( command -v d2u && d2u ./build/camd_demo2.out || true )
+	- diff Demo/camd_demo2.out build/camd_demo2.out
+	./build/camd_simple > build/camd_simple.out && ( command -v d2u && d2u ./build/camd_simple.out || true )
+	- diff Demo/camd_simple.out build/camd_simple.out
 
 # just compile after running cmake&& do not run cmake again
 remake:

--- a/CCOLAMD/Makefile
+++ b/CCOLAMD/Makefile
@@ -53,10 +53,10 @@ all: library
 
 demos: library
 	( cd build && cmake $(CMAKE_OPTIONS) -DSUITESPARSE_DEMOS=1 .. && cmake --build . --config Release -j${JOBS} )
-	- ./build/ccolamd_example > ./build/ccolamd_example.out
-	- diff --strip-trailing-cr ./Demo/ccolamd_example.out ./build/ccolamd_example.out
-	- ./build/ccolamd_l_example > ./build/ccolamd_l_example.out
-	- diff --strip-trailing-cr ./Demo/ccolamd_l_example.out ./build/ccolamd_l_example.out
+	- ./build/ccolamd_example > ./build/ccolamd_example.out && ( command -v d2u && d2u ./build/ccolamd_example.out || true )
+	- diff ./Demo/ccolamd_example.out ./build/ccolamd_example.out
+	- ./build/ccolamd_l_example > ./build/ccolamd_l_example.out && ( command -v d2u && d2u ./build/ccolamd_l_example.out || true )
+	- diff ./Demo/ccolamd_l_example.out ./build/ccolamd_l_example.out
 
 # just compile after running cmake; do not run cmake again
 remake:

--- a/COLAMD/Makefile
+++ b/COLAMD/Makefile
@@ -53,10 +53,10 @@ all: library
 
 demos: library
 	( cd build && cmake $(CMAKE_OPTIONS) -DSUITESPARSE_DEMOS=1 .. && cmake --build . --config Release -j${JOBS} )
-	- ./build/colamd_example > ./build/colamd_example.out
-	- diff --strip-trailing-cr ./Demo/colamd_example.out ./build/colamd_example.out
-	- ./build/colamd_l_example > ./build/colamd_l_example.out
-	- diff --strip-trailing-cr ./Demo/colamd_l_example.out ./build/colamd_l_example.out
+	- ./build/colamd_example > ./build/colamd_example.out && ( command -v d2u && d2u ./build/colamd_example.out || true )
+	- diff ./Demo/colamd_example.out ./build/colamd_example.out
+	- ./build/colamd_l_example > ./build/colamd_l_example.out && ( command -v d2u && d2u ./build/colamd_l_example.out || true )
+	- diff ./Demo/colamd_l_example.out ./build/colamd_l_example.out
 
 # just compile after running cmake; do not run cmake again
 remake:

--- a/LDL/Makefile
+++ b/LDL/Makefile
@@ -52,18 +52,18 @@ all: library
 
 demos: library
 	( cd build && cmake $(CMAKE_OPTIONS) -DSUITESPARSE_DEMOS=1 .. && cmake --build . --config Release -j${JOBS} )
-	./build/ldlsimple > ./build/ldlsimple.out
-	- diff --strip-trailing-cr ./Demo/ldlsimple.out ./build/ldlsimple.out
-	./build/ldllsimple > ./build/ldllsimple.out
-	- diff --strip-trailing-cr ./Demo/ldllsimple.out ./build/ldllsimple.out
-	./build/ldlmain > ./build/ldlmain.out
-	- diff --strip-trailing-cr ./Demo/ldlmain.out ./build/ldlmain.out
-	./build/ldllmain > ./build/ldllmain.out
-	- diff --strip-trailing-cr ./Demo/ldllmain.out ./build/ldllmain.out
-	./build/ldlamd  > ./build/ldlamd.out
-	- diff --strip-trailing-cr ./Demo/ldlamd.out  ./build/ldlamd.out
-	./build/ldllamd  > ./build/ldllamd.out
-	- diff --strip-trailing-cr ./Demo/ldllamd.out  ./build/ldllamd.out
+	./build/ldlsimple > ./build/ldlsimple.out && ( command -v d2u && d2u ./build/ldlsimple.out || true )
+	- diff ./Demo/ldlsimple.out ./build/ldlsimple.out
+	./build/ldllsimple > ./build/ldllsimple.out && ( command -v d2u && d2u ./build/ldllsimple.out || true )
+	- diff ./Demo/ldllsimple.out ./build/ldllsimple.out
+	./build/ldlmain > ./build/ldlmain.out && ( command -v d2u && d2u ./build/ldlmain.out || true )
+	- diff ./Demo/ldlmain.out ./build/ldlmain.out
+	./build/ldllmain > ./build/ldllmain.out && ( command -v d2u && d2u ./build/ldllmain.out || true )
+	- diff ./Demo/ldllmain.out ./build/ldllmain.out
+	./build/ldlamd  > ./build/ldlamd.out && ( command -v d2u && d2u ./build/ldlamd.out || true )
+	- diff ./Demo/ldlamd.out  ./build/ldlamd.out
+	./build/ldllamd  > ./build/ldllamd.out && ( command -v d2u && d2u ./build/ldllamd.out || true )
+	- diff ./Demo/ldllamd.out  ./build/ldllamd.out
 
 # just compile after running cmake; do not run cmake again
 remake:


### PR DESCRIPTION
The flag `--strip-trailing-cr` is a non-standard flag for `diff` and isn't supported on Alpine Linux. Try to use commands that work across POSIX-compatible platforms.

See also #511.
