### PR TITLE
CI (MSVC): Update build rules for MSVC 19.40

### DIFF
--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -455,6 +455,14 @@ jobs:
           if [ ${{ matrix.cuda }} = 'with' ]; then
             _extra_config+=(-DCUDAToolkit_ROOT="$(cygpath -m "${{ steps.cuda-toolkit.outputs.CUDA_PATH }}")")
             _extra_config+=(-DCMAKE_CUDA_COMPILER="$(cygpath -m "${{ steps.cuda-toolkit.outputs.CUDA_PATH }}")/bin/nvcc.exe")
+            # MSVC 19.40 is still Visual Studio 2022.
+            # Suppress erroneous version check.
+            _extra_config+=(-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler)
+          fi
+          if [ ${{ matrix.cc }} = 'clang-cl' ]; then
+            # Move away (old) clang-cl that would be in PATH to make sure that
+            # we use the one that matches the MSVC runtime.
+            mv C:/Program\ Files/LLVM C:/Program\ Files/LLVM_old
           fi
           mkdir -p ${GITHUB_WORKSPACE}/build && cd ${GITHUB_WORKSPACE}/build
           cmake -G"Ninja Multi-Config" \


### PR DESCRIPTION
GitHub seems to be updating their runner images to include MSVC 19.40 currently.

NVIDIA CUDA seems to think this newer version of MSVC is no longer Microsoft Visual Studio 2022 (but it is).
Work around that issue by adding `-allow-unsupported-compiler` to the CUDA flags.

Additionally, it looks like the PATH variable on these runner images is arranged such that a different (older) `clang-cl` is being picked up by CMake instead of the newer one from MSVC 19.40.
Work around that by moving that version out of the PATH so CMake picks the compiler that is installed with Microsoft Visual Studio.
See also https://github.com/actions/runner-images/issues/10001.
