### PR TITLE
GraphBLAS: Silence compiler warnings about values outside `GrB_Field`

### DIFF
--- a/GraphBLAS/Source/GxB_Context_get2.c
+++ b/GraphBLAS/Source/GxB_Context_get2.c
@@ -150,7 +150,7 @@ GrB_Info GxB_Context_get_INT
     // get the field
     //--------------------------------------------------------------------------
 
-    switch (field)
+    switch ((int) field)
     {
 
         case GxB_CONTEXT_NTHREADS :         // same as GxB_NTHREADS

--- a/GraphBLAS/Source/GxB_Context_set2.c
+++ b/GraphBLAS/Source/GxB_Context_set2.c
@@ -60,7 +60,7 @@ GrB_Info GxB_Context_set_Scalar
         return ((info == GrB_NO_VALUE) ? GrB_EMPTY_OBJECT : info) ;
     }
 
-    switch (field)
+    switch ((int) field)
     {
 
         default:
@@ -142,7 +142,7 @@ GrB_Info GxB_Context_set_INT
     // set the field
     //--------------------------------------------------------------------------
 
-    switch (field)
+    switch ((int) field)
     {
 
         case GxB_CONTEXT_NTHREADS :         // same as GxB_NTHREADS

--- a/GraphBLAS/Source/GxB_Serialized_get.c
+++ b/GraphBLAS/Source/GxB_Serialized_get.c
@@ -244,7 +244,7 @@ GrB_Info GxB_Serialized_get_Scalar
 
     if (info == GrB_SUCCESS)
     {
-        switch (field)
+        switch ((int) field)
         {
             case GrB_STORAGE_ORIENTATION_HINT : 
 
@@ -414,7 +414,7 @@ GrB_Info GxB_Serialized_get_INT32
 
     if (info == GrB_SUCCESS)
     {
-        switch (field)
+        switch ((int) field)
         {
             case GrB_STORAGE_ORIENTATION_HINT : 
 


### PR DESCRIPTION
Cast the switch argument to `int` to avoid compiler warnings (with clang) because some of the case values are not in `GrB_Field` but are part of different enumerations.
