### PR TITLE
GraphBLAS: Avoid warning from Clang 17.

### DIFF
--- a/GraphBLAS/Source/omp/include/GB_atomics.h
+++ b/GraphBLAS/Source/omp/include/GB_atomics.h
@@ -410,7 +410,7 @@
     #define GB_ATOMIC_COMPARE_EXCHANGE_32(target, expected, desired)        \
     (                                                                       \
         GB_PUN (int32_t, expected) ==                                       \
-            _InterlockedCompareExchange ((int32_t volatile *) (target),     \
+            _InterlockedCompareExchange ((long volatile *) (target),        \
             GB_PUN (int32_t, desired), GB_PUN (int32_t, expected))          \
     )
 


### PR DESCRIPTION
Clang 17 emits more warnings (or errors) when it comes to incompatible pointer types.

`_InterlockedCompareExchange` is declared with `long volatile *` as the type of its first input argument
See: https://learn.microsoft.com/en-us/cpp/intrinsics/interlockedcompareexchange-intrinsic-functions?view=msvc-170

`int32_t` is `int` on Windows. While `long` and `int` have the same size on Windows (LLP64 data model), they are technically distinct types.

Avoid the compiler warning by casting to the pointer type expected by that function.

Without this change, `clang-cl` 17 emits warnings like the following:
https://github.com/DrTimothyAldenDavis/SuiteSparse/actions/runs/9404241025/job/25902701998#step:16:3057
```
[2990/5428] Building C object GraphBLAS\CMakeFiles\GraphBLAS.dir\Release\FactoryKernels\GB_AxB__band_band_uint32.c.obj
In file included from D:\a\SuiteSparse\SuiteSparse\GraphBLAS\FactoryKernels\GB_AxB__band_band_uint32.c:179:
In file included from D:\a\SuiteSparse\SuiteSparse\GraphBLAS\Source\mxm/template/GB_AxB_saxbit_template.c:240:
D:\a\SuiteSparse\SuiteSparse\GraphBLAS\Source\mxm\template/GB_AxB_saxbit_A_sparse_B_bitmap_template.c(402,33): warning: incompatible pointer types passing 'volatile int32_t *' (aka 'volatile int *') to parameter of type 'volatile long *' [-Wincompatible-pointer-types]
  402 |                                 GB_Z_ATOMIC_UPDATE_HX (i, t) ;    // C(i,j) += t
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:\a\SuiteSparse\SuiteSparse\GraphBLAS\Source\mxm/include/GB_AxB_saxpy3_template.h(509,21): note: expanded from macro 'GB_Z_ATOMIC_UPDATE_HX'
  509 |             while (!GB_Z_ATOMIC_COMPARE_EXCHANGE (pz, zold, znew)) ;    \
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:\a\SuiteSparse\SuiteSparse\GraphBLAS\Source\omp\include/GB_kernel_shared_definitions.h(58,16): note: expanded from macro 'GB_Z_ATOMIC_COMPARE_EXCHANGE'
   58 |                GB_ATOMIC_COMPARE_EXCHANGE_32(target, expected, desired)
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
D:\a\SuiteSparse\SuiteSparse\GraphBLAS\Source\omp/include/GB_atomics.h(413,42): note: expanded from macro 'GB_ATOMIC_COMPARE_EXCHANGE_32'
  413 |             _InterlockedCompareExchange ((int32_t volatile *) (target),     \
      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```


(Side note: I'm unsure where to open PRs wrt GraphBLAS. I opted for this repository because there is CI here.)
