### PR TITLE
SuiteSparse_config: Check if linking to librt is necessary

### DIFF
--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -103,6 +103,28 @@ if ( SUITESPARSE_USE_STRICT AND SUITESPARSE_CONFIG_USE_OPENMP AND NOT SUITESPARS
     message ( FATAL_ERROR "OpenMP required for SuiteSparse_config but not found" )
 endif ( )
 
+# check for librt in case of fallback to "clock_gettime"
+include ( CheckSymbolExists )
+check_symbol_exists ( clock_gettime "time.h" NO_RT )
+if ( NO_RT )
+    message ( STATUS "Using clock_gettime without librt" )
+    set ( SUITESPARSE_HAVE_CLOCK_GETTIME ON )
+else ( )
+    # check if we need to link to librt for that function
+    set ( _orig_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} )
+    list ( APPEND CMAKE_REQUIRED_LIBRARIES "rt" )
+    check_symbol_exists ( clock_gettime "time.h" WITH_RT )
+    set ( CMAKE_REQUIRED_LIBRARIES ${_orig_CMAKE_REQUIRED_LIBRARIES} )
+    if ( WITH_RT )
+        message ( STATUS "Using clock_gettime with librt" )
+        set ( SUITESPARSE_HAVE_CLOCK_GETTIME ON )
+    endif ( )
+endif ( )
+
+if ( NOT SUITESPARSE_CONFIG_USE_OPENMP AND NOT SUITESPARSE_HAVE_CLOCK_GETTIME )
+    message ( STATUS "No OpenMP and no clock_gettime available. Timing functions won't work." )
+endif ( )
+
 #-------------------------------------------------------------------------------
 # find the BLAS
 #-------------------------------------------------------------------------------
@@ -207,6 +229,17 @@ if ( SUITESPARSE_CONFIG_USE_OPENMP )
         target_include_directories ( SuiteSparseConfig_static SYSTEM AFTER INTERFACE
             "$<TARGET_PROPERTY:OpenMP::OpenMP_C,INTERFACE_INCLUDE_DIRECTORIES>" )
         list ( APPEND SUITESPARSE_CONFIG_STATIC_LIBS ${OpenMP_C_LIBRARIES} )
+    endif ( )
+else ( )
+    # librt
+    if ( WITH_RT )
+        if ( BUILD_SHARED_LIBS )
+            target_link_libraries ( SuiteSparseConfig PRIVATE "rt" )
+        endif ( )
+        if ( BUILD_STATIC_LIBS )
+            target_link_libraries ( SuiteSparseConfig_static PRIVATE "rt" )
+            list ( APPEND SUITESPARSE_CONFIG_STATIC_LIBS "rt" )
+        endif ( )
     endif ( )
 endif ( )
 

--- a/SuiteSparse_config/Config/SuiteSparse_config.h.in
+++ b/SuiteSparse_config/Config/SuiteSparse_config.h.in
@@ -372,14 +372,13 @@ int SuiteSparse_divcomplex
     // but other packages can themselves use OpenMP.  In this case,
     // those packages should use omp_get_wtime() directly.  This can
     // be done via the SUITESPARSE_TIME macro, defined below:
+    #cmakedefine SUITESPARSE_HAVE_CLOCK_GETTIME
     #if defined ( _OPENMP )
         #define SUITESPARSE_TIMER_ENABLED
         #define SUITESPARSE_TIME (omp_get_wtime ( ))
-    #elif defined ( _POSIX_C_SOURCE )
-        #if _POSIX_C_SOURCE >= 199309L
+    #elif defined ( SUITESPARSE_HAVE_CLOCK_GETTIME )
         #define SUITESPARSE_TIMER_ENABLED
         #define SUITESPARSE_TIME (SuiteSparse_time ( ))
-        #endif
     #else
         // No timer is available
         #define SUITESPARSE_TIME (0)

--- a/SuiteSparse_config/SuiteSparse_config.c
+++ b/SuiteSparse_config/SuiteSparse_config.c
@@ -495,7 +495,7 @@ void *SuiteSparse_free      /* always returns NULL */
         tic [1] = 0 ;
     }
 
-#else 
+#else
 
     /* ---------------------------------------------------------------------- */
     /* POSIX timer */
@@ -616,7 +616,7 @@ double SuiteSparse_hypot (double x, double y)
             r = x / y ;
             s = y * sqrt (1.0 + r*r) ;
         }
-    } 
+    }
     return (s) ;
 }
 

--- a/SuiteSparse_config/SuiteSparse_config.h
+++ b/SuiteSparse_config/SuiteSparse_config.h
@@ -372,14 +372,13 @@ int SuiteSparse_divcomplex
     // but other packages can themselves use OpenMP.  In this case,
     // those packages should use omp_get_wtime() directly.  This can
     // be done via the SUITESPARSE_TIME macro, defined below:
+    #define SUITESPARSE_HAVE_CLOCK_GETTIME
     #if defined ( _OPENMP )
         #define SUITESPARSE_TIMER_ENABLED
         #define SUITESPARSE_TIME (omp_get_wtime ( ))
-    #elif defined ( _POSIX_C_SOURCE )
-        #if _POSIX_C_SOURCE >= 199309L
+    #elif defined ( SUITESPARSE_HAVE_CLOCK_GETTIME )
         #define SUITESPARSE_TIMER_ENABLED
         #define SUITESPARSE_TIME (SuiteSparse_time ( ))
-        #endif
     #else
         // No timer is available
         #define SUITESPARSE_TIME (0)


### PR DESCRIPTION
On some platform, it is necessary to link to librt when using `clock_gettime`.  Add configure checks to detect if the function is available and whether it needs linking with librt.

That facilitates linking statically to libsuitesparseconfig using the CMake import targets or the pkg-config files.  It could also help to avoid issues when linking to the shared library with `--as-needed`.

The second commit uses the result of the new configure checks to decide whether `clock_gettime` can be used in the code. That change allows using that function also for non-POSIX targets where it is available (e.g., MinGW).
