### PR TITLE
SPEX: Store pointers to current gmp objects in archive.

### DIFF
--- a/SPEX/SPEX_Util/Source/SPEX_gmp.c
+++ b/SPEX/SPEX_Util/Source/SPEX_gmp.c
@@ -81,9 +81,9 @@ void **spex_gmp_list = NULL ;   // list of malloc'd objects
 int64_t spex_gmp_ntrials = -1 ; // number of malloc's allowed (for
                                 // testing only): -1 means unlimited.
 
-mpz_t  *spex_gmpz_archive  = NULL ;    // current mpz object
-mpq_t  *spex_gmpq_archive  = NULL ;    // current mpq object
-mpfr_t *spex_gmpfr_archive = NULL ;    // current mpfr object
+mpz_ptr  spex_gmpz_archive  = NULL ;    // current mpz object
+mpq_ptr  spex_gmpq_archive  = NULL ;    // current mpq object
+mpfr_ptr spex_gmpfr_archive = NULL ;    // current mpfr object
 
 //------------------------------------------------------------------------------
 // spex_gmp_init: initialize gmp

--- a/SPEX/SPEX_Util/Source/SPEX_gmp.h
+++ b/SPEX/SPEX_Util/Source/SPEX_gmp.h
@@ -32,7 +32,7 @@
 
 #define SPEX_GMPZ_WRAPPER_START(x)                                      \
 {                                                                       \
-    spex_gmpz_archive = (mpz_t *) x;                                    \
+    spex_gmpz_archive = x;                                              \
     spex_gmpq_archive = NULL;                                           \
     spex_gmpfr_archive = NULL;                                          \
     SPEX_GMP_WRAPPER_START;                                             \
@@ -41,7 +41,7 @@
 #define SPEX_GMPQ_WRAPPER_START(x)                                      \
 {                                                                       \
     spex_gmpz_archive = NULL;                                           \
-    spex_gmpq_archive =(mpq_t *) x;                                     \
+    spex_gmpq_archive = x;                                              \
     spex_gmpfr_archive = NULL;                                          \
     SPEX_GMP_WRAPPER_START;                                             \
 }
@@ -50,7 +50,7 @@
 {                                                                       \
     spex_gmpz_archive = NULL;                                           \
     spex_gmpq_archive = NULL;                                           \
-    spex_gmpfr_archive = (mpfr_t *) x;                                  \
+    spex_gmpfr_archive = x;                                             \
     SPEX_GMP_WRAPPER_START;                                             \
 }
 
@@ -69,27 +69,27 @@
 {                                                                       \
     if (spex_gmpz_archive != NULL)                                      \
     {                                                                   \
-        if (p == SPEX_MPZ_PTR(*spex_gmpz_archive))                      \
+        if (p == SPEX_MPZ_PTR(spex_gmpz_archive))                       \
         {                                                               \
-            SPEX_MPZ_PTR(*spex_gmpz_archive) = NULL ;                   \
+            SPEX_MPZ_PTR(spex_gmpz_archive) = NULL ;                    \
         }                                                               \
     }                                                                   \
     else if (spex_gmpq_archive != NULL)                                 \
     {                                                                   \
-        if (p == SPEX_MPZ_PTR(SPEX_MPQ_NUM(*spex_gmpq_archive)))        \
+        if (p == SPEX_MPZ_PTR(SPEX_MPQ_NUM(spex_gmpq_archive)))         \
         {                                                               \
-            SPEX_MPZ_PTR(SPEX_MPQ_NUM(*spex_gmpq_archive)) = NULL ;     \
+            SPEX_MPZ_PTR(SPEX_MPQ_NUM(spex_gmpq_archive)) = NULL ;      \
         }                                                               \
-        if (p == SPEX_MPZ_PTR(SPEX_MPQ_DEN(*spex_gmpq_archive)))        \
+        if (p == SPEX_MPZ_PTR(SPEX_MPQ_DEN(spex_gmpq_archive)))         \
         {                                                               \
-            SPEX_MPZ_PTR(SPEX_MPQ_DEN(*spex_gmpq_archive)) = NULL ;     \
+            SPEX_MPZ_PTR(SPEX_MPQ_DEN(spex_gmpq_archive)) = NULL ;      \
         }                                                               \
     }                                                                   \
     else if (spex_gmpfr_archive != NULL)                                \
     {                                                                   \
-        if (p == SPEX_MPFR_REAL_PTR(*spex_gmpfr_archive))               \
+        if (p == SPEX_MPFR_REAL_PTR(spex_gmpfr_archive))                \
         {                                                               \
-            SPEX_MPFR_MANT(*spex_gmpfr_archive) = NULL ;                \
+            SPEX_MPFR_MANT(spex_gmpfr_archive) = NULL ;                 \
         }                                                               \
     }                                                                   \
     SPEX_FREE (p) ;                                                     \


### PR DESCRIPTION
I've been staring at that part of the code for a while. And I think this is a correct change.
IIUC, `x` in those preprocessor macros is of type `mpz_t` (or other types). Casting it to `mpz_t *` (or the other pointer types) is a bit confusing.
Instead, store the *addresses* to those values in the `*_archive` variables.

Because `mpz_t`, `mpq_t` and `mpfr_t` "happen" to be array types, this probably doesn't affect the actual code execution.

