### PR TITLE
GraphBLAS: Avoid possibility of compatible types in `_Generic` selections

### DIFF
--- a/GraphBLAS/Config/GraphBLAS.h.in
+++ b/GraphBLAS/Config/GraphBLAS.h.in
@@ -3965,7 +3965,7 @@ GrB_Info GxB_Context_get       (GxB_Context, GxB_Context_Field, ...) ;
     _Generic                                                    \
     (                                                           \
         (arg1),                                                 \
-            int              : GxB_Global_Option_set ,          \
+            default          : GxB_Global_Option_set ,          \
             GxB_Option_Field : GxB_Global_Option_set ,          \
             GrB_Vector       : GxB_Vector_Option_set ,          \
             GrB_Matrix       : GxB_Matrix_Option_set ,          \
@@ -3978,7 +3978,7 @@ GrB_Info GxB_Context_get       (GxB_Context, GxB_Context_Field, ...) ;
     _Generic                                                    \
     (                                                           \
         (arg1),                                                 \
-            int              : GxB_Global_Option_get ,          \
+            default          : GxB_Global_Option_get ,          \
             GxB_Option_Field : GxB_Global_Option_get ,          \
             GrB_Vector       : GxB_Vector_Option_get ,          \
             GrB_Matrix       : GxB_Matrix_Option_get ,          \

--- a/GraphBLAS/Include/GraphBLAS.h
+++ b/GraphBLAS/Include/GraphBLAS.h
@@ -3965,7 +3965,7 @@ GrB_Info GxB_Context_get       (GxB_Context, GxB_Context_Field, ...) ;
     _Generic                                                    \
     (                                                           \
         (arg1),                                                 \
-            int              : GxB_Global_Option_set ,          \
+            default          : GxB_Global_Option_set ,          \
             GxB_Option_Field : GxB_Global_Option_set ,          \
             GrB_Vector       : GxB_Vector_Option_set ,          \
             GrB_Matrix       : GxB_Matrix_Option_set ,          \
@@ -3978,7 +3978,7 @@ GrB_Info GxB_Context_get       (GxB_Context, GxB_Context_Field, ...) ;
     _Generic                                                    \
     (                                                           \
         (arg1),                                                 \
-            int              : GxB_Global_Option_get ,          \
+            default          : GxB_Global_Option_get ,          \
             GxB_Option_Field : GxB_Global_Option_get ,          \
             GrB_Vector       : GxB_Vector_Option_get ,          \
             GrB_Matrix       : GxB_Matrix_Option_get ,          \

--- a/LAGraph/CMakeLists.txt
+++ b/LAGraph/CMakeLists.txt
@@ -247,13 +247,13 @@ elseif ( "${CMAKE_C_COMPILER_ID}" STREQUAL "Intel" )
     #if ( CMAKE_C_COMPILER_VERSION VERSION_LESS 18.0 )
     #    message ( FATAL_ERROR "icc version must be at least 18.0" )
     #endif ( )
-elseif ( "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" )
+elseif ( "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" AND NOT "${CMAKE_C_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC" )
     # options for clang
     set ( CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -O3 " )
     #if ( CMAKE_C_COMPILER_VERSION VERSION_LESS 3.3 )
     #    message ( FATAL_ERROR "clang version must be at least 3.3" )
     #endif ( )
-elseif ( "${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC" )
+elseif ( "${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC" OR "${CMAKE_C_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC" )
     # options for MicroSoft Visual Studio
 elseif ( "${CMAKE_C_COMPILER_ID}" STREQUAL "PGI" )
     # options for PGI pgcc compiler


### PR DESCRIPTION
If I understand the motivation for these generic selections correctly, they are meant to provide "specializations" if the input is part of some enumerations. The "generic" function is given by the line with the `int` type.
The `int` type in those lists can cause issues if `int` is the underlying type for enumerations (in some implementations).

Avoid that possible issue by using the keyword `default` for the "generic" function.

This should be fixing #753.

Additionally, avoid adding incompatible command line options for `clang-cl` in the build rules of LAGraph (a clang compiler with MSVC-compatible command line interface).
