### PR TITLE
CXSparse: Don't use complex numbers for MSVC targets

### DIFF
--- a/CXSparse/CMakeLists.txt
+++ b/CXSparse/CMakeLists.txt
@@ -45,7 +45,7 @@ include ( SuiteSparsePolicy )
 # MS Visual Studio does not support the complex type for ANSI C11.
 # FIXME: see GraphBLAS for how to use complex types in MS Visual Studio.
 
-if ( MSVC )
+if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
     option ( CXSPARSE_USE_COMPLEX "ON: complex data type enabled.  OFF (default): complex data type disabled." OFF )
 else ( )
     option ( CXSPARSE_USE_COMPLEX "ON (default): complex data type enabled.  OFF: complex data type disabled." ON )


### PR DESCRIPTION
For `clang`/`clang++` targeting MSVC, the CMake variable `MSVC` is not set (only for `clang-cl` targeting MSVC).
However, the MSVC target uses different types for complex numbers that CXSparse doesn't support (yet?).

Deactivate complex number arithmetic for CXSparse also for any compiler that targets MSVC.

Also, avoid overlinking the CXSparse library with libsuitesparseconfig. (It only uses the header but no functions from it.)