### PR TITLE
CI (ubuntu): Use "include-what-you-use" in one configuration.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
             openmp: without
             openmp-cmake-flags: "-DSUITESPARSE_USE_OPENMP=OFF"
           - compiler: gcc
-            compiler-pkgs: "g++ gcc"
+            compiler-pkgs: "g++ gcc iwyu"
             cc: "gcc"
             cxx: "g++"
             ccache-max: 600M
@@ -80,10 +80,13 @@ jobs:
             openmp: with
             link: static
             # "Fake" a cross-compilation to exercise that build system path
+            # Also build with "include-what-you-use" in this configuration
             link-cmake-flags:
               -DBUILD_SHARED_LIBS=OFF
               -DBUILD_STATIC_LIBS=ON
               -DCMAKE_SYSTEM_NAME="Linux"
+              -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE=include-what-you-use
+              -DCMAKE_C_INCLUDE_WHAT_YOU_USE=include-what-you-use
 
     env:
       CC: ${{ matrix.cc }}


### PR DESCRIPTION
Building with "include-what-you-use" increases the build time. Since we don't need to scan every compilation unit twice, add this on top of the runner that only builds static libraries.

The (initial) results can't be perfect because the tool tries to infer the intent of the author. And that might vary in principle. (See https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/WhatIsAUse.md)
However, the results could be improved by adding iwyu pragmas, e.g., `// IWYU pragma: keep` after headers you'd like to keep. (See https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md)
After some initial "tagging", the results could probably help to detect compilation units where some STL headers "just happen" to be included currently. Having this check might have helped to avoid issues like #769.

I could try to add those iwyu pragmas or add missing headers with the results of this check. But I'll wait for you to decide if you think this is worth it (it is imho) or if you think those additional comments (pragmas) are clutter that you prefer to not have in your sources.
