### PR TITLE
SPEX: Fix building stand-alone.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,10 +75,6 @@ option ( UMFPACK_USE_CHOLMOD "ON (default): use CHOLMOD in UMFPACK.  OFF: do not
 # library takes a long time
 option ( GRAPHBLAS_BUILD_STATIC_LIBS "OFF (default): Do not build static libraries for GraphBLAS project.  ON: Use same value of BUILD_STATIC_LIBS for GraphBLAS like in the other projects" OFF )
 
-# control the use of Python interfaces in SuiteSparse packages (currently only
-# for SPEX)
-option ( SUITESPARSE_USE_PYTHON "ON (default): build Python interfaces for SuiteSparse packages (SPEX).  OFF: do not build Python interfaces for SuiteSparse packages" ON )
-
 # options to build with libraries installed on the system instead of building
 # dependencies automatically
 option ( SUITESPARSE_USE_SYSTEM_BTF "ON: use BTF libraries installed on the build system.  OFF (default): Automatically build BTF as dependency if needed." OFF )

--- a/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
+++ b/SuiteSparse_config/cmake_modules/SuiteSparsePolicy.cmake
@@ -132,6 +132,10 @@ set ( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 # Use OpenMP
 option ( SUITESPARSE_USE_OPENMP "ON (default): Use OpenMP in libraries by default if available.  OFF: Do not use OpenMP by default." ON )
 
+# control the use of Python interfaces in SuiteSparse packages (currently only
+# for SPEX)
+option ( SUITESPARSE_USE_PYTHON "ON (default): build Python interfaces for SuiteSparse packages (SPEX).  OFF: do not build Python interfaces for SuiteSparse packages" ON )
+
 # strict usage
 option ( SUITESPARSE_USE_STRICT "ON: treat all _USE__ settings as strict if they are ON. OFF (default): consider *_USE_* as preferences, not strict" OFF )
 


### PR DESCRIPTION
Make sure SUITESPARSE_USE_PYTHON has a default value if packages are built stand-alone (i.e., without using the root CMakeLists.txt).

I missed that when reviewing #805. Sorry.
