### PR TITLE
CHOLMOD: Fix typo in build rules.

### DIFF
--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -554,10 +554,10 @@ if ( CHOLMOD_HAS_CUDA )
         endif ( )
     endif ( )
 
-    set ( old_CMAKE_EXTRA_INCLUDE_FILES CMAKE_EXTRA_INCLUDE_FILES )
+    set ( _orig_CMAKE_EXTRA_INCLUDE_FILES ${CMAKE_EXTRA_INCLUDE_FILES} )
     list ( APPEND CMAKE_EXTRA_INCLUDE_FILES "stdlib.h" )
     check_type_size ( "__compar_fn_t" COMPAR_FN_T )
-    set ( CMAKE_EXTRA_INCLUDE_FILES old_CMAKE_EXTRA_INCLUDE_FILES )
+    set ( CMAKE_EXTRA_INCLUDE_FILES ${_orig_CMAKE_EXTRA_INCLUDE_FILES} )
 
     if ( NOT HAVE_COMPAR_FN_T )
         if ( BUILD_SHARED_LIBS )


### PR DESCRIPTION
`CMAKE_EXTRA_INCLUDE_FILES` is currently not reset to its previous value as it was intended.
Even if this typo doesn't have actual consequences currently afaict, it should still be fixed.
