### PR TITLE
CI: Add check if root CMakeLists.txt pulls in necessary dependencies.

### DIFF
--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -135,6 +135,22 @@ jobs:
           ccache -s
           echo "/usr/lib/ccache" >> $GITHUB_PATH
 
+      - name: check auto-dependency resolution
+        # no need to check this with all runners. One is enough.
+        if: ${{ matrix.cc == 'gcc' && matrix.cuda == 'without' }}
+        run: |
+          mkdir -p ${GITHUB_WORKSPACE}/build-dep && cd ${GITHUB_WORKSPACE}/build-dep
+          IFS=':' read -r -a libs <<< "${INSTALLED_LIBS}"
+          for lib in "${libs[@]}"; do
+            printf "::group::   \033[0;32m==>\033[0m Configuring to build only \033[0;32m${lib}\033[0m\n"
+            cmake --fresh \
+                  -DCMAKE_BUILD_TYPE="Release" \
+                  -DBLA_VENDOR="OpenBLAS" \
+                  -DSUITESPARSE_ENABLE_PROJECTS="${lib,,}" \
+                  ..
+            echo "::endgroup::"
+          done
+
       - name: configure
         run: |
           mkdir -p ${GITHUB_WORKSPACE}/build && cd ${GITHUB_WORKSPACE}/build


### PR DESCRIPTION
When adding a library in `SUITESPARSE_ENABLE_PROJECTS`, the build rules should automatically add all necessary libraries.
Add a step to one single runner to check if this is working as expected for all libraries.

This would probably have detected the issue fixed in #757 a bit earlier.
