### PR TITLE
GraphBLAS: Check if C standard function "system" can be used

### DIFF
--- a/GraphBLAS/cmake_modules/GraphBLAS_JIT_paths.cmake
+++ b/GraphBLAS/cmake_modules/GraphBLAS_JIT_paths.cmake
@@ -43,8 +43,20 @@ if ( SUITESPARSE_HAS_CUDA AND GRAPHBLAS_USE_CUDA )
 #   set ( GRAPHBLAS_COMPACT on )    # FIXME
 endif ( )
 
+include ( CheckSymbolExists )
+check_symbol_exists ( system "stdlib.h" HAVE_C_SYSTEM )
+
 option ( GRAPHBLAS_COMPACT "ON: do not compile FactoryKernels.  OFF (default): compile FactoryKernels" OFF )
-option ( GRAPHBLAS_USE_JIT "ON (default): use the CPU JIT.  OFF: do not use the CPU JIT" ON )
+option ( GRAPHBLAS_USE_JIT "ON (default): use the CPU JIT.  OFF: do not use the CPU JIT" ${HAVE_C_SYSTEM} )
+
+if ( GRAPHBLAS_USE_JIT AND NOT HAVE_C_SYSTEM )
+    if ( SUITESPARSE_USE_STRICT )
+        message ( FATAL_ERROR "GRAPHBLAS CPU JIT cannot be built without support for the C standard function 'system'." )
+    else ( )
+        message ( STATUS "C standard function 'system' cannot be used. GRAPHBLAS CPU JIT will be disabled." )
+        set ( GRAPHBLAS_USE_JIT OFF CACHE BOOL "ON (default): use the CPU JIT.  OFF: do not use the CPU JIT" FORCE )
+    endif ( )
+endif ( )
 
 if ( GRAPHBLAS_USE_JIT )
     message ( STATUS "GraphBLAS CPU JIT: enabled")


### PR DESCRIPTION
Support for the CPU JIT compiler requires that a compiler can be executed on the host using the `system` function.

Disable the JIT compiler if the `system` function cannot be used on the target system.

See also the discussion in #835.
