### PR TITLE
CI (alpine): Add an emulated RISC-V 64-bit runner

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -38,19 +38,19 @@ jobs:
         arch: [x86, aarch64, armv7, ppc64le, s390x, riscv64]
         include:
           - arch: x86
-            ccache-max: 80M
+            ccache-max: 64M
             extra-build-libs: ":GraphBLAS:LAGraph"
             extra-check-libs: ":GraphBLAS:LAGraph"
           - arch: aarch64
-            ccache-max: 42M
+            ccache-max: 28M
           - arch: armv7
-            ccache-max: 42M
+            ccache-max: 25M
           - arch: ppc64le
-            ccache-max: 45M
+            ccache-max: 28M
           - arch: s390x
-            ccache-max: 42M
+            ccache-max: 28M
           - arch: riscv64
-            ccache-max: 42M
+            ccache-max: 28M
 
     name: alpine (${{ matrix.arch }})
 

--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         # For available CPU architectures, see:
         # https://github.com/marketplace/actions/setup-alpine-linux-environment
-        arch: [x86, aarch64, armv7, ppc64le, s390x]
+        arch: [x86, aarch64, armv7, ppc64le, s390x, riscv64]
         include:
           - arch: x86
             ccache-max: 80M
@@ -48,6 +48,8 @@ jobs:
           - arch: ppc64le
             ccache-max: 45M
           - arch: s390x
+            ccache-max: 42M
+          - arch: riscv64
             ccache-max: 42M
 
     name: alpine (${{ matrix.arch }})
@@ -76,7 +78,7 @@ jobs:
             mpfr-dev
             lapack-dev
             python3
-            valgrind
+            ${{ matrix.arch != 'riscv64' && 'valgrind' || '' }}
             util-linux-misc
             autoconf
             automake

--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -78,11 +78,11 @@ jobs:
             mpfr-dev
             lapack-dev
             python3
-            ${{ matrix.arch != 'riscv64' && 'valgrind' || '' }}
             util-linux-misc
             autoconf
             automake
             libtool
+          # ${{ matrix.arch != 'riscv64' && 'valgrind' || '' }}
 
       - name: get CPU information (emulated)
         run: lscpu


### PR DESCRIPTION
This is a simpler alternative to #801 now that Alpine Linux 3.20 is released that includes packages for RISC-V 64.

Like @suvorovrain already wrote in that PR, valgrind isn't packaged for that architecture. (Upstream valgrind doesn't support that architecture.)
I'm not sure why it is installed in the first place on those runners. Could it be removed entirely?
