### PR TITLE
Mongoose: Fix linking errors reported by Visual Studio 2022

### DIFF
--- a/Mongoose/Include/Mongoose_Logger.hpp
+++ b/Mongoose/Include/Mongoose_Logger.hpp
@@ -107,78 +107,14 @@ private:
     static float times[6];
 
 public:
-    static inline void tic(TimingType timingType);
-    static inline void toc(TimingType timingType);
-    static inline float getTime(TimingType timingType);
-    static inline int getDebugLevel();
+    static void tic(TimingType timingType);
+    static void toc(TimingType timingType);
+    static float getTime(TimingType timingType);
+    static int getDebugLevel();
     static void setDebugLevel(int debugType);
     static void setTimingFlag(bool tFlag);
     static void printTimingInfo();
 };
-
-/**
- * Start a timer for a given type/part of the code.
- *
- * Given a timingType (MatchingTiming, CoarseningTiming, RefinementTiming,
- * FMTiming, QPTiming, or IOTiming), a clock is started for that computation.
- * The general structure is to call tic(IOTiming) at the beginning of an I/O
- * operation, then call toc(IOTiming) at the end of the I/O operation.
- *
- * Note that problems can occur and timing results may be inaccurate if a tic
- * is followed by another tic (or a toc is followed by another toc).
- *
- * @param timingType The portion of the library being timed (MatchingTiming,
- *   CoarseningTiming, RefinementTiming, FMTiming, QPTiming, or IOTiming).
- */
-inline void Logger::tic(TimingType timingType)
-{
-    if (timingOn)
-    {
-        clocks[timingType] = SUITESPARSE_TIME;
-    }
-}
-
-/**
- * Stop a timer for a given type/part of the code.
- *
- * Given a timingType (MatchingTiming, CoarseningTiming, RefinementTiming,
- * FMTiming, QPTiming, or IOTiming), a clock is stopped for that computation.
- * The general structure is to call tic(IOTiming) at the beginning of an I/O
- * operation, then call toc(IOTiming) at the end of the I/O operation.
- *
- * Note that problems can occur and timing results may be inaccurate if a tic
- * is followed by another tic (or a toc is followed by another toc).
- *
- * @param timingType The portion of the library being timed (MatchingTiming,
- *   CoarseningTiming, RefinementTiming, FMTiming, QPTiming, or IOTiming).
- */
-inline void Logger::toc(TimingType timingType)
-{
-    if (timingOn)
-    {
-        times[timingType]
-            += (float) (SUITESPARSE_TIME - clocks[timingType]) ;
-    }
-}
-
-/**
- * Get the time recorded for a given timing type.
- *
- * Retreive the total clock time for a given timing type (MatchingTiming,
- * CoarseningTiming, RefinementTiming, FMTiming, QPTiming, or IOTiming).
- *
- * @param timingType The portion of the library being timed (MatchingTiming,
- *   CoarseningTiming, RefinementTiming, FMTiming, QPTiming, or IOTiming).
- */
-inline float Logger::getTime(TimingType timingType)
-{
-    return times[timingType];
-}
-
-inline int Logger::getDebugLevel()
-{
-    return debugLevel;
-}
 
 } // end namespace Mongoose
 

--- a/Mongoose/Source/Mongoose_Logger.cpp
+++ b/Mongoose/Source/Mongoose_Logger.cpp
@@ -32,6 +32,70 @@ bool Logger::timingOn  = false;
 double Logger::clocks[6];
 float Logger::times[6];
 
+/**
+ * Start a timer for a given type/part of the code.
+ *
+ * Given a timingType (MatchingTiming, CoarseningTiming, RefinementTiming,
+ * FMTiming, QPTiming, or IOTiming), a clock is started for that computation.
+ * The general structure is to call tic(IOTiming) at the beginning of an I/O
+ * operation, then call toc(IOTiming) at the end of the I/O operation.
+ *
+ * Note that problems can occur and timing results may be inaccurate if a tic
+ * is followed by another tic (or a toc is followed by another toc).
+ *
+ * @param timingType The portion of the library being timed (MatchingTiming,
+ *   CoarseningTiming, RefinementTiming, FMTiming, QPTiming, or IOTiming).
+ */
+void Logger::tic(TimingType timingType)
+{
+    if (timingOn)
+    {
+        clocks[timingType] = SUITESPARSE_TIME;
+    }
+}
+
+/**
+ * Stop a timer for a given type/part of the code.
+ *
+ * Given a timingType (MatchingTiming, CoarseningTiming, RefinementTiming,
+ * FMTiming, QPTiming, or IOTiming), a clock is stopped for that computation.
+ * The general structure is to call tic(IOTiming) at the beginning of an I/O
+ * operation, then call toc(IOTiming) at the end of the I/O operation.
+ *
+ * Note that problems can occur and timing results may be inaccurate if a tic
+ * is followed by another tic (or a toc is followed by another toc).
+ *
+ * @param timingType The portion of the library being timed (MatchingTiming,
+ *   CoarseningTiming, RefinementTiming, FMTiming, QPTiming, or IOTiming).
+ */
+void Logger::toc(TimingType timingType)
+{
+    if (timingOn)
+    {
+        times[timingType]
+            += (float) (SUITESPARSE_TIME - clocks[timingType]) ;
+    }
+}
+
+/**
+ * Get the time recorded for a given timing type.
+ *
+ * Retreive the total clock time for a given timing type (MatchingTiming,
+ * CoarseningTiming, RefinementTiming, FMTiming, QPTiming, or IOTiming).
+ *
+ * @param timingType The portion of the library being timed (MatchingTiming,
+ *   CoarseningTiming, RefinementTiming, FMTiming, QPTiming, or IOTiming).
+ */
+float Logger::getTime(TimingType timingType)
+{
+    return times[timingType];
+}
+
+int Logger::getDebugLevel()
+{
+    return debugLevel;
+}
+
 void Logger::setDebugLevel(int debugType)
 {
     debugLevel = debugType;


### PR DESCRIPTION
Linking errors reported by Visual Studio 2022 

> mongoose.obj : error LNK2019: 无法解析的外部符号 "private: static float * Mongoose::Logger::times" (?times@Logger@Mongoose@@0PAMA)，函数 main 中
> 引用了该符号 [F:\Li
> bs\suitesparse\SuiteSparse-dev2-x64\Mongoose\build\mongoose_exe.vcxproj]
> F:\Libs\suitesparse\SuiteSparse-dev2-x64\Mongoose\build\Release\suitesparse_mongoose.exe : fatal error LNK1120: 1 个无法解析的外部命令 [F:\Libs\suitespars
> e\SuiteSparse-dev2-x64\Mongoose\build\mongoose_exe.vcxproj]

![linking-errors](https://github.com/DrTimothyAldenDavis/SuiteSparse/assets/8711991/d4da9c1a-0204-4f85-ac15-87d896f5152c)
