### PR TITLE
Test skipping demos and tests when building

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -133,6 +133,8 @@ jobs:
                   -DCMAKE_Fortran_COMPILER_LAUNCHER="ccache" \
                   -DBLA_VENDOR="Generic" \
                   -DGRAPHBLAS_COMPACT=ON \
+                  -DSUITESPARSE_DEMOS=OFF \
+                  -DBUILD_TESTING=OFF \
                   ..
             echo "::endgroup::"
             echo "::group::Build $lib"
@@ -148,7 +150,7 @@ jobs:
           for lib in ${CHECK_LIBS}; do
             printf "::group::   \033[0;32m==>\033[0m Checking library \033[0;32m${lib}\033[0m\n"
             cd ${GITHUB_WORKSPACE}/${lib}
-            make demos
+            make demos CMAKE_OPTIONS="-DSUITESPARSE_DEMOS=ON -DBUILD_TESTING=ON"
             echo "::endgroup::"
           done
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -160,6 +160,8 @@ jobs:
                   -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
                   -DCMAKE_Fortran_COMPILER_LAUNCHER="ccache" \
                   -DBLA_VENDOR="OpenBLAS" \
+                  -DSUITESPARSE_DEMOS=OFF \
+                  -DBUILD_TESTING=OFF \
                   ${{ matrix.cuda-cmake-flags }} \
                   ${{ matrix.openmp-cmake-flags }} \
                   ${{ matrix.link-cmake-flags }} \
@@ -177,7 +179,7 @@ jobs:
           for lib in "${libs[@]}"; do
             printf "::group::   \033[0;32m==>\033[0m Checking library \033[0;32m${lib}\033[0m\n"
             cd ${GITHUB_WORKSPACE}/${lib}
-            make demos
+            make demos CMAKE_OPTIONS="-DSUITESPARSE_DEMOS=ON -DBUILD_TESTING=ON"
             echo "::endgroup::"
           done
 
@@ -389,6 +391,8 @@ jobs:
                   -DCMAKE_Fortran_COMPILER_LAUNCHER="ccache" \
                   -DBLA_VENDOR="OpenBLAS" \
                   -DPython_EXECUTABLE="$(which python)" \
+                  -DSUITESPARSE_DEMOS=OFF \
+                  -DBUILD_TESTING=OFF \
                   ..
             echo "::endgroup::"
             echo "::group::Build $lib"
@@ -408,7 +412,7 @@ jobs:
             printf "::group::   \033[0;32m==>\033[0m Checking library \033[0;32m${lib}\033[0m\n"
             cd ${GITHUB_WORKSPACE}/${lib}
             PATH="${GITHUB_WORKSPACE}/bin:${PATH}" \
-              make demos
+              make demos CMAKE_OPTIONS="-DSUITESPARSE_DEMOS=ON -DBUILD_TESTING=ON"
             echo "::endgroup::"
           done
 

--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -144,6 +144,8 @@ jobs:
                 -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
                 -DCMAKE_Fortran_COMPILER_LAUNCHER="ccache" \
                 -DBLA_VENDOR="OpenBLAS" \
+                -DSUITESPARSE_DEMOS=OFF \
+                -DBUILD_TESTING=OFF \
                 ${{ matrix.cuda-cmake-flags }} \
                 ${{ matrix.link-cmake-flags }} \
                 ..
@@ -157,7 +159,7 @@ jobs:
         run: |
           printf "::group::   \033[0;32m==>\033[0m Configuring for demos\n"
           cd ${GITHUB_WORKSPACE}/build
-          cmake -DSUITESPARSE_DEMOS=ON ..
+          cmake -DSUITESPARSE_DEMOS=ON -DBUILD_TESTING=ON ..
           echo "::endgroup::"
           printf "::group::   \033[0;32m==>\033[0m Building demos\n"
           cd ${GITHUB_WORKSPACE}/build
@@ -431,6 +433,8 @@ jobs:
                 -DSUITESPARSE_USE_FORTRAN=OFF \
                 -DBLA_VENDOR="All" \
                 -DPython_EXECUTABLE="C:/msys64/ucrt64/bin/python.exe" \
+                -DSUITESPARSE_DEMOS=OFF \
+                -DBUILD_TESTING=OFF \
                 ${{ matrix.openmp-cmake-flags }} \
                 ${{ matrix.cuda-cmake-flags }} \
                 "${_extra_config[@]}" \
@@ -445,7 +449,7 @@ jobs:
         run: |
           printf "::group::   \033[0;32m==>\033[0m Configuring for demos\n"
           cd ${GITHUB_WORKSPACE}/build
-          cmake -DSUITESPARSE_DEMOS=ON ..
+          cmake -DSUITESPARSE_DEMOS=ON -DBUILD_TESTING=ON ..
           echo "::endgroup::"
           printf "::group::   \033[0;32m==>\033[0m Building demos\n"
           cd ${GITHUB_WORKSPACE}/build


### PR DESCRIPTION
Delay building tests and demos until actually running them.

The test coverage of the CI will still be the same after this change. All demos and tests should still be built and executed.
This checks if the configure flags `SUITESPARSE_DEMOS` and `BUILD_TESTING` are working correctly.
