### PR TITLE
SuiteSparse_config: Avoid including headers in extern "C" block.

### DIFF
--- a/SuiteSparse_config/Config/SuiteSparse_config.h.in
+++ b/SuiteSparse_config/Config/SuiteSparse_config.h.in
@@ -19,11 +19,6 @@
 #ifndef SUITESPARSE_CONFIG_H
 #define SUITESPARSE_CONFIG_H
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 //------------------------------------------------------------------------------
 // SuiteSparse-wide ANSI C11 #include files
 //------------------------------------------------------------------------------
@@ -261,6 +256,11 @@ extern "C"
     // ANSI C95 and earlier: no restrict keyword
     #define SUITESPARSE_RESTRICT
 
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
 #endif
 
 //==============================================================================

--- a/SuiteSparse_config/SuiteSparse_config.h
+++ b/SuiteSparse_config/SuiteSparse_config.h
@@ -19,11 +19,6 @@
 #ifndef SUITESPARSE_CONFIG_H
 #define SUITESPARSE_CONFIG_H
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 //------------------------------------------------------------------------------
 // SuiteSparse-wide ANSI C11 #include files
 //------------------------------------------------------------------------------
@@ -261,6 +256,11 @@ extern "C"
     // ANSI C95 and earlier: no restrict keyword
     #define SUITESPARSE_RESTRICT
 
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
 #endif
 
 //==============================================================================


### PR DESCRIPTION
Including headers (from the standard library) in extern "C" blocks can be problematic.

Use extern "C" block only around function declarations.

See also #813.
