### PR TITLE
SuiteSparseBLAS.cmake: Unset cache variable BLA_VENDOR

### DIFF
--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -467,7 +467,6 @@ jobs:
                 -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
                 -DCMAKE_Fortran_COMPILER_LAUNCHER="ccache" \
                 -DSUITESPARSE_USE_FORTRAN=OFF \
-                -DBLA_VENDOR="All" \
                 -DPython_EXECUTABLE="C:/msys64/ucrt64/bin/python.exe" \
                 -DSUITESPARSE_DEMOS=OFF \
                 -DBUILD_TESTING=OFF \

--- a/SuiteSparse_config/cmake_modules/SuiteSparseBLAS.cmake
+++ b/SuiteSparse_config/cmake_modules/SuiteSparseBLAS.cmake
@@ -21,8 +21,6 @@ cmake_minimum_required ( VERSION 3.22 )
 if ( DEFINED ENV{BLA_VENDOR} )
     set ( BLA_VENDOR $ENV{BLA_VENDOR} )
 endif ( )
-set ( BLA_VENDOR "ANY" CACHE STRING
-    "if ANY (default): searches for any BLAS. Otherwise: search for a specific BLAS" )
 
 # To allow the use of a BLAS with 64-bit integers, set this to ON
 option ( SUITESPARSE_USE_64BIT_BLAS
@@ -50,7 +48,7 @@ endif ( )
 # To request specific BLAS, use either (for example):
 #
 #   CMAKE_OPTIONS="-DBLA_VENDOR=Apple" make
-#   cd build && cmake -DBLA_VENDOR=Apple .. ; make
+#   cd build && cmake -DBLA_VENDOR=Apple .. ; cmake --build .
 #
 # Use SUITESPARSE_USE_64BIT_BLAS to select 64-bit or 32-bit BLAS.  If
 # BLA_VENDOR is also defined, this setting is strictly enforced.  If set to
@@ -63,7 +61,7 @@ endif ( )
 #
 # The default for SUITESPARSE_USE_64BIT_BLAS is OFF.
 
-if ( NOT (BLA_VENDOR STREQUAL "ANY" ) )
+if ( NOT ( "${BLA_VENDOR} " STREQUAL " " ) )
     # only look for the BLAS from a single vendor
     if ( ( BLA_VENDOR MATCHES "64ilp" ) OR
          ( BLA_VENDOR MATCHES "ilp64" ) )


### PR DESCRIPTION
`BLA_VENDOR` is a cache variable in `SuiteSparseBLAS.cmake` (not a "normal" variable). Use the correct syntax to unset it when necessary.

Fixes #800.

Also remove a configure variable that is now redundant from the CI.
