### PR TITLE
Allow turning off SPEX python interface

### DIFF
--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -389,7 +389,7 @@ jobs:
         if: matrix.cuda == 'with'
         id: cuda-toolkit
         with:
-          cuda: '12.2.0'
+          cuda: '12.4.1'
           #See https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html#install-the-cuda-software
           method: 'local'
           # Do not cache the installer (~3 GiB). It doesn't speed up the

--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -384,12 +384,12 @@ jobs:
 
           msystem: UCRT64
 
-      - uses: Jimver/cuda-toolkit@v0.2.15
+      - uses: Jimver/cuda-toolkit@v0.2.14
         name: install CUDA toolkit
         if: matrix.cuda == 'with'
         id: cuda-toolkit
         with:
-          cuda: '12.4.1'
+          cuda: '12.2.0'
           #See https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html#install-the-cuda-software
           method: 'local'
           # Do not cache the installer (~3 GiB). It doesn't speed up the

--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -384,7 +384,7 @@ jobs:
 
           msystem: UCRT64
 
-      - uses: Jimver/cuda-toolkit@v0.2.14
+      - uses: Jimver/cuda-toolkit@v0.2.15
         name: install CUDA toolkit
         if: matrix.cuda == 'with'
         id: cuda-toolkit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ option ( UMFPACK_USE_CHOLMOD "ON (default): use CHOLMOD in UMFPACK.  OFF: do not
 # library takes a long time
 option ( GRAPHBLAS_BUILD_STATIC_LIBS "OFF (default): Do not build static libraries for GraphBLAS project.  ON: Use same value of BUILD_STATIC_LIBS for GraphBLAS like in the other projects" OFF )
 
-option ( SUITESPARSE_PYTHON "ON (default): build Python interfaces for SuiteSparse packages (SPEX).  OFF: do not build Python interfaces for SuiteSparse packages" ON )
+option ( SUITESPARSE_ENABLE_PYTHON "ON (default): build Python interfaces for SuiteSparse packages (SPEX).  OFF: do not build Python interfaces for SuiteSparse packages" ON )
 
 # options to build with libraries installed on the system instead of building
 # dependencies automatically

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ option ( UMFPACK_USE_CHOLMOD "ON (default): use CHOLMOD in UMFPACK.  OFF: do not
 # library takes a long time
 option ( GRAPHBLAS_BUILD_STATIC_LIBS "OFF (default): Do not build static libraries for GraphBLAS project.  ON: Use same value of BUILD_STATIC_LIBS for GraphBLAS like in the other projects" OFF )
 
+option ( SUITESPARSE_PYTHON "ON (default): build Python interfaces for SuiteSparse packages (SPEX).  OFF: do not build Python interfaces for SuiteSparse packages" ON )
+
 # options to build with libraries installed on the system instead of building
 # dependencies automatically
 option ( SUITESPARSE_USE_SYSTEM_BTF "ON: use BTF libraries installed on the build system.  OFF (default): Automatically build BTF as dependency if needed." OFF )

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -410,8 +410,8 @@ endif ( )
 #-------------------------------------------------------------------------------
 # python interface
 #-------------------------------------------------------------------------------
-option ( SPEX_PYTHON "ON (default): build Python interface for SPEX.  OFF: do not build Python interface for SPEX" ${SUITESPARSE_ENABLE_PYTHON} )
-if ( BUILD_SHARED_LIBS AND SPEX_PYTHON)
+option ( SPEX_ENABLE_PYTHON "ON (default): build Python interface for SPEX.  OFF: do not build Python interface for SPEX" ${SUITESPARSE_ENABLE_PYTHON} )
+if ( BUILD_SHARED_LIBS AND SPEX_ENABLE_PYTHON)
 
     file ( GLOB SPEX_PYTHON_SOURCES "Python/SPEXpy/Source/*.c" )
     add_library ( spexpython SHARED ${SPEX_PYTHON_SOURCES} )

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -410,7 +410,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 # python interface
 #-------------------------------------------------------------------------------
-option ( SPEX_PYTHON "ON (default): build Python interface for SPEX.  OFF: do not build Python interface for SPEX" ${SUITESPARSE_PYTHON} )
+option ( SPEX_PYTHON "ON (default): build Python interface for SPEX.  OFF: do not build Python interface for SPEX" ${SUITESPARSE_ENABLE_PYTHON} )
 if ( BUILD_SHARED_LIBS AND SPEX_PYTHON)
 
     file ( GLOB SPEX_PYTHON_SOURCES "Python/SPEXpy/Source/*.c" )

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -410,8 +410,8 @@ endif ( )
 #-------------------------------------------------------------------------------
 # python interface
 #-------------------------------------------------------------------------------
-
-if ( BUILD_SHARED_LIBS )
+option ( SPEX_PYTHON "ON (default): build Python interface for SPEX.  OFF: do not build Python interface for SPEX" ${SUITESPARSE_PYTHON} )
+if ( BUILD_SHARED_LIBS AND SPEX_PYTHON)
 
     file ( GLOB SPEX_PYTHON_SOURCES "Python/SPEXpy/Source/*.c" )
     add_library ( spexpython SHARED ${SPEX_PYTHON_SOURCES} )


### PR DESCRIPTION
There's currently no way to turn this off when building shared libs, and it would be cleanest to allow turning it off at the SuiteSparse level, not just the SPEX level. 