### PR TITLE
ParU: Explicitly include <cinttypes> in header that uses `PRId64`

### DIFF
--- a/ParU/Source/paru_internal.hpp
+++ b/ParU/Source/paru_internal.hpp
@@ -13,6 +13,8 @@
 //  @author Aznaveh
 //
 
+#include <cinttypes>
+
 #define SUITESPARSE_BLAS_DEFINITIONS
 #include "ParU.hpp"
 #include "paru_omp.hpp"


### PR DESCRIPTION
Potentially fixes #769. 