### PR TITLE
CI: "Fake" a cross-compilation for one of the Ubuntu runners.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,9 +79,11 @@ jobs:
               -DCMAKE_CUDA_COMPILER_LAUNCHER="ccache"
             openmp: with
             link: static
+            # "Fake" a cross-compilation to exercise that build system path
             link-cmake-flags:
               -DBUILD_SHARED_LIBS=OFF
               -DBUILD_STATIC_LIBS=ON
+              -DCMAKE_SYSTEM_NAME="Linux"
 
     env:
       CC: ${{ matrix.cc }}


### PR DESCRIPTION
When cross-compiling, some files (notably the JIT package generator of GraphBLAS) are built in a different order and with different commands than normally.

Setting CMAKE_SYSTEM_NAME to the host system name doesn't actually lead to a cross-compilation. But it should trigger the build path that would also be used for an actual cross-compilation.
