### PR TITLE
Increase timeout for checks on emulated runners to 60 minutes.

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -144,7 +144,7 @@ jobs:
           done
 
       - name: check
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           IFS=':'
           CHECK_LIBS="${CHECK_LIBS}${{ matrix.extra-check-libs }}"


### PR DESCRIPTION
With more tests running now, the average duration of the "check" step is dangerously close to the timeout of 30 minutes for the runners on emulated hardware. The main contributor is "Mongoose_Memory_Test" (about 10 minutes for that test alone).

Increase the timeout to 60 minutes to have enough margin. That's still below the default limit of 6 hours and should help if runners are really "stuck" indefinitely at some test.
