### PR TITLE
GraphBLAS: Limit scope of extern "C" block to function declarations.

### DIFF
--- a/GraphBLAS/Config/GraphBLAS.h.in
+++ b/GraphBLAS/Config/GraphBLAS.h.in
@@ -40,11 +40,6 @@
 #ifndef GRAPHBLAS_H
 #define GRAPHBLAS_H
 
-#if defined ( __cplusplus )
-extern "C"
-{
-#endif
-
 //==============================================================================
 //=== GraphBLAS macros, typedefs, enums, and global variables  =================
 //==============================================================================
@@ -2681,6 +2676,11 @@ GrB_Format ;
 // The GB_CUDA_FOLDER flag is only meant for use by the C++ functions in
 // GraphBLAS/CUDA, since they do not need access these definitions.  User
 // applications have access to these methods.
+
+#if defined ( __cplusplus )
+extern "C"
+{
+#endif
 
 #ifndef GB_CUDA_FOLDER
 

--- a/GraphBLAS/Include/GraphBLAS.h
+++ b/GraphBLAS/Include/GraphBLAS.h
@@ -40,11 +40,6 @@
 #ifndef GRAPHBLAS_H
 #define GRAPHBLAS_H
 
-#if defined ( __cplusplus )
-extern "C"
-{
-#endif
-
 //==============================================================================
 //=== GraphBLAS macros, typedefs, enums, and global variables  =================
 //==============================================================================
@@ -2681,6 +2676,11 @@ GrB_Format ;
 // The GB_CUDA_FOLDER flag is only meant for use by the C++ functions in
 // GraphBLAS/CUDA, since they do not need access these definitions.  User
 // applications have access to these methods.
+
+#if defined ( __cplusplus )
+extern "C"
+{
+#endif
 
 #ifndef GB_CUDA_FOLDER
 


### PR DESCRIPTION
Headers (especially headers from the standard library) shouldn't be included in extern "C" blocks. These blocks are only really needed for function declarations.

Limit the scope of the extern "C" block in GraphBLAS.h to where it's really needed.

This should hopefully avoid the build error when using LLVM `libc++` as the standard library.
