### PR TITLE
Fix a find_package(UMFPACK) bug in ParU/CMakeLists.txt

### DIFF
--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -111,7 +111,7 @@ if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
 
     find_package ( UMFPACK 6.3.3
         PATHS ${CMAKE_SOURCE_DIR}/../UMFPACK/build NO_DEFAULT_PATH )
-    if ( NOT CAMD_FOUND )
+    if ( NOT UMFPACK_FOUND )
         find_package ( UMFPACK 6.3.3 REQUIRED )
     endif ( )
 endif ( )


### PR DESCRIPTION
External `UMFPACK` is currently not being found due to a small bug in `ParU/CMakeLists.txt`.