### PR TITLE
GraphBLAS: Correctly identify `clang-cl` as MSVC-compatible compiler

### DIFF
--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -163,6 +163,12 @@ if ( DEFINED GBAVX512F )
 endif ( )
 
 #-------------------------------------------------------------------------------
+# check compiler features
+#-------------------------------------------------------------------------------
+
+include ( GraphBLAS_complex )
+
+#-------------------------------------------------------------------------------
 # determine build type
 #-------------------------------------------------------------------------------
 
@@ -185,6 +191,9 @@ endif ( )
 
 configure_file ( "Config/GraphBLAS.h.in"
     "${PROJECT_SOURCE_DIR}/Include/GraphBLAS.h"
+    NEWLINE_STYLE LF )
+configure_file ( "Config/GxB_config.h.in"
+    "${PROJECT_SOURCE_DIR}/Source/Shared/GxB_config.h"
     NEWLINE_STYLE LF )
 
 configure_file ( "Config/GraphBLAS_version.tex.in"

--- a/GraphBLAS/Config/GraphBLAS.h.in
+++ b/GraphBLAS/Config/GraphBLAS.h.in
@@ -146,7 +146,13 @@
 #ifndef GXB_COMPLEX_H
 #define GXB_COMPLEX_H
 
-    #if defined (_MSC_VER) && !(defined (__INTEL_COMPILER) || defined(__INTEL_CLANG_COMPILER))
+// Compiler has support for C99 floating point number arithmetic
+#cmakedefine GXB_HAVE_COMPLEX_C99
+
+// Compiler has support for MSVC-style complex numbers
+#cmakedefine GXB_HAVE_COMPLEX_MSVC
+
+    #if defined (GXB_HAVE_COMPLEX_MSVC)
 
         // Microsoft Windows complex types for C
         #include <complex.h>
@@ -156,7 +162,7 @@
         #define GxB_CMPLX(r,i)  ( _Cbuild (r,i))
         #define GB_HAS_CMPLX_MACROS 1
 
-    #else
+    #elif defined (GXB_HAVE_COMPLEX_C99)
 
         // C11 complex types
         #include <complex.h>
@@ -175,6 +181,11 @@
             #define GxB_CMPLXF(r,i) \
             ((GxB_FC32_t)((float)(r)) + (GxB_FC32_t)((float)(i) * _Complex_I))
         #endif
+
+    #else
+
+        #error "Unknown or unsupported complex number arithmetic"
+
     #endif
 #endif
 

--- a/GraphBLAS/Config/GxB_config.h.in
+++ b/GraphBLAS/Config/GxB_config.h.in
@@ -1,0 +1,20 @@
+//------------------------------------------------------------------------------
+// GxB_config.h: configuration header
+//------------------------------------------------------------------------------
+
+// SuiteSparse:GraphBLAS, Timothy A. Davis, (c) 2024, All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//------------------------------------------------------------------------------
+
+
+#ifndef GXB_COMPLEX_H
+#define GXB_COMPLEX_H
+
+// Compiler has support for C99 floating point number arithmetic
+#cmakedefine GXB_HAVE_COMPLEX_C99
+
+// Compiler has support for MSVC-style complex numbers
+#cmakedefine GXB_HAVE_COMPLEX_MSVC
+
+#endif

--- a/GraphBLAS/Include/GraphBLAS.h
+++ b/GraphBLAS/Include/GraphBLAS.h
@@ -146,7 +146,13 @@
 #ifndef GXB_COMPLEX_H
 #define GXB_COMPLEX_H
 
-    #if defined (_MSC_VER) && !(defined (__INTEL_COMPILER) || defined(__INTEL_CLANG_COMPILER))
+// Compiler has support for C99 floating point number arithmetic
+#define GXB_HAVE_COMPLEX_C99
+
+// Compiler has support for MSVC-style complex numbers
+/* #undef GXB_HAVE_COMPLEX_MSVC */
+
+    #if defined (GXB_HAVE_COMPLEX_MSVC)
 
         // Microsoft Windows complex types for C
         #include <complex.h>
@@ -156,7 +162,7 @@
         #define GxB_CMPLX(r,i)  ( _Cbuild (r,i))
         #define GB_HAS_CMPLX_MACROS 1
 
-    #else
+    #elif defined (GXB_HAVE_COMPLEX_C99)
 
         // C11 complex types
         #include <complex.h>
@@ -175,6 +181,11 @@
             #define GxB_CMPLXF(r,i) \
             ((GxB_FC32_t)((float)(r)) + (GxB_FC32_t)((float)(i) * _Complex_I))
         #endif
+
+    #else
+
+        #error "Unknown or unsupported complex number arithmetic"
+
     #endif
 #endif
 

--- a/GraphBLAS/Source/Factories/GB_ops_template.h
+++ b/GraphBLAS/Source/Factories/GB_ops_template.h
@@ -858,7 +858,7 @@ inline void GB_FUNC (POW) (GB_Z_X_Y_ARGS)
     }
     inline void GB_FUNC (CMPLX) (GxB_FC32_t *z, const float *x, const float *y)
     {
-        #if defined ( __cplusplus ) || GB_COMPILER_MSC || defined (CMPLX)
+        #if defined ( __cplusplus ) || defined (GXB_HAVE_COMPLEX_MSVC) || defined (CMPLX)
         (*z) = GxB_CMPLXF ((*x),(*y)) ;
         #else
         ((float *) z) [0] = (*x) ;

--- a/GraphBLAS/Source/GB_ops.c
+++ b/GraphBLAS/Source/GB_ops.c
@@ -568,7 +568,7 @@ const GxB_Format_Value GxB_FORMAT_DEFAULT = GxB_BY_ROW ;
 // predefined built-in monoids
 //------------------------------------------------------------------------------
 
-#if GB_COMPILER_MSC
+#if defined (GXB_HAVE_COMPLEX_MSVC)
 #define GB_FC32_ONE  {1.0f, 0.0f}
 #define GB_FC64_ONE  {1.0 , 0.0 }
 #define GB_FC32_ZERO {0.0f, 0.0f}

--- a/GraphBLAS/Source/Shared/GB_complex.h
+++ b/GraphBLAS/Source/Shared/GB_complex.h
@@ -205,7 +205,7 @@
 // macros for basic complex operations: mult, add, minus, ainv
 //------------------------------------------------------------------------------
 
-#if GB_COMPILER_MSC
+#if defined (GXB_HAVE_COMPLEX_MSVC)
 
     //--------------------------------------------------------------------------
     // Microsoft Visual Studio compiler with its own complex type

--- a/GraphBLAS/Source/Shared/GxB_complex.h
+++ b/GraphBLAS/Source/Shared/GxB_complex.h
@@ -17,7 +17,9 @@
 #ifndef GXB_COMPLEX_H
 #define GXB_COMPLEX_H
 
-    #if defined (_MSC_VER) && !(defined (__INTEL_COMPILER) || defined(__INTEL_CLANG_COMPILER))
+#include "GxB_config.h"
+
+    #if defined (GXB_HAVE_COMPLEX_MSVC)
 
         // Microsoft Windows complex types for C
         #include <complex.h>
@@ -27,7 +29,7 @@
         #define GxB_CMPLX(r,i)  ( _Cbuild (r,i))
         #define GB_HAS_CMPLX_MACROS 1
 
-    #else
+    #elif defined (GXB_HAVE_COMPLEX_C99)
 
         // C11 complex types
         #include <complex.h>
@@ -46,6 +48,11 @@
             #define GxB_CMPLXF(r,i) \
             ((GxB_FC32_t)((float)(r)) + (GxB_FC32_t)((float)(i) * _Complex_I))
         #endif
+
+    #else
+
+        #error "Unknown or unsupported complex number arithmetic"
+
     #endif
 #endif
 

--- a/GraphBLAS/Source/Shared/GxB_config.h
+++ b/GraphBLAS/Source/Shared/GxB_config.h
@@ -1,0 +1,20 @@
+//------------------------------------------------------------------------------
+// GxB_config.h: configuration header
+//------------------------------------------------------------------------------
+
+// SuiteSparse:GraphBLAS, Timothy A. Davis, (c) 2024, All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//------------------------------------------------------------------------------
+
+
+#ifndef GXB_COMPLEX_H
+#define GXB_COMPLEX_H
+
+// Compiler has support for C99 floating point number arithmetic
+#define GXB_HAVE_COMPLEX_C99
+
+// Compiler has support for MSVC-style complex numbers
+/* #undef GXB_HAVE_COMPLEX_MSVC */
+
+#endif

--- a/GraphBLAS/Source/Template/GB_compiler.h
+++ b/GraphBLAS/Source/Template/GB_compiler.h
@@ -55,6 +55,17 @@
     #define GB_COMPILER_SUB   0
     #define GB_COMPILER_NAME  __VERSION__
 
+#elif defined ( _MSC_VER )
+
+    // Microsoft Visual Studio (cl compiler)
+    #undef  GB_COMPILER_MSC
+    #define GB_COMPILER_MSC     1
+
+    #define GB_COMPILER_MAJOR ( _MSC_VER / 100 )
+    #define GB_COMPILER_MINOR ( _MSC_VER - 100 * GB_COMPILER_MAJOR)
+    #define GB_COMPILER_SUB   0
+    #define GB_COMPILER_NAME  "Microsoft Visual Studio " GB_XSTR (_MSC_VER)
+
 #elif defined ( __clang__ )
 
     // clang
@@ -88,17 +99,6 @@
     #define GB_COMPILER_SUB   __GNUC_PATCHLEVEL__
     #define GB_COMPILER_NAME  "GNU gcc " GB_XSTR (__GNUC__) "." \
         GB_XSTR (__GNUC_MINOR__) "." GB_XSTR (__GNUC_PATCHLEVEL__)
-
-#elif defined ( _MSC_VER )
-
-    // Microsoft Visual Studio (cl compiler)
-    #undef  GB_COMPILER_MSC
-    #define GB_COMPILER_MSC     1
-
-    #define GB_COMPILER_MAJOR ( _MSC_VER / 100 )
-    #define GB_COMPILER_MINOR ( _MSC_VER - 100 * GB_COMPILER_MAJOR)
-    #define GB_COMPILER_SUB   0
-    #define GB_COMPILER_NAME  "Microsoft Visual Studio " GB_XSTR (_MSC_VER)
 
 #else
 

--- a/GraphBLAS/cmake_modules/GraphBLAS_complex.cmake
+++ b/GraphBLAS/cmake_modules/GraphBLAS_complex.cmake
@@ -1,0 +1,42 @@
+#-------------------------------------------------------------------------------
+# GraphBLAS/cmake_modules/GraphBLAS_complex.cmake
+#-------------------------------------------------------------------------------
+
+# SuiteSparse:GraphBLAS, Timothy A. Davis, (c) 2024, All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+#-------------------------------------------------------------------------------
+
+# Check for C compiler support for complex floating point numbers and used API
+
+include ( CheckSourceCompiles )
+
+# Check for C99 complex number arithmetic
+
+check_source_compiles ( C
+    "#include <complex.h>
+    int main(void) {
+    double _Complex z1 = 1.0;
+    double _Complex z2 = 1.0 * I;
+    double _Complex z3 = z1 * z2;
+    return 0;
+    }"
+    GXB_HAVE_COMPLEX_C99 )
+
+if ( NOT GXB_HAVE_COMPLEX_C99 )
+    # Check for complex number arithmetic as implemented by MSVC
+
+    check_source_compiles ( C
+        "#include <complex.h>
+        int main(void) {
+        _Dcomplex z1 = {1., 0.};
+        _Dcomplex z2 = {0., 1.};
+        _Dcomplex z3 = _Cmulcc(z1, z2);
+        return 0;
+        }"
+        GXB_HAVE_COMPLEX_MSVC )
+endif ( )
+
+if ( NOT GXB_HAVE_COMPLEX_C99 AND NOT GXB_HAVE_COMPLEX_MSVC )
+    message ( FATAL_ERROR "Complex floating point numbers are not supported by the used compiler." )
+endif ( )


### PR DESCRIPTION
For `clang-cl`, both `_MSC_VER` and `__clang__` are set. Move check for `_MSC_VER` to before check for `__clang__` to allow identifying `clang-cl` as a MSVC compatible compiler.

This should be fixing #751.

