### PR TITLE
CI: Build only shared libraries on Alpine runners

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -132,6 +132,8 @@ jobs:
                   -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
                   -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
                   -DCMAKE_Fortran_COMPILER_LAUNCHER="ccache" \
+                  -DBUILD_SHARED_LIBS=ON \
+                  -DBUILD_STATIC_LIBS=OFF \
                   -DBLA_VENDOR="Generic" \
                   -DGRAPHBLAS_COMPACT=ON \
                   -DSUITESPARSE_DEMOS=OFF \
@@ -195,10 +197,6 @@ jobs:
           ./my_demo
           printf "\033[1;35m  C++ binary with shared libraries\033[0m\n"
           ./my_cxx_demo
-          printf "\033[1;35m  C binary with statically linked libraries\033[0m\n"
-          ./my_demo_static
-          printf "\033[1;35m  C++ binary with statically linked libraries\033[0m\n"
-          ./my_cxx_demo_static
           echo "::endgroup::"
 
       - name: test Config

--- a/TestConfig/SPQR/CMakeLists.txt
+++ b/TestConfig/SPQR/CMakeLists.txt
@@ -74,6 +74,11 @@ if ( BUILD_STATIC_LIBS )
     else ( )
         target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC ${TEST_IMPORT_TARGET} )
     endif ( )
+    if ( TARGET SuiteSparse::CHOLMOD_static )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC SuiteSparse::CHOLMOD_static )
+    else ( )
+        target_link_libraries ( ${TEST_STATIC_BIN} PUBLIC SuiteSparse::CHOLMOD )
+    endif ( )
 endif ( )
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
The runners on emulated hardware take significantly longer than the ones on native hardware - especially when building from a cold ccache.
The main point of those runners is to check if there are platform-specific errors. It is probably not actually necessary to build most of the objects twice (for the static and the shared version of each library) to check that.

To cut down on the build time, build only shared libraries on the (emulated) Alpine runners.

Additionally, this can serve as a check if there are issues with that configuration (i.e., building shared libraries only).
