### PR TITLE
Mongoose: Prefer shared linking

### DIFF
--- a/Mongoose/CMakeLists.txt
+++ b/Mongoose/CMakeLists.txt
@@ -257,31 +257,23 @@ endif ( )
 add_executable ( mongoose_exe ${EXE_FILES} )
 set_target_properties ( mongoose_exe PROPERTIES
         OUTPUT_NAME suitesparse_mongoose )
-if ( BUILD_STATIC_LIBS )
-    target_link_libraries ( mongoose_exe Mongoose_static )
+if ( BUILD_SHARED_LIBS )
+    target_link_libraries ( mongoose_exe PRIVATE Mongoose )
 else ( )
-    target_link_libraries ( mongoose_exe Mongoose )
+    target_link_libraries ( mongoose_exe PRIVATE Mongoose_static )
 endif ( )
-if ( TARGET SuiteSparse::SuiteSparseConfig_static )
-    target_link_libraries ( mongoose_exe SuiteSparse::SuiteSparseConfig_static )
-else ( )
-    target_link_libraries ( mongoose_exe SuiteSparse::SuiteSparseConfig )
-endif ( )
+target_link_libraries ( mongoose_exe PRIVATE SuiteSparse::SuiteSparseConfig )
 
 # Build the Demo executable
 add_executable ( demo_exe ${DEMO_FILES} )
 set_target_properties ( demo_exe PROPERTIES
         OUTPUT_NAME demo )
-if ( BUILD_STATIC_LIBS )
-    target_link_libraries ( demo_exe Mongoose_static )
-else ( )
+if ( BUILD_SHARED_LIBS )
     target_link_libraries ( demo_exe Mongoose )
-endif ( )
-if ( TARGET SuiteSparse::SuiteSparseConfig_static )
-    target_link_libraries ( demo_exe SuiteSparse::SuiteSparseConfig_static )
 else ( )
-    target_link_libraries ( demo_exe SuiteSparse::SuiteSparseConfig )
+    target_link_libraries ( demo_exe Mongoose_static )
 endif ( )
+target_link_libraries ( demo_exe SuiteSparse::SuiteSparseConfig )
 
 # Coverage and Unit Testing Setup
 include ( CTest )
@@ -294,28 +286,28 @@ if ( BUILD_TESTING )
         add_executable ( mongoose_test_io
             Tests/Mongoose_Test_IO.cpp
             Tests/Mongoose_Test_IO_exe.cpp )
-        target_link_libraries ( mongoose_test_io Mongoose_static )
-        if ( TARGET SuiteSparse::SuiteSparseConfig_static )
-            target_link_libraries ( mongoose_test_io SuiteSparse::SuiteSparseConfig_static )
+        if ( BUILD_SHARED_LIBS )
+            target_link_libraries ( mongoose_test_io PRIVATE Mongoose )
         else ( )
-            target_link_libraries ( mongoose_test_io SuiteSparse::SuiteSparseConfig )
+            target_link_libraries ( mongoose_test_io PRIVATE Mongoose_static )
         endif ( )
+        target_link_libraries ( mongoose_test_io PRIVATE SuiteSparse::SuiteSparseConfig )
         set_target_properties ( mongoose_test_io PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY ${TESTING_OUTPUT_PATH} )
 
         add_test ( NAME Mongoose_IO_Test
             COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/Tests/runTests -min 1 -max 15 -t io -k )
 
-        if ( WIN32 AND BUILD_SHARED_LIBS )
-            set_tests_properties ( Mongoose_IO_Test PROPERTIES
-                ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:Mongoose>" )
-        endif ( )
-
         # Edge Separator Tests
         add_executable ( mongoose_test_edgesep
             Tests/Mongoose_Test_EdgeSeparator.cpp
             Tests/Mongoose_Test_EdgeSeparator_exe.cpp)
-        target_link_libraries ( mongoose_test_edgesep Mongoose_static )
+        if ( BUILD_SHARED_LIBS )
+            target_link_libraries ( mongoose_test_edgesep PRIVATE Mongoose )
+        else ( )
+            target_link_libraries ( mongoose_test_edgesep PRIVATE Mongoose_static )
+        endif ( )
+        target_link_libraries ( mongoose_test_edgesep PRIVATE SuiteSparse::SuiteSparseConfig )
         set_target_properties ( mongoose_test_edgesep PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY ${TESTING_OUTPUT_PATH} )
 
@@ -328,41 +320,32 @@ if ( BUILD_TESTING )
         add_test ( NAME Mongoose_Target_Split_Test
             COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/Tests/runTests -min 1 -max 15 -t edgesep -s 0.3 )
 
-        if ( WIN32 AND BUILD_SHARED_LIBS )
-            set_tests_properties ( Mongoose_Edge_Separator_Test Mongoose_Edge_Separator_Test_2 Mongoose_Weighted_Edge_Separator_Test Mongoose_Target_Split_Test PROPERTIES
-                ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:Mongoose>" )
-        endif ( )
-
         # Memory Tests
         add_executable ( mongoose_test_memory
             Tests/Mongoose_Test_Memory.cpp
             Tests/Mongoose_Test_Memory_exe.cpp)
-        target_link_libraries ( mongoose_test_memory Mongoose_static )
+        if ( BUILD_SHARED_LIBS )
+            target_link_libraries ( mongoose_test_memory PRIVATE Mongoose )
+        else ( )
+            target_link_libraries ( mongoose_test_memory PRIVATE Mongoose_static )
+        endif ( )
+        target_link_libraries ( mongoose_test_memory PRIVATE SuiteSparse::SuiteSparseConfig )
         set_target_properties ( mongoose_test_memory PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY ${TESTING_OUTPUT_PATH} )
 
         add_test ( NAME Mongoose_Memory_Test
             COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/Tests/runTests -min 1 -max 15 -t memory )
 
-        if ( WIN32 AND BUILD_SHARED_LIBS )
-            set_tests_properties ( Mongoose_Memory_Test PROPERTIES
-                ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:Mongoose>" )
-        endif ( )
-
         # Performance Test
         add_executable ( mongoose_test_performance
             Tests/Mongoose_Test_Performance.cpp
             Tests/Mongoose_Test_Performance_exe.cpp )
-        if ( BUILD_STATIC_LIBS )
-            target_link_libraries ( mongoose_test_performance Mongoose_static )
+        if ( BUILD_SHARED_LIBS )
+            target_link_libraries ( mongoose_test_performance PRIVATE Mongoose )
         else ( )
-            target_link_libraries ( mongoose_test_performance Mongoose )
+            target_link_libraries ( mongoose_test_performance PRIVATE Mongoose_static )
         endif ( )
-        if ( TARGET SuiteSparse::SuiteSparseConfig_static )
-            target_link_libraries ( mongoose_test_performance SuiteSparse::SuiteSparseConfig_static )
-        else ( )
-            target_link_libraries ( mongoose_test_performance SuiteSparse::SuiteSparseConfig )
-        endif ( )
+        target_link_libraries ( mongoose_test_performance PRIVATE SuiteSparse::SuiteSparseConfig )
         set_target_properties ( mongoose_test_performance PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY ${TESTING_OUTPUT_PATH} )
 
@@ -372,8 +355,12 @@ if ( BUILD_TESTING )
             COMMAND ${Python_EXECUTABLE} ${PROJECT_SOURCE_DIR}/Tests/runTests -t performance -i 21 39 1557 1562 353 2468 1470 1380 505 182 201 2331 760 1389 2401 2420 242 250 1530 1533 -p )
 
         if ( WIN32 AND BUILD_SHARED_LIBS )
-            set_tests_properties ( Mongoose_Performance_Test Mongoose_Performance_Test_2 PROPERTIES
-                ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:Mongoose>" )
+            set_tests_properties ( Mongoose_IO_Test
+                Mongoose_Edge_Separator_Test Mongoose_Edge_Separator_Test_2 Mongoose_Weighted_Edge_Separator_Test Mongoose_Target_Split_Test
+                Mongoose_Memory_Test
+                Mongoose_Performance_Test Mongoose_Performance_Test_2
+                PROPERTIES
+                ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:Mongoose>;PATH=path_list_prepend:$<TARGET_FILE_DIR:SuiteSparse::SuiteSparseConfig>" )
         endif ( )
     endif ( )
 
@@ -381,22 +368,24 @@ if ( BUILD_TESTING )
     add_executable ( mongoose_test_reference
         Tests/Mongoose_Test_Reference.cpp
         Tests/Mongoose_Test_Reference_exe.cpp )
-    if ( BUILD_STATIC_LIBS )
-        target_link_libraries ( mongoose_test_reference Mongoose_static )
+    if ( BUILD_SHARED_LIBS )
+        target_link_libraries ( mongoose_test_reference PRIVATE Mongoose )
     else ( )
-        target_link_libraries ( mongoose_test_reference Mongoose )
+        target_link_libraries ( mongoose_test_reference PRIVATE Mongoose_static )
     endif ( )
-    if ( TARGET SuiteSparse::SuiteSparseConfig_static )
-        target_link_libraries ( mongoose_test_reference SuiteSparse::SuiteSparseConfig_static )
-    else ( )
-        target_link_libraries ( mongoose_test_reference SuiteSparse::SuiteSparseConfig )
-    endif ( )
+    target_link_libraries ( mongoose_test_reference PRIVATE SuiteSparse::SuiteSparseConfig )
     set_target_properties ( mongoose_test_reference PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${TESTING_OUTPUT_PATH} )
+    # FIXME: Is there a test that is using this executable?
 
     # Unit Tests
     add_executable ( mongoose_unit_test_io
         Tests/Mongoose_UnitTest_IO_exe.cpp )
-    target_link_libraries ( mongoose_unit_test_io Mongoose_static )
+    if ( BUILD_SHARED_LIBS )
+        target_link_libraries ( mongoose_unit_test_io PRIVATE Mongoose )
+    else ( )
+        target_link_libraries ( mongoose_unit_test_io PRIVATE Mongoose_static )
+    endif ( )
+    target_link_libraries ( mongoose_unit_test_io PRIVATE SuiteSparse::SuiteSparseConfig )
     set_target_properties ( mongoose_unit_test_io PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${TESTING_OUTPUT_PATH} )
     add_test ( NAME Mongoose_Unit_Test_IO
         COMMAND ${TESTING_OUTPUT_PATH}/mongoose_unit_test_io
@@ -404,7 +393,12 @@ if ( BUILD_TESTING )
 
     add_executable ( mongoose_unit_test_graph
         Tests/Mongoose_UnitTest_Graph_exe.cpp )
-    target_link_libraries ( mongoose_unit_test_graph Mongoose_static )
+    if ( BUILD_SHARED_LIBS )
+        target_link_libraries ( mongoose_unit_test_graph PRIVATE Mongoose )
+    else ( )
+        target_link_libraries ( mongoose_unit_test_graph PRIVATE Mongoose_static )
+    endif ( )
+    target_link_libraries ( mongoose_unit_test_graph PRIVATE SuiteSparse::SuiteSparseConfig )
     set_target_properties ( mongoose_unit_test_graph PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${TESTING_OUTPUT_PATH} )
     add_test ( NAME Mongoose_Unit_Test_Graph
         COMMAND ${TESTING_OUTPUT_PATH}/mongoose_unit_test_graph
@@ -412,7 +406,12 @@ if ( BUILD_TESTING )
 
     add_executable ( mongoose_unit_test_edgesep
         Tests/Mongoose_UnitTest_EdgeSep_exe.cpp )
-    target_link_libraries ( mongoose_unit_test_edgesep Mongoose_static )
+    if ( BUILD_SHARED_LIBS )
+        target_link_libraries ( mongoose_unit_test_edgesep PRIVATE Mongoose )
+    else ( )
+        target_link_libraries ( mongoose_unit_test_edgesep PRIVATE Mongoose_static )
+    endif ( )
+    target_link_libraries ( mongoose_unit_test_edgesep PRIVATE SuiteSparse::SuiteSparseConfig )
     set_target_properties ( mongoose_unit_test_edgesep PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${TESTING_OUTPUT_PATH} )
     add_test ( NAME Mongoose_Unit_Test_EdgeSep
         COMMAND ${TESTING_OUTPUT_PATH}/mongoose_unit_test_edgesep
@@ -420,7 +419,7 @@ if ( BUILD_TESTING )
 
     if ( WIN32 AND BUILD_SHARED_LIBS )
         set_tests_properties ( Mongoose_Unit_Test_IO Mongoose_Unit_Test_Graph Mongoose_Unit_Test_EdgeSep PROPERTIES
-            ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:Mongoose>" )
+            ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:Mongoose>;PATH=path_list_prepend:$<TARGET_FILE_DIR:SuiteSparse::SuiteSparseConfig>" )
     endif ( )
 
     if ( $ENV{MONGOOSE_COVERAGE} )
@@ -475,9 +474,15 @@ if ( BUILD_TESTING )
     endif ()
 
     if ( MONGOOSE_COVERAGE )
-        set_target_properties ( Mongoose_static PROPERTIES
-            COMPILE_FLAGS "${CMAKE_CXX_FLAGS_DEBUG}"
-            LINK_FLAGS "${CMAKE_EXE_LINKER_FLAGS_DEBUG}" )
+        if ( BUILD_SHARED_LIBS )
+            set_target_properties ( Mongoose PROPERTIES
+                COMPILE_FLAGS "${CMAKE_CXX_FLAGS_DEBUG}"
+                LINK_FLAGS "${CMAKE_EXE_LINKER_FLAGS_DEBUG}" )
+        else ( )
+            set_target_properties ( Mongoose_static PROPERTIES
+                COMPILE_FLAGS "${CMAKE_CXX_FLAGS_DEBUG}"
+                LINK_FLAGS "${CMAKE_EXE_LINKER_FLAGS_DEBUG}" )
+        endif ( )
 
         # Add debug compile/linker flags
         if ( Python_Interpreter_FOUND )

--- a/Mongoose/CMakeLists.txt
+++ b/Mongoose/CMakeLists.txt
@@ -223,6 +223,8 @@ if ( BUILD_STATIC_LIBS )
     else ( )
         target_link_libraries ( Mongoose_static PUBLIC SuiteSparse::SuiteSparseConfig )
     endif ( )
+
+    target_compile_definitions ( Mongoose_static PUBLIC MONGOOSE_STATIC )
 endif ( )
 
 if ( BUILD_SHARED_LIBS )
@@ -249,6 +251,8 @@ if ( BUILD_SHARED_LIBS )
         "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 
     target_include_directories ( Mongoose PRIVATE . )
+
+    target_compile_definitions ( Mongoose PRIVATE MONGOOSE_BUILDING )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/Mongoose/Executable/mongoose.cpp
+++ b/Mongoose/Executable/mongoose.cpp
@@ -10,11 +10,11 @@
 
 //------------------------------------------------------------------------------
 
+#include "Mongoose.hpp"
 // #include "Mongoose_Internal.hpp"
 // #include "Mongoose_EdgeCut.hpp"
 // #include "Mongoose_IO.hpp"
 #include "Mongoose_Logger.hpp"
-#include "Mongoose.hpp"
 
 #include <fstream>
 

--- a/Mongoose/Include/Mongoose.hpp
+++ b/Mongoose/Include/Mongoose.hpp
@@ -29,6 +29,21 @@
 #error "Mongoose 3.3.1 requires SuiteSparse_config 7.5.0 or later"
 #endif
 
+#if defined (_MSC_VER) && ! defined (__INTEL_COMPILER)
+    #if defined (MONGOOSE_STATIC)
+        #define MONGOOSE_API
+    #else
+        #if defined (MONGOOSE_BUILDING)
+            #define MONGOOSE_API __declspec ( dllexport )
+        #else
+            #define MONGOOSE_API __declspec ( dllimport )
+        #endif
+    #endif
+#else
+    // for other compilers
+    #define MONGOOSE_API
+#endif
+
 namespace Mongoose
 {
 

--- a/Mongoose/Include/Mongoose_Internal.hpp
+++ b/Mongoose/Include/Mongoose_Internal.hpp
@@ -36,14 +36,33 @@
 #error "Mongoose requires SuiteSparse_config 7.4.0 or later"
 #endif
 
+#ifndef MAX_INT
+#define MAX_INT INT64_MAX
+#endif
+
+#ifndef MONGOOSE_HPP
+// avoid collision with symbols that are declared in Mongoose.hpp
+
+#if defined (_MSC_VER) && ! defined (__INTEL_COMPILER)
+    #if defined (MONGOOSE_STATIC)
+        #define MONGOOSE_API
+    #else
+        #if defined (MONGOOSE_BUILDING)
+            #define MONGOOSE_API __declspec ( dllexport )
+        #else
+            #define MONGOOSE_API __declspec ( dllimport )
+        #endif
+    #endif
+#else
+    // for other compilers
+    #define MONGOOSE_API
+#endif
+
 namespace Mongoose
 {
 
 /* Type definitions */
 typedef int64_t Int;
-#ifndef MAX_INT
-#define MAX_INT INT64_MAX
-#endif
 
 /* Enumerations */
 enum MatchingStrategy
@@ -70,5 +89,6 @@ enum MatchType
 };
 
 } // end namespace Mongoose
+#endif
 
 #endif

--- a/Mongoose/Include/Mongoose_Logger.hpp
+++ b/Mongoose/Include/Mongoose_Logger.hpp
@@ -32,6 +32,8 @@
 #error "Mongoose requires SuiteSparse_config 7.4.0 or later"
 #endif
 
+#include "Mongoose_Internal.hpp"
+
 // Default Logging Levels
 #ifndef LOG_ERROR
 #define LOG_ERROR 1
@@ -101,10 +103,10 @@ typedef enum TimingType
 class Logger
 {
 private:
-    static int debugLevel;
-    static bool timingOn;
-    static double clocks[6];
-    static float times[6];
+    MONGOOSE_API static int debugLevel;
+    MONGOOSE_API static bool timingOn;
+    MONGOOSE_API static double clocks[6];
+    MONGOOSE_API static float times[6];
 
 public:
     static inline void tic(TimingType timingType);

--- a/Mongoose/Version/Mongoose.hpp.in
+++ b/Mongoose/Version/Mongoose.hpp.in
@@ -29,6 +29,21 @@
 #error "Mongoose @Mongoose_VERSION_MAJOR@.@Mongoose_VERSION_MINOR@.@Mongoose_VERSION_PATCH@ requires SuiteSparse_config 7.5.0 or later"
 #endif
 
+#if defined (_MSC_VER) && ! defined (__INTEL_COMPILER)
+    #if defined (MONGOOSE_STATIC)
+        #define MONGOOSE_API
+    #else
+        #if defined (MONGOOSE_BUILDING)
+            #define MONGOOSE_API __declspec ( dllexport )
+        #else
+            #define MONGOOSE_API __declspec ( dllimport )
+        #endif
+    #endif
+#else
+    // for other compilers
+    #define MONGOOSE_API
+#endif
+
 namespace Mongoose
 {
 


### PR DESCRIPTION
Most projects in SuiteSparse prefer shared linking over static linking. One (maybe the only?) exception is Mongoose.

Change the build rules of Mongoose to also prefer shared linking over static linking (like the other subprojects).

Also, fix an issue with shared linking with MSVC. The approach here is different to the change proposed in #686 and more in line with how this is handled in LAGraph.
The change is slightly complicated by the fact that many symbols are declared multiple times for some reason (once in `Mongoose.hpp` and then again in separate headers).