### PR TITLE
CI: Install Python on Alpine Linux runners

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -75,6 +75,7 @@ jobs:
             gmp-dev
             mpfr-dev
             lapack-dev
+            python3
             valgrind
             util-linux-misc
             autoconf


### PR DESCRIPTION
That is needed to run some of the tests for Mongoose.
