### PR TITLE
Avoid including headers in extern "C" blocks

### DIFF
--- a/CHOLMOD/GPU/cholmod_gpu_kernels.h
+++ b/CHOLMOD/GPU/cholmod_gpu_kernels.h
@@ -15,12 +15,12 @@
 #ifndef CHOLMODGPUKERNELS_H
 #define CHOLMODGPUKERNELS_H
 
+#include "SuiteSparse_config.h"
+
 /* make it easy for C++ programs to include CHOLMOD */
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "SuiteSparse_config.h"
 
 int createMapOnDevice ( int64_t *d_Map, int64_t *d_Ls, int64_t psi, int64_t nsrow ); 
 

--- a/ParU/Config/ParU.h.in
+++ b/ParU/Config/ParU.h.in
@@ -620,13 +620,13 @@ ParU_Info ParU_FreeControl
 
 // The following definitions are available in both C and C++:
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdint.h>
 #include <stdbool.h>
 #include <math.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct ParU_C_Symbolic_struct *ParU_C_Symbolic ;
 typedef struct ParU_C_Numeric_struct  *ParU_C_Numeric ;

--- a/ParU/Include/ParU.h
+++ b/ParU/Include/ParU.h
@@ -620,13 +620,13 @@ ParU_Info ParU_FreeControl
 
 // The following definitions are available in both C and C++:
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdint.h>
 #include <stdbool.h>
 #include <math.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct ParU_C_Symbolic_struct *ParU_C_Symbolic ;
 typedef struct ParU_C_Numeric_struct  *ParU_C_Numeric ;

--- a/ParU/Tcov/paru_c_test.cpp
+++ b/ParU/Tcov/paru_c_test.cpp
@@ -45,10 +45,7 @@
 }
 
 #include "paru_cov.hpp"
-extern "C"
-{
 #include "ParU.h"
-}
 
 int main(int argc, char **argv)
 {

--- a/SPQR/Include/SuiteSparseQR.hpp
+++ b/SPQR/Include/SuiteSparseQR.hpp
@@ -18,12 +18,11 @@
 #include <cublas_v2.h>
 #endif
 #define SUITESPARSE_GPU_EXTERN_ON
-extern "C"
-{
-    #include "SuiteSparse_config.h"
-    #include "cholmod.h"
-    #include "SuiteSparseQR_definitions.h"
-}
+
+#include "SuiteSparse_config.h"
+#include "cholmod.h"
+#include "SuiteSparseQR_definitions.h"
+
 #undef SUITESPARSE_GPU_EXTERN_ON
 
 #include <complex>


### PR DESCRIPTION
I believe that covers the remaining files where headers shouldn't be included in `extern "C"` blocks.
