### PR TITLE
Mongoose: Define `MONGOOSE_BUILDING` when building objects for `.mex`

### DIFF
--- a/Mongoose/Include/Mongoose_Logger.hpp
+++ b/Mongoose/Include/Mongoose_Logger.hpp
@@ -103,23 +103,10 @@ typedef enum TimingType
 class Logger
 {
 private:
-    #ifdef MATLAB_MEX_FILE
-    // Compiling the Mongoose mexFunction inside MATLAB on Windows with the
-    // MSVC cl compiler (via the MATLAB mex command) causes an error, stating
-    // that private class members cannot be tagged with __declspec(...).
-    static int debugLevel;
-    static bool timingOn;
-    static double clocks[6];
-    static float times[6];
-    #else
-    // However, compiling the mongoose executable with the Windows cl compiler
-    // causes the mongoose.cpp executable to fail to link without the nasty
-    // __declspec(...) added below.
     MONGOOSE_API static int debugLevel;
     MONGOOSE_API static bool timingOn;
     MONGOOSE_API static double clocks[6];
     MONGOOSE_API static float times[6];
-    #endif
 
 public:
     static inline void tic(TimingType timingType);

--- a/Mongoose/MATLAB/mongoose_make.m
+++ b/Mongoose/MATLAB/mongoose_make.m
@@ -38,6 +38,9 @@ flags = [flags ' -DGP_MEX_FUNCTION'] ;
 % Append optimization
 flags = [flags ' -O -silent COPTIMFLAGS="-O3 -fwrapv"'];
 
+% Append while building objects for shared library
+flags = [flags ' -DMONGOOSE_BUILDING'];
+
 cpp_flags = '' ;
 lib = '';
 if (isunix)


### PR DESCRIPTION
`.mex` files are basically shared libraries that are loaded by Matlab.

Define `MONGOOSE_BUILDING` while building the object files for the `.mex` file.

@DrTimothyAldenDavis: Does that fix the build issues of Mongoose in Matlab on Windows?
