### PR TITLE
CI (MSVC): Install reference BLAS and LAPACK libraries.

### DIFF
--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -351,7 +351,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: C:/Miniconda/envs/test
-          key: conda:msvc
+          key: conda:netlib:msvc
 
       - name: install packages with conda
         if: ${{ steps.conda-cache.outputs.cache-hit != 'true' }}
@@ -359,8 +359,8 @@ jobs:
           echo ${{ steps.conda-cache.outputs.cache-hit }}
           conda info
           conda list
-          conda install -y -c intel mkl-devel
-          conda install -y -c conda-forge --override-channels ccache
+          conda install -y -c conda-forge --override-channels ccache m2w64-gcc-libs
+          conda install -y -c conda-forge/label/lapack_rc --override-channels liblapack=3.11
 
       - name: save conda cache
         if: ${{ steps.conda-cache.outputs.cache-hit != 'true' }}
@@ -467,6 +467,7 @@ jobs:
                 -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
                 -DCMAKE_Fortran_COMPILER_LAUNCHER="ccache" \
                 -DSUITESPARSE_USE_FORTRAN=OFF \
+                -DSUITESPARSE_C_TO_FORTRAN="(name,NAME) name##_" \
                 -DPython_EXECUTABLE="C:/msys64/ucrt64/bin/python.exe" \
                 -DSUITESPARSE_DEMOS=OFF \
                 -DBUILD_TESTING=OFF \


### PR DESCRIPTION
Be more careful not to mix binaries that have been built with different OpenMP implementations. Intel MKL is linked against libiomp5md. But these runners build with MSVC `cl` or LLVM `clang-cl`, respectively. I.e., they are linking against the MS implementation or the LLVM implementation of OpenMP, respectively. That is dangerous, since it can degrade performance or cause incorrect results.

Avoid that issue by linking against the reference implementations of the BLAS and LAPACK libraries that don't use OpenMP at all.

This should help to avoid issues like the one in #823 where the tests failed with this runtime error:

> OMP: Error #15: Initializing libomp140.x86_64.dll, but found libiomp5md.dll already initialized.
> OMP: Hint This means that multiple copies of the OpenMP runtime have been linked into the program. That is dangerous, since it can degrade performance or cause incorrect results. The best thing to do is to ensure that only a single OpenMP runtime is linked into the process, e.g. by avoiding static linking of the OpenMP runtime in any library. As an unsafe, unsupported, undocumented workaround you can set the environment variable KMP_DUPLICATE_LIB_OK=TRUE to allow the program to continue to execute, but that may cause crashes or silently produce incorrect results. For more information, please see http://openmp.llvm.org/


