### PR TITLE
CHOLMOD: Don't use macOS extensions of math library

### DIFF
--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -351,6 +351,13 @@ if ( BUILD_SHARED_LIBS )
     target_include_directories ( CHOLMOD
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
+
+    if ( APPLE AND CMAKE_SYSTEM_VERSION VERSION_LESS 11 )
+        # Older versions of math.h on the Mac (PowerPC only) define Real and Imag,
+        # which conflicts the internal use of those symbols in KLU and CHOLMOD.
+        # This can be disabled with -D__NO_EXTENSIONS__
+        target_compile_definitions ( CHOLMOD PRIVATE "__NOEXTENSIONS__" )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -384,6 +391,12 @@ if ( BUILD_STATIC_LIBS )
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 
+    if ( APPLE AND CMAKE_SYSTEM_VERSION VERSION_LESS 11 )
+        # Older versions of math.h on the Mac (PowerPC only) define Real and Imag,
+        # which conflicts the internal use of those symbols in KLU and CHOLMOD.
+        # This can be disabled with -D__NO_EXTENSIONS__
+        target_compile_definitions ( CHOLMOD_static PRIVATE "__NOEXTENSIONS__" )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -830,7 +843,7 @@ if ( SUITESPARSE_DEMOS OR BUILD_TESTING )
     if ( WIN32 AND BUILD_SHARED_LIBS )
         # Set PATH to pick up the necessary libraries for all tests
 
-        set ( CHOLMOD_CTEST_NAMES 
+        set ( CHOLMOD_CTEST_NAMES
             CHOLMOD_int32_double_bcsstk01 CHOLMOD_int64_double_bcsstk01 CHOLMOD_int32_single_bcsstk01 CHOLMOD_int64_single_bcsstk01
             CHOLMOD_int32_double_lp_afiro CHOLMOD_int64_double_lp_afiro CHOLMOD_int32_single_lp_afiro CHOLMOD_int64_single_lp_afiro
             CHOLMOD_int32_double_can24 CHOLMOD_int64_double_can24 CHOLMOD_int32_single_can24 CHOLMOD_int64_single_can24

--- a/GraphBLAS/cmake_modules/SuiteSparsePolicy.cmake
+++ b/GraphBLAS/cmake_modules/SuiteSparsePolicy.cmake
@@ -248,19 +248,6 @@ message ( STATUS "Build type:       ${CMAKE_BUILD_TYPE} ")
 set ( CMAKE_INCLUDE_CURRENT_DIR ON )
 
 #-------------------------------------------------------------------------------
-# MacOS workaround
-#-------------------------------------------------------------------------------
-
-# Older versions of math.h on the Mac (PowerPC only) define Real and Imag,
-# which conflicts the internal use of those symbols in KLU and CHOLMOD.  This
-# can be disabled with -D__NO_EXTENSTIONS__
-
-if ( APPLE AND CMAKE_SYSTEM_VERSION VERSION_LESS 11 )
-    message ( STATUS "MacOS: workaround for mangled math.h" )
-    add_compile_definitions ( __NO_EXTENSTIONS__ )
-endif ( )
-
-#-------------------------------------------------------------------------------
 # check if Fortran is available and enabled
 #-------------------------------------------------------------------------------
 

--- a/LAGraph/cmake_modules/SuiteSparsePolicy.cmake
+++ b/LAGraph/cmake_modules/SuiteSparsePolicy.cmake
@@ -248,19 +248,6 @@ message ( STATUS "Build type:       ${CMAKE_BUILD_TYPE} ")
 set ( CMAKE_INCLUDE_CURRENT_DIR ON )
 
 #-------------------------------------------------------------------------------
-# MacOS workaround
-#-------------------------------------------------------------------------------
-
-# Older versions of math.h on the Mac (PowerPC only) define Real and Imag,
-# which conflicts the internal use of those symbols in KLU and CHOLMOD.  This
-# can be disabled with -D__NO_EXTENSTIONS__
-
-if ( APPLE AND CMAKE_SYSTEM_VERSION VERSION_LESS 11 )
-    message ( STATUS "MacOS: workaround for mangled math.h" )
-    add_compile_definitions ( __NO_EXTENSTIONS__ )
-endif ( )
-
-#-------------------------------------------------------------------------------
 # check if Fortran is available and enabled
 #-------------------------------------------------------------------------------
 

--- a/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
+++ b/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
@@ -248,19 +248,6 @@ message ( STATUS "Build type:       ${CMAKE_BUILD_TYPE} ")
 set ( CMAKE_INCLUDE_CURRENT_DIR ON )
 
 #-------------------------------------------------------------------------------
-# MacOS workaround
-#-------------------------------------------------------------------------------
-
-# Older versions of math.h on the Mac (PowerPC only) define Real and Imag,
-# which conflicts the internal use of those symbols in KLU and CHOLMOD.  This
-# can be disabled with -D__NO_EXTENSTIONS__
-
-if ( APPLE AND CMAKE_SYSTEM_VERSION VERSION_LESS 11 )
-    message ( STATUS "MacOS: workaround for mangled math.h" )
-    add_compile_definitions ( __NO_EXTENSTIONS__ )
-endif ( )
-
-#-------------------------------------------------------------------------------
 # check if Fortran is available and enabled
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
Limit scope of workaround to affected libraries only.

Also use the correct name of the preprocessor definition `__NOEXTENSIONS__`. (See: https://opensource.apple.com/source/Libm/Libm-92/i386.subproj/math.h.auto.html)

Should be fixing #682.
