### PR TITLE
Fix UMFPACK compilation errors in Visual Studio 2017

### DIFF
--- a/UMFPACK/Source/umf_internal.h
+++ b/UMFPACK/Source/umf_internal.h
@@ -169,7 +169,11 @@
 #elif defined (HAVE_PRAGMA_IVDEP)
 #  define UMFPACK_IVDEP _Pragma("ivdep")
 #elif defined (HAVE_PRAGMA_LOOP_IVDEP)
+#if defined ( _MSC_VER )
+#  define UMFPACK_IVDEP __pragma("loop( ivdep )")
+#else 
 #  define UMFPACK_IVDEP _Pragma("loop( ivdep )")
+#endif 
 #else
 #  define UMFPACK_IVDEP
 #endif
@@ -181,7 +185,11 @@
 #elif defined (HAVE_PRAGMA_NOVECTOR)
 #  define UMFPACK_NOVECTOR _Pragma("novector")
 #elif defined (HAVE_PRAGMA_LOOP_NO_VECTOR)
+#if defined ( _MSC_VER )
+#  define UMFPACK_NOVECTOR __pragma("loop( no_vector )")
+#else 
 #  define UMFPACK_NOVECTOR _Pragma("loop( no_vector )")
+#endif 
 #else
 #  define UMFPACK_NOVECTOR
 #endif

--- a/UMFPACK/Source/umf_internal.h
+++ b/UMFPACK/Source/umf_internal.h
@@ -170,7 +170,7 @@
 #  define UMFPACK_IVDEP _Pragma("ivdep")
 #elif defined (HAVE_PRAGMA_LOOP_IVDEP)
 #if defined ( _MSC_VER )
-#  define UMFPACK_IVDEP __pragma(loop( ivdep ))
+#  define UMFPACK_IVDEP __pragma(loop(ivdep))
 #else 
 #  define UMFPACK_IVDEP _Pragma("loop( ivdep )")
 #endif 
@@ -186,7 +186,7 @@
 #  define UMFPACK_NOVECTOR _Pragma("novector")
 #elif defined (HAVE_PRAGMA_LOOP_NO_VECTOR)
 #if defined ( _MSC_VER )
-#  define UMFPACK_NOVECTOR __pragma(loop( no_vector ))
+#  define UMFPACK_NOVECTOR __pragma(loop(no_vector))
 #else 
 #  define UMFPACK_NOVECTOR _Pragma("loop( no_vector )")
 #endif 

--- a/UMFPACK/Source/umf_internal.h
+++ b/UMFPACK/Source/umf_internal.h
@@ -170,7 +170,7 @@
 #  define UMFPACK_IVDEP _Pragma("ivdep")
 #elif defined (HAVE_PRAGMA_LOOP_IVDEP)
 #if defined ( _MSC_VER )
-#  define UMFPACK_IVDEP __pragma("loop( ivdep )")
+#  define UMFPACK_IVDEP __pragma(loop( ivdep ))
 #else 
 #  define UMFPACK_IVDEP _Pragma("loop( ivdep )")
 #endif 
@@ -186,7 +186,7 @@
 #  define UMFPACK_NOVECTOR _Pragma("novector")
 #elif defined (HAVE_PRAGMA_LOOP_NO_VECTOR)
 #if defined ( _MSC_VER )
-#  define UMFPACK_NOVECTOR __pragma("loop( no_vector )")
+#  define UMFPACK_NOVECTOR __pragma(loop( no_vector ))
 #else 
 #  define UMFPACK_NOVECTOR _Pragma("loop( no_vector )")
 #endif 


### PR DESCRIPTION
When building suitesparse with Visual Studio 2017, I encountered some compilation errors related to UMFPACK. After investigation, I found that it was caused by  Visual Studio 2017 not supporting c11 (_Pragma).
This PR fixed this problem.