### PR TITLE
GraphBLAS: Check for ability to link with libdl.

### DIFF
--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -409,13 +409,13 @@ if ( NOT NO_LIBM )
 endif ( )
 
 # libdl
-if ( NOT WIN32 )
+if ( NOT "${CMAKE_DL_LIBS}" STREQUAL "" )
     if ( BUILD_SHARED_LIBS )
-        target_link_libraries ( GraphBLAS PRIVATE dl )
+        target_link_libraries ( GraphBLAS PRIVATE ${CMAKE_DL_LIBS} )
     endif ( )
     if ( BUILD_STATIC_LIBS )
-        list ( APPEND GRAPHBLAS_STATIC_LIBS "dl" )
-        target_link_libraries ( GraphBLAS_static PUBLIC dl )
+        list ( APPEND GRAPHBLAS_STATIC_LIBS ${CMAKE_DL_LIBS} )
+        target_link_libraries ( GraphBLAS_static PUBLIC ${CMAKE_DL_LIBS} )
     endif ( )
 endif ( )
 

--- a/Mongoose/Include/Mongoose_Logger.hpp
+++ b/Mongoose/Include/Mongoose_Logger.hpp
@@ -103,10 +103,10 @@ typedef enum TimingType
 class Logger
 {
 private:
-    /* MONGOOSE_API */ static int debugLevel;
-    /* MONGOOSE_API */ static bool timingOn;
-    /* MONGOOSE_API */ static double clocks[6];
-    /* MONGOOSE_API */ static float times[6];
+    MONGOOSE_API static int debugLevel;
+    MONGOOSE_API static bool timingOn;
+    MONGOOSE_API static double clocks[6];
+    MONGOOSE_API static float times[6];
 
 public:
     static inline void tic(TimingType timingType);


### PR DESCRIPTION
On some platforms (like NetBSD), `dlopen` and similar functions are not in a library. They can be used in any dynamically linked program instead:
https://man.netbsd.org/dlopen.3

Use a feature test during configuration to check whether linking to libdl is necessary (or possible).

Fixes #837.
