### PR TITLE
GraphBLAS: Emit more verbose error message if _Atomic doesn't work.

### DIFF
--- a/GraphBLAS/cmake_modules/SuiteSparseAtomic.cmake
+++ b/GraphBLAS/cmake_modules/SuiteSparseAtomic.cmake
@@ -50,7 +50,11 @@ if ( NOT TEST_FOR_STDATOMIC )
     check_c_source_compiles ( "${atomic_source}" TEST_FOR_STDATOMIC_WITH_LIBATOMIC )
     if ( NOT TEST_FOR_STDATOMIC_WITH_LIBATOMIC )
         # fails with -latomic
-        message ( FATAL_ERROR "C11 atomics: failed" )
+        string ( CONCAT ERR_MSG
+            "C11 atomics: failed.\n"
+            "Cannot build GraphBLAS with the used C compiler "
+            "(${CMAKE_C_COMPILER_ID}) and/or libraries." )
+        message ( FATAL_ERROR "${ERR_MSG}" )
     endif ( )
     # source compiles but -latomic is required
     set ( LIBATOMIC_REQUIRED true )


### PR DESCRIPTION
The additional information in the error message might help debugging build errors like the one in #818 in the future.
