### PR TITLE
CI: Add a runner (MinGW/UCRT64) that builds without Fortran compiler.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -309,7 +309,7 @@ jobs:
       matrix:
 #       CLANG32 disabled for now:
 #       msystem: [MINGW64, MINGW32, CLANG64, CLANG32]
-        msystem: [MINGW64, MINGW32, CLANG64]
+        msystem: [MINGW64, MINGW32, UCRT64, CLANG64]
         include:
           - msystem: MINGW64
             target-prefix: mingw-w64-x86_64
@@ -317,6 +317,10 @@ jobs:
           - msystem: MINGW32
             target-prefix: mingw-w64-i686
             f77-package: mingw-w64-i686-fc
+          - msystem: UCRT64
+            target-prefix: mingw-w64-ucrt-x86_64
+            # Purposefully don't install a Fortran compiler to test that configuration
+            f77-package: mingw-w64-ucrt-x86_64-cc
           - msystem: CLANG64
             target-prefix: mingw-w64-clang-x86_64
             f77-package: mingw-w64-clang-x86_64-fc


### PR DESCRIPTION
The CLANG32 (that is now failing and has been removed) checked if SuiteSparse could be built successfully in the absence of a Fortran compiler.

This PR adds a new runner that installs a build environment where the Fortran compiler is omitted (on purpose).

The UCRT64 environment of MSYS2 uses a GNU toolchain (GCC, GNU ld, libstdc++, ...) that links against the (newer) C runtime of Windows called UCRT (Universal CRT). The latter is the main difference to the MINGW64 environment which links against the (traditional) MSVCRT. 
See: https://www.msys2.org/docs/environments/
