### PR TITLE
Example: Don't include OpenMP header if building without it.

### DIFF
--- a/Example/Include/my_internal.h
+++ b/Example/Include/my_internal.h
@@ -2,7 +2,7 @@
 // SuiteSparse/Example/Include/my_internal.h
 //------------------------------------------------------------------------------
 
-// Copyright (c) 2022-2023, Timothy A. Davis, All Rights Reserved.
+// Copyright (c) 2022-2024, Timothy A. Davis, All Rights Reserved.
 // SPDX-License-Identifier: BSD-3-clause
 
 //------------------------------------------------------------------------------
@@ -110,7 +110,9 @@
 #endif
 
 // OpenMP include file:
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 // GMP and MPFR
 #include <gmp.h>


### PR DESCRIPTION
Include `omp.h` only if `_OPENMP` is defined.

This fixes an issue when trying to build the example on a system on which no OpenMP implementation can be detected by CMake.

Afaict, the example doesn't use any OpenMP features directly. So, it shouldn't be necessary at all to include the OpenMP header. If a library requires that the OpenMP header is included, that library should include it in its own header.

Should including `omp.h` in the header of the example be removed entirely?
