### PR TITLE
Example: Add autotools build rules for separate sub-projects

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -232,3 +232,15 @@ jobs:
           printf "\033[1;35m  C++ binary\033[0m\n"
           LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_cxx_demo
           echo "::endgroup::"
+          IFS=:
+          INSTALLED_LIBS="${INSTALLED_LIBS}${{ matrix.extra-build-libs }}"
+          for lib in ${INSTALLED_LIBS}; do
+            printf "::group::   \033[0;32m==>\033[0m Building test with library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/TestConfig/${lib}
+            autoreconf -fi
+            mkdir build-autotools && cd build-autotools
+            PKG_CONFIG_PATH=${GITHUB_WORKSPACE}/lib/pkgconfig/ \
+              ../configure --enable-shared --disable-static
+            make all
+            echo "::endgroup::"
+          done

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -268,6 +268,17 @@ jobs:
           printf "\033[1;35m  C++ binary\033[0m\n"
           LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_cxx_demo
           echo "::endgroup::"
+          IFS=':' read -r -a libs <<< "${INSTALLED_LIBS}"
+          for lib in "${libs[@]}"; do
+            printf "::group::   \033[0;32m==>\033[0m Building test with library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/TestConfig/${lib}
+            autoreconf -fi
+            mkdir build-autotools && cd build-autotools
+            PKG_CONFIG_PATH=${GITHUB_WORKSPACE}/lib/pkgconfig/ \
+              ../configure ${_extra_config_flags}
+            make all
+            echo "::endgroup::"
+          done
 
   mingw:
     # For available GitHub-hosted runners, see:
@@ -476,3 +487,14 @@ jobs:
           PATH="${GITHUB_WORKSPACE}/bin:${PATH}" \
             ./my_cxx_demo
           echo "::endgroup::"
+          IFS=':' read -r -a libs <<< "${INSTALLED_LIBS}"
+          for lib in "${libs[@]}"; do
+            printf "::group::   \033[0;32m==>\033[0m Building test with library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/TestConfig/${lib}
+            autoreconf -fi
+            mkdir build-autotools && cd build-autotools
+            PKG_CONFIG_PATH=${GITHUB_WORKSPACE}/lib/pkgconfig/ \
+              ../configure --enable-shared --disable-static
+            make all
+            echo "::endgroup::"
+          done

--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -253,6 +253,17 @@ jobs:
           printf "\033[1;35m  C++ binary\033[0m\n"
           LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/lib ./my_cxx_demo
           echo "::endgroup::"
+          IFS=':' read -r -a libs <<< "${INSTALLED_LIBS}"
+          for lib in "${libs[@]}"; do
+            printf "::group::   \033[0;32m==>\033[0m Building test with library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/TestConfig/${lib}
+            autoreconf -fi
+            mkdir build-autotools && cd build-autotools
+            PKG_CONFIG_PATH=${GITHUB_WORKSPACE}/lib/pkgconfig/ \
+              ../configure ${_extra_config_flags}
+            make all
+            echo "::endgroup::"
+          done
 
 
   msvc:

--- a/TestConfig/AMD/Makefile.am
+++ b/TestConfig/AMD/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/AMD/configure.ac
+++ b/TestConfig/AMD/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [AMD])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/TestConfig/BTF/Makefile.am
+++ b/TestConfig/BTF/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/BTF/configure.ac
+++ b/TestConfig/BTF/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [BTF])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/TestConfig/CAMD/Makefile.am
+++ b/TestConfig/CAMD/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/CAMD/configure.ac
+++ b/TestConfig/CAMD/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [CAMD])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/TestConfig/CCOLAMD/Makefile.am
+++ b/TestConfig/CCOLAMD/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/CCOLAMD/configure.ac
+++ b/TestConfig/CCOLAMD/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [CCOLAMD])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/TestConfig/CHOLMOD/Makefile.am
+++ b/TestConfig/CHOLMOD/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/CHOLMOD/configure.ac
+++ b/TestConfig/CHOLMOD/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [CHOLMOD])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/TestConfig/COLAMD/Makefile.am
+++ b/TestConfig/COLAMD/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/COLAMD/configure.ac
+++ b/TestConfig/COLAMD/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [COLAMD])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/TestConfig/CXSparse/Makefile.am
+++ b/TestConfig/CXSparse/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/CXSparse/configure.ac
+++ b/TestConfig/CXSparse/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [CXSparse])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/TestConfig/GraphBLAS/Makefile.am
+++ b/TestConfig/GraphBLAS/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/GraphBLAS/configure.ac
+++ b/TestConfig/GraphBLAS/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [GraphBLAS])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/TestConfig/KLU/Makefile.am
+++ b/TestConfig/KLU/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/KLU/configure.ac
+++ b/TestConfig/KLU/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [KLU])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/TestConfig/LAGraph/Makefile.am
+++ b/TestConfig/LAGraph/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/LAGraph/configure.ac
+++ b/TestConfig/LAGraph/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [LAGraph])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/TestConfig/LDL/Makefile.am
+++ b/TestConfig/LDL/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/LDL/configure.ac
+++ b/TestConfig/LDL/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [LDL])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/TestConfig/Mongoose/Makefile.am
+++ b/TestConfig/Mongoose/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/Mongoose/configure.ac
+++ b/TestConfig/Mongoose/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [SuiteSparse_Mongoose])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/TestConfig/ParU/Makefile.am
+++ b/TestConfig/ParU/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/ParU/configure.ac
+++ b/TestConfig/ParU/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [ParU])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/TestConfig/RBio/Makefile.am
+++ b/TestConfig/RBio/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/RBio/configure.ac
+++ b/TestConfig/RBio/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [RBio])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/TestConfig/SPEX/Makefile.am
+++ b/TestConfig/SPEX/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/SPEX/configure.ac
+++ b/TestConfig/SPEX/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [SPEX])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/TestConfig/SPQR/Makefile.am
+++ b/TestConfig/SPQR/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/SPQR/configure.ac
+++ b/TestConfig/SPQR/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [SPQR CHOLMOD])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/TestConfig/SuiteSparse_config/Makefile.am
+++ b/TestConfig/SuiteSparse_config/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/SuiteSparse_config/configure.ac
+++ b/TestConfig/SuiteSparse_config/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [SuiteSparse_config])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/TestConfig/UMFPACK/Makefile.am
+++ b/TestConfig/UMFPACK/Makefile.am
@@ -1,0 +1,17 @@
+#-------------------------------------------------------------------------------
+# SuiteSparse/Example/.../Makefile
+#-------------------------------------------------------------------------------
+
+# Example: Copyright (c) 2024, Timothy A. Davis, All Rights Reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+#-------------------------------------------------------------------------------
+
+demo_PROGRAMS = \
+  %reldir%/suitesparse_demo
+
+demodir = %canon_reldir%
+
+%canon_reldir%_suitesparse_demo_SOURCES = %reldir%/demo.cc
+%canon_reldir%_suitesparse_demo_CPPFLAGS = @SUITESPARSE_CFLAGS@
+%canon_reldir%_suitesparse_demo_LDADD = @SUITESPARSE_LIBS@

--- a/TestConfig/UMFPACK/configure.ac
+++ b/TestConfig/UMFPACK/configure.ac
@@ -1,0 +1,25 @@
+# simple configure file for example project in SuiteSparse
+
+# initialize
+AC_INIT([example], [1.6.0])
+
+AM_INIT_AUTOMAKE([foreign subdir-objects])
+
+LT_INIT
+
+# check for working compilers
+AC_PROG_CXX
+
+# find pkg-config executable
+PKG_PROG_PKG_CONFIG()
+
+if test "$enable_static" = yes; then
+  PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
+# find installed SuiteSparse library
+PKG_CHECK_MODULES([SUITESPARSE], [UMFPACK])
+
+# create Makefile.in from Makefile.am
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT


### PR DESCRIPTION
Addendum to #675 that uses autotools as the build system.
