### PR TITLE
SPEX: Silence compiler warnings about unknown pragmas

### DIFF
--- a/GraphBLAS/JITpackage/Source/grb_jitpackage.c
+++ b/GraphBLAS/JITpackage/Source/grb_jitpackage.c
@@ -16,7 +16,9 @@
 //------------------------------------------------------------------------------
 
 // ZSTD uses switch statements with no default case.
+#if defined (__GNUC__)
 #pragma GCC diagnostic ignored "-Wswitch-default"
+#endif
 
 // disable ZSTD deprecation warnings and include all ZSTD definitions  
 

--- a/SPEX/SPEX_Left_LU/Demo/demos.c
+++ b/SPEX/SPEX_Left_LU/Demo/demos.c
@@ -16,8 +16,10 @@
 
 #include "demos.h"
 
+#if defined (__GNUC__)
 // ignore warnings about unused parameters in this file
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 
 //------------------------------------------------------------------------------
 // SPEX_print_options

--- a/SPEX/SPEX_Util/Source/SPEX_gmp.c
+++ b/SPEX/SPEX_Util/Source/SPEX_gmp.c
@@ -64,8 +64,10 @@
 #include "spex_util_internal.h"
 #include "SPEX_gmp.h"
 
+#if defined (__GNUC__)
 // ignore warnings about unused parameters in this file
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#endif
 
 //------------------------------------------------------------------------------
 // global variables

--- a/SPEX/SPEX_Util/Source/SPEX_matrix_free.c
+++ b/SPEX/SPEX_Util/Source/SPEX_matrix_free.c
@@ -9,7 +9,10 @@
 //------------------------------------------------------------------------------
 
 // Free a SPEX_matrix.  Any shallow component is not freed.
+#if defined (__GNUC__)
 #pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+
 #include "spex_util_internal.h"
 
 SPEX_info SPEX_matrix_free

--- a/SPEX/SPEX_Util/Source/SPEX_matrix_nnz.c
+++ b/SPEX/SPEX_Util/Source/SPEX_matrix_nnz.c
@@ -8,7 +8,10 @@
 
 //------------------------------------------------------------------------------
 
+#if defined (__GNUC__)
 #pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+
 #include "spex_util_internal.h"
 
 

--- a/SPEX/SPEX_Util/Source/spex_cast_array.c
+++ b/SPEX/SPEX_Util/Source/spex_cast_array.c
@@ -38,7 +38,10 @@
 SPEX_MPQ_CLEAR(temp);       \
 
 #include "spex_util_internal.h"
+
+#if defined (__GNUC__)
 #pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
 
 SPEX_info spex_cast_array
 (

--- a/SPEX/SPEX_Util/Source/spex_util_internal.h
+++ b/SPEX/SPEX_Util/Source/spex_util_internal.h
@@ -14,8 +14,10 @@
 #ifndef SPEX_UTIL_INTERNAL_H
 #define SPEX_UTIL_INTERNAL_H
 
+#if defined (__GNUC__)
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wunused-value"
+#endif
 
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Compilers that don't recognize `#pragma GCC` (e.g., MSVC) emit warnings when they see those pragmas.
Add a condition (for GCC compatible compilers like gcc, clang, icc, ...) to silence those warnings for non-GCC compatible compilers.
