### PR TITLE
Explicitly select linker for some mixed language libraries.

### DIFF
--- a/AMD/CMakeLists.txt
+++ b/AMD/CMakeLists.txt
@@ -90,7 +90,8 @@ if ( BUILD_SHARED_LIBS )
         OUTPUT_NAME amd
         SOVERSION ${AMD_VERSION_MAJOR}
         PUBLIC_HEADER "Include/amd.h"
-        WINDOWS_EXPORT_ALL_SYMBOLS ON )
+        WINDOWS_EXPORT_ALL_SYMBOLS ON
+        LINKER_LANGUAGE C )
 
     if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
         set_target_properties ( AMD PROPERTIES EXPORT_NO_SYSTEM ON )
@@ -111,7 +112,8 @@ if ( BUILD_STATIC_LIBS )
         C_STANDARD 11
         C_STANDARD_REQUIRED ON
         OUTPUT_NAME amd
-        PUBLIC_HEADER "Include/amd.h" )
+        PUBLIC_HEADER "Include/amd.h"
+        LINKER_LANGUAGE C )
 
     if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
         set_target_properties ( AMD_static PROPERTIES

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -383,7 +383,8 @@ if ( BUILD_SHARED_LIBS )
         OUTPUT_NAME cholmod
         SOVERSION ${CHOLMOD_VERSION_MAJOR}
         PUBLIC_HEADER "Include/cholmod.h"
-        WINDOWS_EXPORT_ALL_SYMBOLS ON )
+        WINDOWS_EXPORT_ALL_SYMBOLS ON
+        LINKER_LANGUAGE C )
 
     if ( CHOLMOD_HAS_CUDA )
         set_target_properties ( CHOLMOD PROPERTIES CUDA_SEPARABLE_COMPILATION ON )
@@ -410,7 +411,8 @@ if ( BUILD_STATIC_LIBS )
         C_STANDARD 11
         C_STANDARD_REQUIRED ON
         OUTPUT_NAME cholmod
-        PUBLIC_HEADER "Include/cholmod.h" )
+        PUBLIC_HEADER "Include/cholmod.h"
+        LINKER_LANGUAGE C )
 
     if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
         set_target_properties ( CHOLMOD_static PROPERTIES


### PR DESCRIPTION
If no linker preference is set for a shared library, CMake is choosing the executable that is used for linking based on the highest linker preference value. If a library consists of C and Fortran sources, the Fortran compiler frontend has the higher linker preference value and it is chosen by default.

For the Intel oneAPI compiler with MSVC-like syntax `icx-cl` as the C and C++ compiler and the Intel oneAPI Fortran compilers `ifort` or `ifx`, this leads to the following situation in combination with `WINDOWS_EXPORT_ALL_SYMBOLS`:
* The symbols that are to be exported from the library are collected from the C objects and written to a `.def` file.
* Flags are generated that pass that `.def` file to the linker. However, the syntax for these flags match the C compiler `icx-cl`.
* The Fortran compiler is used for linking (higher linker preference value). But `.def` files need to be passed differently for `ifx` or `ifort` than for `icx-cl`.

That leads to the linked libraries being empty or only exporting the Fortran symbols.

This is probably an issue that should be fixed in CMake. (However, that doesn't seem to be solvable easily.)
To work around the issue, explicitly specify to use the C compiler frontend as the linker for the AMD and CHOLMOD libraries.

Fixes #799.
