### PR TITLE
SPQR: Slightly overhaul code of GPU libraries

### DIFF
--- a/SPQR/GPUQREngine/CMakeLists.txt
+++ b/SPQR/GPUQREngine/CMakeLists.txt
@@ -66,7 +66,12 @@ configure_file ( "Config/GPUQREngine.hpp.in"
 
 #-------------------------------------------------------------------------------
 
-file ( GLOB GPUQRENGINE_SOURCES "Source/*.cpp" "Source/*.cu" "Source/*/*.cpp" )
+file ( GLOB GPUQRENGINE_SOURCES "Source/*.cpp"
+    "Source/*.cu"
+    "Source/BucketList/BucketList.cpp"
+    "Source/LLBundle/LLBundle.cpp"
+    "Source/Scheduler/Scheduler.cpp"
+    "Source/TaskDescriptor/*.cpp" )
 
 set ( GPUQRENGINE_INCLUDES Include Include/Kernel
     Include/Kernel/Apply Include/Kernel/Assemble Include/Kernel/Factorize )

--- a/SPQR/GPUQREngine/Include/GPUQREngine_BucketList.hpp
+++ b/SPQR/GPUQREngine/Include/GPUQREngine_BucketList.hpp
@@ -21,6 +21,7 @@
 #define GPUQRENGINE_BUCKETLIST_HPP
 
 #include <cstddef>
+#include <new>
 
 #include "GPUQREngine_Common.hpp"
 #include "GPUQREngine_TaskDescriptor.hpp"
@@ -74,10 +75,6 @@ public:
     int VThead;              // Index of the first available entry in VTlist
 
     // Constructors
-    void *operator new(std::size_t, BucketList <Int>* p)
-    {
-        return p;
-    }
     BucketList(Front <Int> *f, Int minApplyGranularity);
     ~BucketList();
 

--- a/SPQR/GPUQREngine/Include/GPUQREngine_BucketList.hpp
+++ b/SPQR/GPUQREngine/Include/GPUQREngine_BucketList.hpp
@@ -187,7 +187,9 @@ public:
     );
 };
 
+#if ! defined (GPUQRENGINE_NO_EXTERN_BUCKETLIST)
 extern template class BucketList<int32_t>;
 extern template class BucketList<int64_t>;
+#endif
 
 #endif

--- a/SPQR/GPUQREngine/Include/GPUQREngine_Front.hpp
+++ b/SPQR/GPUQREngine/Include/GPUQREngine_Front.hpp
@@ -20,6 +20,7 @@
 #define GPUQRENGINE_FRONT_HPP
 
 #include <cstddef>
+#include <new>
 
 #include "GPUQREngine_Common.hpp"
 #include "GPUQREngine_SparseMeta.hpp"
@@ -54,8 +55,6 @@ public:
 
     /* Debug Fields */
     bool printMe;
-
-    void* operator new(std::size_t reqMem, Front* ptr){ return ptr; }
 
     Front(
         Int fids_arg,                   // the front identifier

--- a/SPQR/GPUQREngine/Include/GPUQREngine_LLBundle.hpp
+++ b/SPQR/GPUQREngine/Include/GPUQREngine_LLBundle.hpp
@@ -25,6 +25,7 @@
 #define GPUQRENGINE_LLBUNDLE_HPP
 
 #include <cstddef>
+#include <new>
 
 #include "GPUQREngine_Common.hpp"
 #include "GPUQREngine_TaskDescriptor.hpp"
@@ -78,7 +79,6 @@ public:
 
     TaskType CurrentTask;
 
-    void *operator new(std::size_t, LLBundle <Int>* p){ return p; }
     //------------------------------------------------------------------------------
     //
     // This file contains the constructor and destructor for the LLBundle class.

--- a/SPQR/GPUQREngine/Include/GPUQREngine_LLBundle.hpp
+++ b/SPQR/GPUQREngine/Include/GPUQREngine_LLBundle.hpp
@@ -127,6 +127,9 @@ public:
     void gpuPack(TaskDescriptor *cpuTask);
 };
 
+#if ! defined (GPUQRENGINE_NO_EXTERN_LLBUNDLE)
 extern template class LLBundle<int32_t>;
 extern template class LLBundle<int64_t>;
+#endif
+
 #endif

--- a/SPQR/GPUQREngine/Include/GPUQREngine_Scheduler.hpp
+++ b/SPQR/GPUQREngine/Include/GPUQREngine_Scheduler.hpp
@@ -174,6 +174,9 @@ public:
 #endif
 };
 
+#if ! defined (GPUQRENGINE_NO_EXTERN_SCHEDULER)
 extern template class Scheduler<int32_t>;
 extern template class Scheduler<int64_t>;
+#endif
+
 #endif

--- a/SPQR/GPUQREngine/Include/GPUQREngine_Scheduler.hpp
+++ b/SPQR/GPUQREngine/Include/GPUQREngine_Scheduler.hpp
@@ -20,6 +20,7 @@
 #define GPUQRENGINE_SCHEDULER_HPP
 
 #include <cstddef>
+#include <new>
 
 #include "GPUQREngine_Common.hpp"
 #include "GPUQREngine_FrontState.hpp"
@@ -99,7 +100,6 @@ public:
     cudaStream_t memoryStreamD2H;
 
     /* Scheduler.cpp */
-    void *operator new(std::size_t, Scheduler <Int>* p){ return p; }
     Scheduler(Front <Int> *fronts, Int numFronts, size_t gpuMemorySize);
     ~Scheduler();
 

--- a/SPQR/GPUQREngine/Source/BucketList/BucketList.cpp
+++ b/SPQR/GPUQREngine/Source/BucketList/BucketList.cpp
@@ -31,6 +31,9 @@
     Bundles = (LLBundle <Int> *) SuiteSparse_free(Bundles); \
     gpuVT = (double **) SuiteSparse_free(gpuVT); \
     wsMongoVT = Workspace::destroy(wsMongoVT);
+
+#define GPUQRENGINE_NO_EXTERN_BUCKETLIST
+
 #include "GPUQREngine_BucketList.hpp"
 template <typename Int>
 BucketList<Int>::BucketList
@@ -103,16 +106,6 @@ BucketList<Int>::BucketList
     }
 }
 
-template BucketList<int32_t>::BucketList
-(
-    Front <int32_t> *F,
-    int32_t minApplyGranularity
-) ;
-template BucketList<int64_t>::BucketList
-(
-    Front <int64_t> *F,
-    int64_t minApplyGranularity
-) ;
 
 template <typename Int>
 BucketList<Int>::~BucketList()
@@ -120,9 +113,6 @@ BucketList<Int>::~BucketList()
     FREE_EVERYTHING_BUCKET ;
 
 }
-
-template BucketList<int32_t>::~BucketList() ;
-template BucketList<int64_t>::~BucketList() ;
 
 
 template <typename Int>
@@ -149,5 +139,17 @@ void BucketList<Int>::Initialize()
     }
 }
 
-template void BucketList<int32_t>::Initialize() ;
-template void BucketList<int64_t>::Initialize() ;
+
+// Instantiate BucketList class template with types int32_t and int64_t
+// for export from library.
+
+#include "BucketList_AdvanceBundles.cpp"
+#include "BucketList_CreateBundles.cpp"
+#include "BucketList_FillWorkQueue.cpp"
+#include "BucketList_GrowBundles.cpp"
+#include "BucketList_Manage.cpp"
+#include "BucketList_PostProcessing.cpp"
+
+template class BucketList<int32_t>;
+template class BucketList<int64_t>;
+

--- a/SPQR/GPUQREngine/Source/BucketList/BucketList_AdvanceBundles.cpp
+++ b/SPQR/GPUQREngine/Source/BucketList/BucketList_AdvanceBundles.cpp
@@ -43,6 +43,3 @@ void BucketList<Int>::AdvanceBundles()
         }
     }
 }
-
-template void BucketList<int32_t>::AdvanceBundles() ;
-template void BucketList<int64_t>::AdvanceBundles() ;

--- a/SPQR/GPUQREngine/Source/BucketList/BucketList_CreateBundles.cpp
+++ b/SPQR/GPUQREngine/Source/BucketList/BucketList_CreateBundles.cpp
@@ -58,15 +58,6 @@ void BucketList<Int>::CreateBundles
     }
 }
 
-template void BucketList<int32_t>::CreateBundles
-(
-    void
-) ;
-template void BucketList<int64_t>::CreateBundles
-(
-    void
-) ;
-
 // SkipBundleCreation determines whether we should skip creating a new
 // bundle for the specified tile in the specified column bucket.
 template <typename Int>
@@ -92,17 +83,6 @@ bool BucketList<Int>::SkipBundleCreation
 
     return false;
 }
-
-template bool BucketList<int32_t>::SkipBundleCreation
-(
-    int32_t tile,           // The tile to consider
-    int32_t colBucket       // The column bucket it sits in
-) ;
-template bool BucketList<int64_t>::SkipBundleCreation
-(
-    int64_t tile,           // The tile to consider
-    int64_t colBucket       // The column bucket it sits in
-) ;
 
 // IsInternal determines whether a tile is completely within the bounds
 // of the front because if it isn't then we will need to use the special
@@ -133,14 +113,3 @@ bool BucketList<Int>::IsInternal
     Int iLast = TILESIZE * (iTile+1) - 1;
     return(iLast < front->fm && jLast < front->fn);
 }
-
-template bool BucketList<int32_t>::IsInternal
-(
-    LLBundle <int32_t>& Bundle,
-    int jLast
-) ;
-template bool BucketList<int64_t>::IsInternal
-(
-    LLBundle <int64_t>& Bundle,
-    int jLast
-) ;

--- a/SPQR/GPUQREngine/Source/BucketList/BucketList_FillWorkQueue.cpp
+++ b/SPQR/GPUQREngine/Source/BucketList/BucketList_FillWorkQueue.cpp
@@ -202,14 +202,3 @@ Int BucketList<Int>::FillWorkQueue
 
     return numTasks;
 }
-
-template int32_t BucketList<int32_t>::FillWorkQueue
-(
-    TaskDescriptor *queue,  // The list of work items for the GPU
-    int32_t *queueIndex         // The current index into the queue
-) ;
-template int64_t BucketList<int64_t>::FillWorkQueue
-(
-    TaskDescriptor *queue,  // The list of work items for the GPU
-    int64_t *queueIndex         // The current index into the queue
-) ;

--- a/SPQR/GPUQREngine/Source/BucketList/BucketList_GrowBundles.cpp
+++ b/SPQR/GPUQREngine/Source/BucketList/BucketList_GrowBundles.cpp
@@ -72,13 +72,4 @@ void BucketList<Int>::GrowBundles
         }
     }
 }
-
-template void BucketList<int32_t>::GrowBundles
-(
-    void
-) ;
-template void BucketList<int64_t>::GrowBundles
-(
-    void
-) ;
 #endif

--- a/SPQR/GPUQREngine/Source/BucketList/BucketList_Manage.cpp
+++ b/SPQR/GPUQREngine/Source/BucketList/BucketList_Manage.cpp
@@ -39,18 +39,6 @@ void BucketList<Int>::Insert
     /* Keep track of the last bucket. */
     LastBucket = MAX(LastBucket, bucket);
 }
-template void BucketList<int32_t>::Insert
-(
-    int32_t tile,
-    int32_t bucket,
-    bool upperTriangular
-) ;
-template void BucketList<int64_t>::Insert
-(
-    int64_t tile,
-    int64_t bucket,
-    bool upperTriangular
-) ;
 
 template <typename Int>
 void BucketList<Int>::Remove
@@ -77,17 +65,6 @@ void BucketList<Int>::Remove
     numIdleTiles--;
 }
 
-template void BucketList<int32_t>::Remove
-(
-    int32_t tile,
-    int32_t bucket
-) ;
-template void BucketList<int64_t>::Remove
-(
-    int64_t tile,
-    int64_t bucket
-) ;
-
 #ifdef GPUQRENGINE_PIPELINING
 template <typename Int>
 Int BucketList<Int>::RemoveHead
@@ -99,12 +76,4 @@ Int BucketList<Int>::RemoveHead
     Remove(tile, bucket);
     return tile;
 }
-template int32_t BucketList<int32_t>::RemoveHead
-(
-    int32_t bucket                  // The bucket number
-) ;
-template int64_t BucketList<int64_t>::RemoveHead
-(
-    int64_t bucket                  // The bucket number
-) ;
 #endif

--- a/SPQR/GPUQREngine/Source/BucketList/BucketList_PostProcessing.cpp
+++ b/SPQR/GPUQREngine/Source/BucketList/BucketList_PostProcessing.cpp
@@ -46,12 +46,3 @@ void BucketList<Int>::PostProcess
         }
     }
 }
-
-template void BucketList<int32_t>::PostProcess
-(
-    void
-) ;
-template void BucketList<int64_t>::PostProcess
-(
-    void
-) ;

--- a/SPQR/GPUQREngine/Source/GPUQREngine_Internal.cpp
+++ b/SPQR/GPUQREngine/Source/GPUQREngine_Internal.cpp
@@ -124,14 +124,5 @@ template QREngineResultCode GPUQREngine_Internal
                             // via this struct
 ) ;
 
-template class BucketList<int32_t>;
-template class BucketList<int64_t>;
-
-template class LLBundle<int32_t>;
-template class LLBundle<int64_t>;
-
-template class Scheduler<int32_t>;
-template class Scheduler<int64_t>;
-
 #endif
 

--- a/SPQR/GPUQREngine/Source/LLBundle/LLBundle.cpp
+++ b/SPQR/GPUQREngine/Source/LLBundle/LLBundle.cpp
@@ -1,0 +1,28 @@
+// =============================================================================
+// === GPUQREngine/Source/LLBundle.cpp ================================
+// =============================================================================
+
+// GPUQREngine, Copyright (c) 2024, Timothy A Davis, Sencer Nuri Yeralan,
+// and Sanjay Ranka.  All Rights Reserved.
+// SPDX-License-Identifier: GPL-2.0+
+
+//------------------------------------------------------------------------------
+//
+// Instantiate LLBundle class template with types int32_t and int64_t
+// for export from library.
+//
+// =============================================================================
+
+#define GPUQRENGINE_NO_EXTERN_LLBUNDLE
+
+#include "GPUQREngine_LLBundle.hpp"
+#include "GPUQREngine_BucketList.hpp"
+
+#include "LLBundle_AddTiles.cpp"
+#include "LLBundle_Advance.cpp"
+#include "LLBundle_GPUPack.cpp"
+#include "LLBundle_PipelinedRearrange.cpp"
+#include "LLBundle_UpdateSecondMinIndex.cpp"
+
+template class LLBundle<int32_t>;
+template class LLBundle<int64_t>;

--- a/SPQR/GPUQREngine/Source/LLBundle/LLBundle_AddTiles.cpp
+++ b/SPQR/GPUQREngine/Source/LLBundle/LLBundle_AddTiles.cpp
@@ -117,12 +117,3 @@ void LLBundle <Int>::AddTileToSlots
     /* Update last, if needed. */
     if (next[Last] != EMPTY) Last = next[Last];
 }
-
-template void LLBundle <int32_t>::AddTileToSlots
-(
-    int32_t rowTile
-) ;
-template void LLBundle <int64_t>::AddTileToSlots
-(
-    int64_t rowTile
-) ;

--- a/SPQR/GPUQREngine/Source/LLBundle/LLBundle_Advance.cpp
+++ b/SPQR/GPUQREngine/Source/LLBundle/LLBundle_Advance.cpp
@@ -83,12 +83,3 @@ bool LLBundle <Int>::Advance
 
     return stillAround;
 }
-
-template bool LLBundle <int32_t>::Advance
-(
-    void
-) ;
-template bool LLBundle <int64_t>::Advance
-(
-    void
-) ;

--- a/SPQR/GPUQREngine/Source/LLBundle/LLBundle_GPUPack.cpp
+++ b/SPQR/GPUQREngine/Source/LLBundle/LLBundle_GPUPack.cpp
@@ -59,12 +59,3 @@ void LLBundle <Int>::gpuPack
     cpuTask->AuxAddress[0] = VT[0];
     cpuTask->AuxAddress[1] = VT[1];
 }
-
-template void LLBundle <int32_t>::gpuPack
-(
-    TaskDescriptor* cpuTask
-) ;
-template void LLBundle <int64_t>::gpuPack
-(
-    TaskDescriptor* cpuTask
-) ;

--- a/SPQR/GPUQREngine/Source/LLBundle/LLBundle_PipelinedRearrange.cpp
+++ b/SPQR/GPUQREngine/Source/LLBundle/LLBundle_PipelinedRearrange.cpp
@@ -109,12 +109,3 @@ void LLBundle <Int>::PipelinedRearrange
         while (next[Last] != EMPTY) Last = next[Last];
     }
 }
-
-template void LLBundle <int32_t>::PipelinedRearrange
-(
-    void
-) ;
-template void LLBundle <int64_t>::PipelinedRearrange
-(
-    void
-) ;

--- a/SPQR/GPUQREngine/Source/LLBundle/LLBundle_UpdateSecondMinIndex.cpp
+++ b/SPQR/GPUQREngine/Source/LLBundle/LLBundle_UpdateSecondMinIndex.cpp
@@ -37,14 +37,6 @@ void LLBundle <Int>::UpdateSecondMinIndex
         inspect = next[inspect];
     }
 }
-template void LLBundle <int32_t>::UpdateSecondMinIndex
-(
-    void
-) ;
-template void LLBundle <int64_t>::UpdateSecondMinIndex
-(
-    void
-) ;
 
 // -----------------------------------------------------------------------------
 // LLBundle::UpdateMax
@@ -61,12 +53,3 @@ void LLBundle <Int>::UpdateMax
     Max = Shadow;
     for(Int tile=First; tile!=EMPTY; tile=next[tile]) Max = MAX(Max, tile);
 }
-
-template void LLBundle <int32_t>::UpdateMax
-(
-    void
-) ;
-template void LLBundle <int64_t>::UpdateMax
-(
-    void
-) ;

--- a/SPQR/GPUQREngine/Source/Scheduler/Scheduler.cpp
+++ b/SPQR/GPUQREngine/Source/Scheduler/Scheduler.cpp
@@ -21,10 +21,12 @@
 // the constructor is responsible for memory management AND initialization.
 // =============================================================================
 
+#define GPUQRENGINE_NO_EXTERN_SCHEDULER
+#include "GPUQREngine_Scheduler.hpp"
+
 // -----------------------------------------------------------------------------
 // Macro destructor
 // -----------------------------------------------------------------------------
-#include "GPUQREngine_Scheduler.hpp"
 #define FREE_EVERYTHING_SCHEDULER \
     afPerm = (Int *) SuiteSparse_free(afPerm); \
     afPinv = (Int *) SuiteSparse_free(afPinv); \
@@ -159,18 +161,6 @@ Scheduler <Int>::Scheduler
     renderCount = 0;
     #endif
 }
-template Scheduler <int32_t>::Scheduler
-(
-    Front <int32_t> *fronts,
-    int32_t numFronts,
-    size_t gpuMemorySize
-) ;
-template Scheduler <int64_t>::Scheduler
-(
-    Front <int64_t> *fronts,
-    int64_t numFronts,
-    size_t gpuMemorySize
-) ;
 
 // -----------------------------------------------------------------------------
 // Scheduler destructor
@@ -180,9 +170,6 @@ Scheduler <Int>::~Scheduler()
 {
     FREE_EVERYTHING_SCHEDULER ;
 }
-template Scheduler <int32_t>::~Scheduler() ;
-template Scheduler <int64_t>::~Scheduler() ;
-
 
 // -----------------------------------------------------------------------------
 // Scheduler::initialize
@@ -274,11 +261,16 @@ bool Scheduler <Int>::initialize
     return cuda_ok;
 }
 
-template bool Scheduler <int32_t>::initialize
-(
-    size_t gpuMemorySize
-) ;
-template bool Scheduler <int64_t>::initialize
-(
-    size_t gpuMemorySize
-) ;
+// Instantiate Scheduler class template with types int32_t and int64_t
+// for export from library.
+
+#include "Scheduler_FillWorkQueue.cpp"
+#include "Scheduler_Front.cpp"
+#include "Scheduler_LaunchKernel.cpp"
+#include "Scheduler_PostProcess.cpp"
+#include "Scheduler_Render.cpp"
+#include "Scheduler_TransferData.cpp"
+
+template class Scheduler<int32_t>;
+template class Scheduler<int64_t>;
+

--- a/SPQR/GPUQREngine/Source/Scheduler/Scheduler_FillWorkQueue.cpp
+++ b/SPQR/GPUQREngine/Source/Scheduler/Scheduler_FillWorkQueue.cpp
@@ -171,14 +171,6 @@ void Scheduler <Int>::fillWorkQueue
 #endif
 }
 
-template void Scheduler <int32_t>::fillWorkQueue
-(
-    void
-) ;
-template void Scheduler <int64_t>::fillWorkQueue
-(
-    void
-) ;
 // -----------------------------------------------------------------------------
 // Scheduler::fillTasks
 // -----------------------------------------------------------------------------
@@ -397,18 +389,7 @@ void Scheduler <Int>::fillTasks
     /* Copy-out the indexes. */
     *queueIndex = qindex;
 }
-template void Scheduler <int32_t>::fillTasks
-(
-    int32_t f,                      // INPUT: Current front
-    TaskDescriptor *queue,      // INPUT: CPU Task entries
-    int32_t *queueIndex             // IN/OUT: The index of the current entry
-) ;
-template void Scheduler <int64_t>::fillTasks
-(
-    int64_t f,                      // INPUT: Current front
-    TaskDescriptor *queue,      // INPUT: CPU Task entries
-    int64_t *queueIndex             // IN/OUT: The index of the current entry
-) ;
+
 // -----------------------------------------------------------------------------
 // buildSAssemblyTask
 // -----------------------------------------------------------------------------

--- a/SPQR/GPUQREngine/Source/Scheduler/Scheduler_Front.cpp
+++ b/SPQR/GPUQREngine/Source/Scheduler/Scheduler_Front.cpp
@@ -74,14 +74,7 @@ void Scheduler <Int>::activateFront
         }
     }
 }
-template void Scheduler <int32_t>::activateFront
-(
-    int32_t f                                      // The front id to manipulate
-) ;
-template void Scheduler <int64_t>::activateFront
-(
-    int64_t f                                      // The front id to manipulate
-) ;
+
 // -----------------------------------------------------------------------------
 // Scheduler::pullFrontData
 // -----------------------------------------------------------------------------
@@ -136,14 +129,6 @@ bool Scheduler <Int>::pullFrontData
     return (FrontDataPulled[f] = true);
 }
 
-template bool Scheduler <int32_t>::pullFrontData
-(
-    int32_t f                                      // The front id to manipulate
-) ;
-template bool Scheduler <int64_t>::pullFrontData
-(
-    int64_t f                                      // The front id to manipulate
-) ;
 // -----------------------------------------------------------------------------
 // Scheduler::finishFront
 // -----------------------------------------------------------------------------
@@ -184,14 +169,6 @@ bool Scheduler <Int>::finishFront
     /* If we got through this method, we have successfully freed the front. */
     return true;
 }
-template bool Scheduler <int32_t>::finishFront
-(
-    int32_t f                                     // The front id to manipulate
-) ;
-template bool Scheduler <int64_t>::finishFront
-(
-    int64_t f                                     // The front id to manipulate
-) ;
 
 #include "GPUQREngine.hpp"
 // -----------------------------------------------------------------------------
@@ -244,7 +221,5 @@ void Scheduler <Int>::debugDumpFront(Front <Int> *front)
     wsFront->assign(wsFront->cpu(), NULL);
     wsFront = Workspace::destroy(wsFront);
 }
-template void Scheduler <int32_t>::debugDumpFront(Front <int32_t> *front) ;
-template void Scheduler <int64_t>::debugDumpFront(Front <int64_t> *front) ;
 
 #endif

--- a/SPQR/GPUQREngine/Source/Scheduler/Scheduler_Front.cpp
+++ b/SPQR/GPUQREngine/Source/Scheduler/Scheduler_Front.cpp
@@ -29,7 +29,12 @@
 //    to not accidentally free a front whose R factor is still in transit.
 //
 // =============================================================================
+
+#include <iostream>
+#include <iomanip>
+
 #include "GPUQREngine_Scheduler.hpp"
+
 // -----------------------------------------------------------------------------
 // Scheduler::activateFront
 // -----------------------------------------------------------------------------
@@ -205,32 +210,37 @@ void Scheduler <Int>::debugDumpFront(Front <Int> *front)
     Int fn = front->fn;
     wsFront->assign(wsFront->cpu(), front->gpuF);
     wsFront->transfer(cudaMemcpyDeviceToHost);
-    printf("--- %g ---\n", (double) (front->fidg));
+    std::cout << "--- " << static_cast<double> (front->fidg) << " ---" << std::endl;
 
 //  for(Int i=0; i<fm; i++)
 //  {
+//      std::cout << std::setw(16) << std::setprecision(8);
 //      for(Int j=0; j<fn; j++)
 //      {
-//          printf("%16.8e ", F[i*fn+j]);
+//          std::cout << F[i*fn+j] << " ";
 //      }
 //      printf("\n");
 //  }
 
     for (int64_t j = 0 ; j < fn ; j++)
     {
-        printf ("   --- column %ld of %ld\n", (int64_t) j, (int64_t) fn) ;
+        std::cout << "   --- column " << std::setw(0) << j << " of " << fn << std::endl;
         for (int64_t i = 0 ; i < fm ; i++)
         {
-            if (i == j) printf ("      [ diag:     ") ;
-            else        printf ("      row %4ld    ", i) ;
-            printf (" %10.4g", F [fn*i+j]) ;
-            if (i == j) printf (" ]\n") ;
-            else        printf ("\n") ;
+            if (i == j)
+                std::cout << "      [ diag:      ";
+            else
+                std::cout << "      row " << std::setw(4) << i << "     ";
+            std::cout << std::setw(10) << std::setprecision(4) << F [fn*i+j];
+            if (i == j)
+                std::cout << " ]" << std::endl;
+            else
+                std::cout << std::endl;
         }
-        printf ("\n") ;
+        std::cout << std::endl;
     }
 
-    printf("----------\n");
+    std::cout << "----------" << std::endl;
     wsFront->assign(wsFront->cpu(), NULL);
     wsFront = Workspace::destroy(wsFront);
 }

--- a/SPQR/GPUQREngine/Source/Scheduler/Scheduler_LaunchKernel.cpp
+++ b/SPQR/GPUQREngine/Source/Scheduler/Scheduler_LaunchKernel.cpp
@@ -67,12 +67,3 @@ void Scheduler <Int>::launchKernel
     /* Clear the number of tasks. */
     numTasks[activeSet] = 0;
 }
-
-template void Scheduler <int32_t>::launchKernel
-(
-    void
-) ;
-template void Scheduler <int64_t>::launchKernel
-(
-    void
-) ;

--- a/SPQR/GPUQREngine/Source/Scheduler/Scheduler_PostProcess.cpp
+++ b/SPQR/GPUQREngine/Source/Scheduler/Scheduler_PostProcess.cpp
@@ -243,12 +243,3 @@ bool Scheduler <Int>::postProcess
     /* Return whether all the fronts are DONE. */
     return (numFronts == numFrontsCompleted);
 }
-
-template bool Scheduler <int32_t>::postProcess
-(
-    void
-) ;
-template bool Scheduler <int64_t>::postProcess
-(
-    void
-) ;

--- a/SPQR/GPUQREngine/Source/Scheduler/Scheduler_Render.cpp
+++ b/SPQR/GPUQREngine/Source/Scheduler/Scheduler_Render.cpp
@@ -99,12 +99,4 @@ void Scheduler <Int>::render
 
     fclose(output);
 }
-template void Scheduler <int32_t>::render
-(
-    void
-) ;
-template void Scheduler <int64_t>::render
-(
-    void
-) ;
 #endif

--- a/SPQR/GPUQREngine/Source/Scheduler/Scheduler_TransferData.cpp
+++ b/SPQR/GPUQREngine/Source/Scheduler/Scheduler_TransferData.cpp
@@ -64,12 +64,3 @@ void Scheduler <Int>::transferData
     wsQueueSurgical.transfer(cudaMemcpyHostToDevice, false, memoryStreamH2D);
     wsQueueSurgical.assign(NULL, NULL);
 }
-
-template void Scheduler <int32_t>::transferData
-(
-    void
-) ;
-template void Scheduler <int64_t>::transferData
-(
-    void
-) ;

--- a/SPQR/GPURuntime/Include/SuiteSparseGPU_Workspace.hpp
+++ b/SPQR/GPURuntime/Include/SuiteSparseGPU_Workspace.hpp
@@ -11,6 +11,8 @@
 #ifndef SUITESPARSE_GPURUNTIME_WORKSPACE_HPP
 #define SUITESPARSE_GPURUNTIME_WORKSPACE_HPP
 
+#include <new>
+
 #include "SuiteSparseGPU_internal.hpp"
 
 class Workspace
@@ -35,7 +37,6 @@ public:
     void *gpu(void){ return gpuReference; }
 
     // Constructor/Destructor
-    void *operator new(size_t bytes, Workspace* ptr){ return ptr; }
     Workspace(size_t nitems, size_t size_of_item);
     ~Workspace();
 


### PR DESCRIPTION
This mostly avoids warnings with some compilers. If I understand those warnings correctly, they point to valid "issues":

* Incorrect size of format specifiers when printing to stdout. Avoid that by using a C++ style output stream.
* Missing placement delete operator for overloaded placement new operator. Avoid that issue by using the placement new/delete operators from the STL instead.
* Incomplete template class definition for explicit instantiation of the template class. Avoid that issue by defining the entire template class in a single compilation unit.

