### PR TITLE
SPEX: Fix building demo without OpenMP.

### DIFF
--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -490,7 +490,7 @@ if ( SUITESPARSE_DEMOS )
         target_link_libraries ( spex_demo_threaded          PUBLIC SPEX_static SuiteSparse::AMD_static SuiteSparse::COLAMD_static )
     endif ( )
 
-    if ( SPEX_USE_OPENMP )
+    if ( SPEX_HAS_OPENMP )
         if ( BUILD_SHARED_LIBS )
             target_link_libraries ( spex_demo_threaded PUBLIC OpenMP::OpenMP_C )
         endif ( )


### PR DESCRIPTION
Depend on `SPEX_HAS_OPENMP` (not `SPEX_USE_OPENMP`) for linking to OpenMP.

This should avoid the configuration error seen, e.g., here:
https://github.com/DrTimothyAldenDavis/SuiteSparse/actions/runs/9201634447/job/25310164131#step:22:73
```
CMake Error at CMakeLists.txt:495 (target_link_libraries):
-- Generating done (0.1s)
  Target "spex_demo_threaded" links to:

    OpenMP::OpenMP_C

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.



CMake Generate step failed.  Build files cannot be regenerated correctly.
make: *** [demos] Error 1
```
