### PR TITLE
CI: Add riscv64 arch

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -41,22 +41,16 @@ jobs:
             ccache-max: 80M
             extra-build-libs: ":GraphBLAS:LAGraph"
             extra-check-libs: ":GraphBLAS:LAGraph"
-            branch: latest-stable
           - arch: aarch64
             ccache-max: 42M
-            branch: latest-stable
           - arch: armv7
             ccache-max: 42M
-            branch: latest-stable
           - arch: ppc64le
             ccache-max: 45M
-            branch: latest-stable
           - arch: s390x
             ccache-max: 42M
-            branch: latest-stable
           - arch: riscv64
             ccache-max: 42M
-            branch: edge
 
     name: alpine (${{ matrix.arch }})
 
@@ -74,7 +68,6 @@ jobs:
         # shell: bash
         with:
           arch: ${{ matrix.arch }}
-          branch: ${{ matrix.branch }}
           packages: >
             build-base
             ccache
@@ -89,7 +82,7 @@ jobs:
             autoconf
             automake
             libtool
-            ${{ matrix.arch != 'riscv64' && 'valgrind' || '' }}
+            # ${{ matrix.arch != 'riscv64' && 'valgrind' || '' }}
 
       - name: get CPU information (emulated)
         run: lscpu
@@ -106,7 +99,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           # location of the ccache of the chroot in the root file system
-          path: /home/runner/rootfs/alpine-${{ matrix.arch == 'riscv64' && 'edge' || 'latest'}}-${{ matrix.arch }}/home/runner/.ccache
+          path: /home/runner/rootfs/alpine-latest-${{ matrix.arch }}/home/runner/.ccache
           key: ${{ steps.ccache-prepare.outputs.key }}
           # Prefer caches from the same branch. Fall back to caches from the dev branch.
           restore-keys: |
@@ -175,8 +168,9 @@ jobs:
         # This helps to retain the ccache even if the subsequent steps are failing.
         uses: actions/cache/save@v4
         with:
-          path: /home/runner/rootfs/alpine-${{ matrix.arch == 'riscv64' && 'edge' || 'latest' }}-${{ matrix.arch }}/home/runner/.ccache
+          path: /home/runner/rootfs/alpine-latest-${{ matrix.arch }}/home/runner/.ccache
           key: ${{ steps.ccache-prepare.outputs.key }}
+
 
       - name: install
         run: |
@@ -196,7 +190,6 @@ jobs:
           cmake \
             -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/lib/cmake" \
             -DBLA_VENDOR="Generic" \
-            ${{ matrix.arch == 'riscv64' && '-DBUILD_STATIC_LIBS=FALSE' || '' }} \
             ..
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Building example\n"
@@ -208,6 +201,7 @@ jobs:
           printf "\033[1;35m  C++ binary with shared libraries\033[0m\n"
           ./my_cxx_demo
           echo "::endgroup::"
+      
 
       - name: test Config
         run: |

--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -35,20 +35,28 @@ jobs:
       matrix:
         # For available CPU architectures, see:
         # https://github.com/marketplace/actions/setup-alpine-linux-environment
-        arch: [x86, aarch64, armv7, ppc64le, s390x]
+        arch: [x86, aarch64, armv7, ppc64le, s390x, riscv64]
         include:
           - arch: x86
             ccache-max: 80M
             extra-build-libs: ":GraphBLAS:LAGraph"
             extra-check-libs: ":GraphBLAS:LAGraph"
+            branch: latest-stable
           - arch: aarch64
             ccache-max: 42M
+            branch: latest-stable
           - arch: armv7
             ccache-max: 42M
+            branch: latest-stable
           - arch: ppc64le
             ccache-max: 45M
+            branch: latest-stable
           - arch: s390x
             ccache-max: 42M
+            branch: latest-stable
+          - arch: riscv64
+            ccache-max: 42M
+            branch: edge
 
     name: alpine (${{ matrix.arch }})
 
@@ -66,6 +74,7 @@ jobs:
         # shell: bash
         with:
           arch: ${{ matrix.arch }}
+          branch: ${{ matrix.branch }}
           packages: >
             build-base
             ccache
@@ -76,11 +85,11 @@ jobs:
             mpfr-dev
             lapack-dev
             python3
-            valgrind
             util-linux-misc
             autoconf
             automake
             libtool
+            ${{ matrix.arch != 'riscv64' && 'valgrind' || '' }}
 
       - name: get CPU information (emulated)
         run: lscpu
@@ -97,7 +106,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           # location of the ccache of the chroot in the root file system
-          path: /home/runner/rootfs/alpine-latest-${{ matrix.arch }}/home/runner/.ccache
+          path: /home/runner/rootfs/alpine-${{ matrix.arch == 'riscv64' && 'edge' || 'latest'}}-${{ matrix.arch }}/home/runner/.ccache
           key: ${{ steps.ccache-prepare.outputs.key }}
           # Prefer caches from the same branch. Fall back to caches from the dev branch.
           restore-keys: |
@@ -166,7 +175,7 @@ jobs:
         # This helps to retain the ccache even if the subsequent steps are failing.
         uses: actions/cache/save@v4
         with:
-          path: /home/runner/rootfs/alpine-latest-${{ matrix.arch }}/home/runner/.ccache
+          path: /home/runner/rootfs/alpine-${{ matrix.arch == 'riscv64' && 'edge' || 'latest' }}-${{ matrix.arch }}/home/runner/.ccache
           key: ${{ steps.ccache-prepare.outputs.key }}
 
       - name: install
@@ -187,6 +196,7 @@ jobs:
           cmake \
             -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/lib/cmake" \
             -DBLA_VENDOR="Generic" \
+            ${{ matrix.arch == 'riscv64' && '-DBUILD_STATIC_LIBS=FALSE' || '' }} \
             ..
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Building example\n"


### PR DESCRIPTION
CI for `riscv64` runs on alpine edge branch. `Valgrind` packages are not available on this architecture, so I had to remove it from the dependency list. The directory for saving the `ccahce` cache is different on the edge branch, so I also changed it in `riscv64` arch case. Also i had to disable static libs flag in `Cmake` examples. The problem is that the package versions in the `edge` branch are different from the `stable` one, and when i tried to statically link i got following: `lto1: fatal error: bytecode stream in file '/usr/lib/libgmp.a' generated with LTO version 13.0 instead of the expected 13.1` (on other architectures in the edge branch the problem is same)