### PR TITLE
Disable extensions in math.h with older versions of macOS for all projects

### DIFF
--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -351,13 +351,6 @@ if ( BUILD_SHARED_LIBS )
     target_include_directories ( CHOLMOD
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
-
-    if ( APPLE AND CMAKE_SYSTEM_VERSION VERSION_LESS 11 )
-        # Older versions of math.h on the Mac (PowerPC only) define Real and Imag,
-        # which conflicts the internal use of those symbols in KLU and CHOLMOD.
-        # This can be disabled with -D__NOEXTENSIONS__
-        target_compile_definitions ( CHOLMOD PRIVATE "__NOEXTENSIONS__" )
-    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -391,12 +384,6 @@ if ( BUILD_STATIC_LIBS )
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 
-    if ( APPLE AND CMAKE_SYSTEM_VERSION VERSION_LESS 11 )
-        # Older versions of math.h on the Mac (PowerPC only) define Real and Imag,
-        # which conflicts the internal use of those symbols in KLU and CHOLMOD.
-        # This can be disabled with -D__NOEXTENSIONS__
-        target_compile_definitions ( CHOLMOD_static PRIVATE "__NOEXTENSIONS__" )
-    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/GraphBLAS/cmake_modules/SuiteSparsePolicy.cmake
+++ b/GraphBLAS/cmake_modules/SuiteSparsePolicy.cmake
@@ -248,6 +248,19 @@ message ( STATUS "Build type:       ${CMAKE_BUILD_TYPE} ")
 set ( CMAKE_INCLUDE_CURRENT_DIR ON )
 
 #-------------------------------------------------------------------------------
+# Workaround for math.h on old macOS
+#-------------------------------------------------------------------------------
+
+if ( APPLE AND CMAKE_SYSTEM_VERSION VERSION_LESS 11 )
+    # Older versions of math.h on the Mac define Real and Imag, which
+    # conflict with the internal use of those symbols in CHOLMOD, KLU, SPQR,
+    # UMFPACK, and ParU.
+    # This can be disabled with -D__NOEXTENSIONS__
+    message ( STATUS "MacOS: disable extensions in math.h" )
+    add_compile_definitions ( "__NOEXTENSIONS__" )
+endif ( )
+
+#-------------------------------------------------------------------------------
 # check if Fortran is available and enabled
 #-------------------------------------------------------------------------------
 

--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -144,16 +144,9 @@ if ( BUILD_SHARED_LIBS )
         set_target_properties ( KLU PROPERTIES EXPORT_NO_SYSTEM ON )
     endif ( )
 
-    target_include_directories ( KLU 
+    target_include_directories ( KLU
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
-
-    if ( APPLE AND CMAKE_SYSTEM_VERSION VERSION_LESS 11 )
-        # Older versions of math.h on the Mac (PowerPC only) define Real and Imag,
-        # which conflicts the internal use of those symbols in KLU and CHOLMOD.
-        # This can be disabled with -D__NOEXTENSIONS__
-        target_compile_definitions ( KLU PRIVATE "__NOEXTENSIONS__" )
-    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -181,13 +174,6 @@ if ( BUILD_STATIC_LIBS )
     target_include_directories ( KLU_static
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
-
-    if ( APPLE AND CMAKE_SYSTEM_VERSION VERSION_LESS 11 )
-        # Older versions of math.h on the Mac (PowerPC only) define Real and Imag,
-        # which conflicts the internal use of those symbols in KLU and CHOLMOD.
-        # This can be disabled with -D__NOEXTENSIONS__
-        target_compile_definitions ( KLU_static PRIVATE "__NOEXTENSIONS__" )
-    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -213,7 +199,7 @@ if ( KLU_HAS_CHOLMOD )
             set_target_properties ( KLU_CHOLMOD PROPERTIES EXPORT_NO_SYSTEM ON )
         endif ( )
 
-        target_include_directories ( KLU_CHOLMOD 
+        target_include_directories ( KLU_CHOLMOD
             INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                       $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
     endif ( )
@@ -236,7 +222,7 @@ if ( KLU_HAS_CHOLMOD )
             set_target_properties ( KLU_CHOLMOD_static PROPERTIES EXPORT_NO_SYSTEM ON )
         endif ( )
 
-        target_include_directories ( KLU_CHOLMOD_static 
+        target_include_directories ( KLU_CHOLMOD_static
             INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                       $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
     endif ( )

--- a/LAGraph/cmake_modules/SuiteSparsePolicy.cmake
+++ b/LAGraph/cmake_modules/SuiteSparsePolicy.cmake
@@ -248,6 +248,19 @@ message ( STATUS "Build type:       ${CMAKE_BUILD_TYPE} ")
 set ( CMAKE_INCLUDE_CURRENT_DIR ON )
 
 #-------------------------------------------------------------------------------
+# Workaround for math.h on old macOS
+#-------------------------------------------------------------------------------
+
+if ( APPLE AND CMAKE_SYSTEM_VERSION VERSION_LESS 11 )
+    # Older versions of math.h on the Mac define Real and Imag, which
+    # conflict with the internal use of those symbols in CHOLMOD, KLU, SPQR,
+    # UMFPACK, and ParU.
+    # This can be disabled with -D__NOEXTENSIONS__
+    message ( STATUS "MacOS: disable extensions in math.h" )
+    add_compile_definitions ( "__NOEXTENSIONS__" )
+endif ( )
+
+#-------------------------------------------------------------------------------
 # check if Fortran is available and enabled
 #-------------------------------------------------------------------------------
 

--- a/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
+++ b/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
@@ -248,6 +248,19 @@ message ( STATUS "Build type:       ${CMAKE_BUILD_TYPE} ")
 set ( CMAKE_INCLUDE_CURRENT_DIR ON )
 
 #-------------------------------------------------------------------------------
+# Workaround for math.h on old macOS
+#-------------------------------------------------------------------------------
+
+if ( APPLE AND CMAKE_SYSTEM_VERSION VERSION_LESS 11 )
+    # Older versions of math.h on the Mac define Real and Imag, which
+    # conflict with the internal use of those symbols in CHOLMOD, KLU, SPQR,
+    # UMFPACK, and ParU.
+    # This can be disabled with -D__NOEXTENSIONS__
+    message ( STATUS "MacOS: disable extensions in math.h" )
+    add_compile_definitions ( "__NOEXTENSIONS__" )
+endif ( )
+
+#-------------------------------------------------------------------------------
 # check if Fortran is available and enabled
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
Afaict, more libraries apart from KLU and CHOLMOD might need this workaround on older versions of macOS.

This essentially reverts to your original change (with the typo fixed). 

Sorry for the confusion.