### PR TITLE
Use same objects for linking to shared and static libraries.

### DIFF
--- a/AMD/CMakeLists.txt
+++ b/AMD/CMakeLists.txt
@@ -66,13 +66,7 @@ configure_file ( "Config/amd_version.tex.in" "${PROJECT_SOURCE_DIR}/Doc/amd_vers
     NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
-# include directories
-#-------------------------------------------------------------------------------
-
-include_directories ( Source Include )
-
-#-------------------------------------------------------------------------------
-# dynamic amd library properties
+# object library
 #-------------------------------------------------------------------------------
 
 if ( SUITESPARSE_HAS_FORTRAN )
@@ -81,8 +75,15 @@ else ( )
     file ( GLOB AMD_SOURCES "Source/*.c" )
 endif ( )
 
+add_library ( amd_obj OBJECT ${AMD_SOURCES} )
+target_include_directories ( amd_obj PRIVATE Source Include )
+
+#-------------------------------------------------------------------------------
+# dynamic amd library properties
+#-------------------------------------------------------------------------------
+
 if ( BUILD_SHARED_LIBS )
-    add_library ( AMD SHARED ${AMD_SOURCES} )
+    add_library ( AMD SHARED $<TARGET_OBJECTS:amd_obj> )
     set_target_properties ( AMD PROPERTIES
         VERSION ${AMD_VERSION_MAJOR}.${AMD_VERSION_MINOR}.${AMD_VERSION_SUB}
         C_STANDARD 11
@@ -107,7 +108,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( AMD_static STATIC ${AMD_SOURCES} )
+    add_library ( AMD_static STATIC $<TARGET_OBJECTS:amd_obj> )
     set_target_properties ( AMD_static PROPERTIES
         C_STANDARD 11
         C_STANDARD_REQUIRED ON
@@ -135,6 +136,8 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 # SuiteSparseConfig:
+target_include_directories ( amd_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( AMD PRIVATE SuiteSparse::SuiteSparseConfig )
     target_include_directories ( AMD PUBLIC

--- a/BTF/CMakeLists.txt
+++ b/BTF/CMakeLists.txt
@@ -59,19 +59,20 @@ configure_file ( "Config/btf.h.in" "${PROJECT_SOURCE_DIR}/Include/btf.h"
     NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
-# include directories
+# object library
 #-------------------------------------------------------------------------------
 
-include_directories ( Source Include )
+file ( GLOB BTF_SOURCES "Source/*.c" )
+
+add_library ( btf_obj OBJECT ${BTF_SOURCES} )
+target_include_directories ( btf_obj PRIVATE Source Include )
 
 #-------------------------------------------------------------------------------
 # dynamic btf library properties
 #-------------------------------------------------------------------------------
 
-file ( GLOB BTF_SOURCES "Source/*.c" )
-
 if ( BUILD_SHARED_LIBS )
-    add_library ( BTF SHARED ${BTF_SOURCES} )
+    add_library ( BTF SHARED $<TARGET_OBJECTS:btf_obj> )
 
     set_target_properties ( BTF PROPERTIES
         VERSION ${BTF_VERSION_MAJOR}.${BTF_VERSION_MINOR}.${BTF_VERSION_SUB}
@@ -96,7 +97,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( BTF_static STATIC ${BTF_SOURCES} )
+    add_library ( BTF_static STATIC $<TARGET_OBJECTS:btf_obj> )
 
     set_target_properties ( BTF_static PROPERTIES
         C_STANDARD 11
@@ -123,6 +124,8 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 # SuiteSparseConfig:
+target_include_directories ( btf_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_include_directories ( BTF PUBLIC
         "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )

--- a/CAMD/CMakeLists.txt
+++ b/CAMD/CMakeLists.txt
@@ -62,19 +62,20 @@ configure_file ( "Config/camd_version.tex.in"
     NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
-# include directories
+# object library
 #-------------------------------------------------------------------------------
 
-include_directories ( Source Include )
+file ( GLOB CAMD_SOURCES "Source/*.c" )
+
+add_library ( camd_obj OBJECT ${CAMD_SOURCES} )
+target_include_directories ( camd_obj PRIVATE  Source Include )
 
 #-------------------------------------------------------------------------------
 # dynamic camd library properties
 #-------------------------------------------------------------------------------
 
-file ( GLOB CAMD_SOURCES "Source/*.c" )
-
 if ( BUILD_SHARED_LIBS )
-    add_library ( CAMD SHARED ${CAMD_SOURCES} )
+    add_library ( CAMD SHARED $<TARGET_OBJECTS:camd_obj> )
 
     set_target_properties ( CAMD PROPERTIES
         VERSION ${CAMD_VERSION_MAJOR}.${CAMD_VERSION_MINOR}.${CAMD_VERSION_SUB}
@@ -99,7 +100,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( CAMD_static STATIC ${CAMD_SOURCES} )
+    add_library ( CAMD_static STATIC $<TARGET_OBJECTS:camd_obj> )
 
     set_target_properties ( CAMD_static PROPERTIES
         C_STANDARD 11
@@ -124,6 +125,9 @@ endif ( )
 #-------------------------------------------------------------------------------
 # add the library dependencies
 #-------------------------------------------------------------------------------
+
+target_include_directories ( camd_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( CAMD PRIVATE SuiteSparse::SuiteSparseConfig )

--- a/CCOLAMD/CMakeLists.txt
+++ b/CCOLAMD/CMakeLists.txt
@@ -59,19 +59,20 @@ configure_file ( "Config/ccolamd.h.in"
     NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
-# include directories
+# object library
 #-------------------------------------------------------------------------------
 
-include_directories ( Source Include )
+file ( GLOB CCOLAMD_SOURCES "Source/*.c" )
+
+add_library ( ccolamd_obj OBJECT ${CCOLAMD_SOURCES} )
+target_include_directories ( ccolamd_obj PRIVATE Source Include )
 
 #-------------------------------------------------------------------------------
 # dynamic ccolamd library properties
 #-------------------------------------------------------------------------------
 
-file ( GLOB CCOLAMD_SOURCES "Source/*.c" )
-
 if ( BUILD_SHARED_LIBS )
-    add_library ( CCOLAMD SHARED ${CCOLAMD_SOURCES} )
+    add_library ( CCOLAMD SHARED $<TARGET_OBJECTS:ccolamd_obj> )
 
     set_target_properties ( CCOLAMD PROPERTIES
         VERSION ${CCOLAMD_VERSION_MAJOR}.${CCOLAMD_VERSION_MINOR}.${CCOLAMD_VERSION_SUB}
@@ -96,7 +97,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( CCOLAMD_static STATIC ${CCOLAMD_SOURCES} )
+    add_library ( CCOLAMD_static STATIC $<TARGET_OBJECTS:ccolamd_obj> )
 
     set_target_properties ( CCOLAMD_static PROPERTIES
         OUTPUT_NAME ccolamd
@@ -122,6 +123,8 @@ endif ( )
 # add the library dependencies
 #-------------------------------------------------------------------------------
 
+target_include_directories ( ccolamd_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( CCOLAMD PRIVATE SuiteSparse::SuiteSparseConfig )
     target_include_directories ( CCOLAMD PUBLIC

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -359,22 +359,23 @@ configure_file ( "Config/cholmod_version.tex.in"
     NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
-# include directories
-#-------------------------------------------------------------------------------
-
-include_directories ( Check Cholesky Utility MatrixOps Modify Partition
-    Supernodal Include ${PROJECT_SOURCE_DIR} )
-
-#-------------------------------------------------------------------------------
-# dynamic cholmod library properties
+# object library
 #-------------------------------------------------------------------------------
 
 file ( GLOB CHOLMOD_SOURCES "Check/cholmod_*.c" "Cholesky/cholmod_*.c"
     "Utility/cholmod_*.c" "MatrixOps/cholmod_*.c" "Modify/cholmod_*.c"
     "Partition/cholmod_*.c" "Supernodal/cholmod_*.c" )
 
+add_library ( cholmod_obj OBJECT ${CHOLMOD_SOURCES} )
+target_include_directories ( cholmod_obj PRIVATE Check Cholesky Utility
+    MatrixOps Modify Partition Supernodal Include ${PROJECT_SOURCE_DIR} )
+
+#-------------------------------------------------------------------------------
+# dynamic cholmod library properties
+#-------------------------------------------------------------------------------
+
 if ( BUILD_SHARED_LIBS )
-    add_library ( CHOLMOD SHARED ${CHOLMOD_SOURCES} )
+    add_library ( CHOLMOD SHARED $<TARGET_OBJECTS:cholmod_obj> )
 
     set_target_properties ( CHOLMOD PROPERTIES
         VERSION ${CHOLMOD_VERSION_MAJOR}.${CHOLMOD_VERSION_MINOR}.${CHOLMOD_VERSION_SUB}
@@ -405,7 +406,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( CHOLMOD_static STATIC ${CHOLMOD_SOURCES} )
+    add_library ( CHOLMOD_static STATIC $<TARGET_OBJECTS:cholmod_obj> )
 
     set_target_properties ( CHOLMOD_static PROPERTIES
         C_STANDARD 11
@@ -439,6 +440,8 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 # SuiteSparseConfig:
+target_include_directories ( cholmod_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( CHOLMOD PRIVATE SuiteSparse::SuiteSparseConfig )
     target_include_directories ( CHOLMOD PUBLIC
@@ -453,6 +456,8 @@ if ( BUILD_STATIC_LIBS )
 endif ( )
 
 # AMD:
+target_include_directories ( cholmod_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::AMD,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( CHOLMOD PRIVATE SuiteSparse::AMD )
 endif ( )
@@ -465,6 +470,8 @@ if ( BUILD_STATIC_LIBS )
 endif ( )
 
 # COLAMD:
+target_include_directories ( cholmod_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::COLAMD,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( CHOLMOD PRIVATE SuiteSparse::COLAMD )
 endif ( )
@@ -478,6 +485,8 @@ endif ( )
 
 # CAMD and CCOLAMD:
 if ( CHOLMOD_CAMD )
+    target_include_directories ( cholmod_obj PRIVATE
+        "$<TARGET_PROPERTY:SuiteSparse::CAMD,INTERFACE_INCLUDE_DIRECTORIES>" )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( CHOLMOD PRIVATE SuiteSparse::CAMD )
     endif ( )
@@ -490,6 +499,8 @@ if ( CHOLMOD_CAMD )
         endif ( )
     endif ( )
 
+    target_include_directories ( cholmod_obj PRIVATE
+        "$<TARGET_PROPERTY:SuiteSparse::CCOLAMD,INTERFACE_INCLUDE_DIRECTORIES>" )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( CHOLMOD PRIVATE SuiteSparse::CCOLAMD )
     endif ( )
@@ -508,6 +519,7 @@ if ( CHOLMOD_HAS_OPENMP )
     message ( STATUS "OpenMP C libraries:      ${OpenMP_C_LIBRARIES}" )
     message ( STATUS "OpenMP C include:        ${OpenMP_C_INCLUDE_DIRS}" )
     message ( STATUS "OpenMP C flags:          ${OpenMP_C_FLAGS}" )
+    target_link_libraries ( cholmod_obj PRIVATE OpenMP::OpenMP_C )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( CHOLMOD PRIVATE OpenMP::OpenMP_C )
     endif ( )
@@ -548,7 +560,7 @@ if ( CHOLMOD_SUPERNODAL )
         list ( APPEND CHOLMOD_STATIC_LIBS ${LAPACK_LIBRARIES} )
         target_link_libraries ( CHOLMOD_static PRIVATE ${LAPACK_LIBRARIES} )
     endif ( )
-    include_directories ( ${LAPACK_INCLUDE_DIR} )
+    target_include_directories ( cholmod_obj PRIVATE ${LAPACK_INCLUDE_DIR} )
 
     # BLAS:
     message ( STATUS "BLAS libraries:      ${BLAS_LIBRARIES}" )
@@ -561,14 +573,15 @@ if ( CHOLMOD_SUPERNODAL )
         list ( APPEND CHOLMOD_STATIC_LIBS ${BLAS_LIBRARIES} )
         target_link_libraries ( CHOLMOD_static PRIVATE ${BLAS_LIBRARIES} )
     endif ( )
-    include_directories ( ${BLAS_INCLUDE_DIRS} )
+    target_include_directories ( cholmod_obj PRIVATE ${BLAS_INCLUDE_DIRS} )
 endif ( )
 
 # METIS and the Partition module:
 if ( CHOLMOD_PARTITION )
-    include_directories ( SuiteSparse_metis/GKlib )
-    include_directories ( SuiteSparse_metis/libmetis )
-    include_directories ( SuiteSparse_metis/include )
+    target_include_directories ( cholmod_obj PRIVATE
+        SuiteSparse_metis/GKlib
+        SuiteSparse_metis/libmetis
+        SuiteSparse_metis/include )
 endif ( )
 
 # CHOLMOD_CUDA
@@ -582,6 +595,8 @@ if ( CHOLMOD_HAS_CUDA )
 #   if ( BUILD_STATIC_LIBS )
 #       target_compile_definitions ( CHOLMOD_static PUBLIC "CHOLMOD_HAS_CUDA" )
 #   endif ( )
+    target_link_libraries ( cholmod_obj PRIVATE
+        CUDA::nvrtc CUDA::cudart_static CUDA::cublas )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( CHOLMOD PRIVATE CUDA::nvrtc CUDA::cudart_static CUDA::cublas )
         target_include_directories ( CHOLMOD INTERFACE
@@ -610,6 +625,7 @@ if ( CHOLMOD_HAS_CUDA )
     set ( CMAKE_EXTRA_INCLUDE_FILES ${_orig_CMAKE_EXTRA_INCLUDE_FILES} )
 
     if ( NOT HAVE_COMPAR_FN_T )
+        target_compile_definitions ( cholmod_obj PRIVATE NCOMPAR_FN_T )
         if ( BUILD_SHARED_LIBS )
             target_compile_definitions ( CHOLMOD PRIVATE NCOMPAR_FN_T )
         endif ( )

--- a/CHOLMOD/GPU/CMakeLists.txt
+++ b/CHOLMOD/GPU/CMakeLists.txt
@@ -28,13 +28,7 @@ message ( STATUS "nvcc flags for CUDA: ${CMAKE_CUDA_FLAGS}" )
 file ( GLOB CHOLMOD_CUDA_SOURCES "cholmod_gpu.c" "cholmod_l_gpu.c"
     "cholmod_gpu_kernels.cu" )
 
-if ( BUILD_SHARED_LIBS )
-    target_sources ( CHOLMOD PRIVATE ${CHOLMOD_CUDA_SOURCES} )
-endif ( )
-
-if ( BUILD_STATIC_LIBS )
-    target_sources ( CHOLMOD_static PRIVATE ${CHOLMOD_CUDA_SOURCES} )
-endif ( )
+target_sources ( cholmod_obj PRIVATE ${CHOLMOD_CUDA_SOURCES} )
 
 set ( CHOLMOD_CUDA_INCLUDES
         ../Check
@@ -45,12 +39,13 @@ set ( CHOLMOD_CUDA_INCLUDES
         ../Include
         ../GPU )
 
-include_directories ( ${CHOLMOD_CUDA_INCLUDES} ${CUDAToolkit_INCLUDE_DIRS} )
+target_include_directories ( cholmod_obj PRIVATE
+    ${CHOLMOD_CUDA_INCLUDES} ${CUDAToolkit_INCLUDE_DIRS} )
+set_target_properties ( cholmod_obj PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    CUDA_SEPARABLE_COMPILATION ON )
 
 if ( BUILD_SHARED_LIBS )
-    target_include_directories ( CHOLMOD PRIVATE
-        ${CUDAToolkit_INCLUDE_DIRS}
-        ${CHOLMOD_CUDA_INCLUDES} )
     set_target_properties ( CHOLMOD PROPERTIES POSITION_INDEPENDENT_CODE ON )
     set_target_properties ( CHOLMOD PROPERTIES CUDA_SEPARABLE_COMPILATION ON )
 #   target_compile_definitions ( CHOLMOD PUBLIC "CHOLMOD_HAS_CUDA" )
@@ -60,16 +55,7 @@ if ( BUILD_STATIC_LIBS )
     target_include_directories ( CHOLMOD_static PRIVATE
         ${CUDAToolkit_INCLUDE_DIRS}
         ${CHOLMOD_CUDA_INCLUDES} )
-    set_target_properties ( CHOLMOD_static PROPERTIES CUDA_SEPARABLE_COMPILATION on )
-    set_target_properties ( CHOLMOD_static PROPERTIES POSITION_INDEPENDENT_CODE on )
+    set_target_properties ( CHOLMOD_static PROPERTIES CUDA_SEPARABLE_COMPILATION ON )
+    set_target_properties ( CHOLMOD_static PROPERTIES POSITION_INDEPENDENT_CODE ON )
 #   target_compile_definitions ( CHOLMOD_static PUBLIC "CHOLMOD_HAS_CUDA" )
-endif ( )
-
-if ( BUILD_SHARED_LIBS )
-    target_link_libraries ( CHOLMOD PRIVATE
-        CUDA::nvrtc CUDA::cudart_static CUDA::cublas )
-endif ( )
-if ( BUILD_STATIC_LIBS )
-    target_link_libraries ( CHOLMOD_static PRIVATE
-        CUDA::nvrtc CUDA::cudart_static CUDA::cublas )
 endif ( )

--- a/COLAMD/CMakeLists.txt
+++ b/COLAMD/CMakeLists.txt
@@ -59,19 +59,20 @@ configure_file ( "Config/colamd.h.in"
     NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
-# include directories
+# object library
 #-------------------------------------------------------------------------------
 
-include_directories ( Source Include )
+file ( GLOB COLAMD_SOURCES "Source/*.c" )
+
+add_library ( colamd_obj OBJECT ${COLAMD_SOURCES} )
+target_include_directories ( colamd_obj PRIVATE Source Include )
 
 #-------------------------------------------------------------------------------
 # dynamic colamd library properties
 #-------------------------------------------------------------------------------
 
-file ( GLOB COLAMD_SOURCES "Source/*.c" )
-
 if ( BUILD_SHARED_LIBS )
-    add_library ( COLAMD SHARED ${COLAMD_SOURCES} )
+    add_library ( COLAMD SHARED $<TARGET_OBJECTS:colamd_obj> )
 
     set_target_properties ( COLAMD PROPERTIES
         VERSION ${COLAMD_VERSION_MAJOR}.${COLAMD_VERSION_MINOR}.${COLAMD_VERSION_SUB}
@@ -96,7 +97,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( COLAMD_static STATIC ${COLAMD_SOURCES} )
+    add_library ( COLAMD_static STATIC $<TARGET_OBJECTS:colamd_obj> )
 
     set_target_properties ( COLAMD_static PROPERTIES
         OUTPUT_NAME colamd
@@ -122,6 +123,8 @@ endif ( )
 # add the library dependencies
 #-------------------------------------------------------------------------------
 
+target_include_directories ( colamd_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( COLAMD PRIVATE SuiteSparse::SuiteSparseConfig )
     target_include_directories ( COLAMD PUBLIC

--- a/CSparse/CMakeLists.txt
+++ b/CSparse/CMakeLists.txt
@@ -76,20 +76,24 @@ configure_file ( "Config/cs.h.in"
     NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
-# include directories
+# object library
 #-------------------------------------------------------------------------------
 
-set ( CMAKE_INCLUDE_CURRENT_DIR ON )
-include_directories ( Source Include )
+file ( GLOB CSPARSE_SOURCES "Source/*.c" )
+
+add_library ( csparse_obj OBJECT ${CSPARSE_SOURCES} )
+target_include_directories ( csparse_obj PRIVATE Source Include )
+
+set_target_properties ( csparse_obj PROPERTIES
+    C_STANDARD 11
+    C_STANDARD_REQUIRED ON )
 
 #-------------------------------------------------------------------------------
 # dynamic csparse library properties
 #-------------------------------------------------------------------------------
 
-file ( GLOB CSPARSE_SOURCES "Source/*.c" )
-
 if ( BUILD_SHARED_LIBS )
-    add_library ( csparse SHARED ${CSPARSE_SOURCES} )
+    add_library ( csparse SHARED $<TARGET_OBJECTS:csparse_obj> )
 
     set_target_properties ( csparse PROPERTIES
         VERSION ${CSPARSE_VERSION_MAJOR}.${CSPARSE_VERSION_MINOR}.${CSPARSE_VERSION_SUB}
@@ -98,6 +102,10 @@ if ( BUILD_SHARED_LIBS )
         SOVERSION ${CSPARSE_VERSION_MAJOR}
         PUBLIC_HEADER "Include/cs.h"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
+
+    target_include_directories ( csparse
+        INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
+                  $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -105,7 +113,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( csparse_static STATIC ${CSPARSE_SOURCES} )
+    add_library ( csparse_static STATIC $<TARGET_OBJECTS:csparse_obj> )
 
     set_target_properties ( csparse_static PROPERTIES
         OUTPUT_NAME csparse
@@ -117,6 +125,10 @@ if ( BUILD_STATIC_LIBS )
         set_target_properties ( csparse_static PROPERTIES
             OUTPUT_NAME csparse_static )
     endif ( )
+
+    target_include_directories ( csparse_static
+        INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
+                  $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/CXSparse/CMakeLists.txt
+++ b/CXSparse/CMakeLists.txt
@@ -86,13 +86,7 @@ configure_file ( "Config/cs.h.in"
     NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
-# include directories
-#-------------------------------------------------------------------------------
-
-include_directories ( Source Include )
-
-#-------------------------------------------------------------------------------
-# dynamic cxsparse library properties
+# object library
 #-------------------------------------------------------------------------------
 
 if ( CXSPARSE_HAS_COMPLEX )
@@ -110,8 +104,15 @@ else ( )
         )
 endif ( )
 
+add_library ( cxsparse_obj OBJECT ${CXSPARSE_SOURCES} )
+target_include_directories ( cxsparse_obj PRIVATE Source Include )
+
+#-------------------------------------------------------------------------------
+# dynamic cxsparse library properties
+#-------------------------------------------------------------------------------
+
 if ( BUILD_SHARED_LIBS )
-    add_library ( CXSparse SHARED ${CXSPARSE_SOURCES} )
+    add_library ( CXSparse SHARED $<TARGET_OBJECTS:cxsparse_obj> )
 
     set_target_properties ( CXSparse PROPERTIES
         VERSION ${CXSPARSE_VERSION_MAJOR}.${CXSPARSE_VERSION_MINOR}.${CXSPARSE_VERSION_SUB}
@@ -136,7 +137,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( CXSparse_static STATIC ${CXSPARSE_SOURCES} )
+    add_library ( CXSparse_static STATIC $<TARGET_OBJECTS:cxsparse_obj> )
 
     set_target_properties ( CXSparse_static PROPERTIES
         OUTPUT_NAME cxsparse
@@ -162,6 +163,8 @@ endif ( )
 # add the library dependencies
 #-------------------------------------------------------------------------------
 
+target_include_directories ( cxsparse_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( CXSparse PRIVATE SuiteSparse::SuiteSparseConfig )
     target_include_directories ( CXSparse PUBLIC

--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -117,19 +117,25 @@ configure_file ( "Config/klu_version.tex.in"
     NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
-# include directories
+# object library
 #-------------------------------------------------------------------------------
 
-include_directories ( Source Include User )
+file ( GLOB KLU_SOURCES "Source/*.c" )
+
+add_library ( klu_obj OBJECT ${KLU_SOURCES} )
+target_include_directories ( klu_obj PRIVATE Source Include User )
+
+set_target_properties ( klu_obj PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    C_STANDARD 11
+    C_STANDARD_REQUIRED ON )
 
 #-------------------------------------------------------------------------------
 # dynamic klu library properties
 #-------------------------------------------------------------------------------
 
-file ( GLOB KLU_SOURCES "Source/*.c" )
-
 if ( BUILD_SHARED_LIBS )
-    add_library ( KLU SHARED ${KLU_SOURCES} )
+    add_library ( KLU SHARED $<TARGET_OBJECTS:klu_obj> )
 
     set_target_properties ( KLU PROPERTIES
         VERSION ${KLU_VERSION_MAJOR}.${KLU_VERSION_MINOR}.${KLU_VERSION_SUB}
@@ -154,7 +160,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( KLU_static STATIC ${KLU_SOURCES} )
+    add_library ( KLU_static STATIC $<TARGET_OBJECTS:klu_obj> )
 
     set_target_properties ( KLU_static PROPERTIES
         C_STANDARD 11
@@ -184,8 +190,15 @@ if ( KLU_HAS_CHOLMOD )
 
     file ( GLOB KLU_CHOLMOD_SOURCES "User/*.c" )
 
+    add_library ( klu_cholmod_obj OBJECT ${KLU_CHOLMOD_SOURCES} )
+    target_include_directories ( klu_cholmod_obj PRIVATE Source Include User )
+    set_target_properties ( klu_cholmod_obj PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        C_STANDARD 11
+        C_STANDARD_REQUIRED ON )
+
     if ( BUILD_SHARED_LIBS )
-        add_library ( KLU_CHOLMOD SHARED ${KLU_CHOLMOD_SOURCES} )
+        add_library ( KLU_CHOLMOD SHARED $<TARGET_OBJECTS:klu_cholmod_obj> )
 
         set_target_properties ( KLU_CHOLMOD PROPERTIES
             VERSION ${KLU_VERSION_MAJOR}.${KLU_VERSION_MINOR}.${KLU_VERSION_SUB}
@@ -201,11 +214,12 @@ if ( KLU_HAS_CHOLMOD )
 
         target_include_directories ( KLU_CHOLMOD
             INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
+                      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/User>
                       $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
     endif ( )
 
     if ( BUILD_STATIC_LIBS )
-        add_library ( KLU_CHOLMOD_static STATIC ${KLU_CHOLMOD_SOURCES} )
+        add_library ( KLU_CHOLMOD_static STATIC $<TARGET_OBJECTS:klu_cholmod_obj> )
 
         set_target_properties ( KLU_CHOLMOD_static PROPERTIES
             C_STANDARD 11
@@ -224,6 +238,7 @@ if ( KLU_HAS_CHOLMOD )
 
         target_include_directories ( KLU_CHOLMOD_static
             INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
+                      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/User>
                       $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
     endif ( )
 
@@ -234,6 +249,8 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 # SuiteSparseConfig:
+target_include_directories ( klu_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( KLU PRIVATE SuiteSparse::SuiteSparseConfig )
 endif ( )
@@ -246,6 +263,8 @@ if ( BUILD_STATIC_LIBS )
 endif ( )
 
 # AMD:
+target_include_directories ( klu_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::AMD,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( KLU PRIVATE SuiteSparse::AMD )
     target_include_directories ( KLU PUBLIC
@@ -260,6 +279,8 @@ if ( BUILD_STATIC_LIBS )
 endif ( )
 
 # COLAMD:
+target_include_directories ( klu_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::COLAMD,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( KLU PRIVATE SuiteSparse::COLAMD )
     target_include_directories ( KLU PUBLIC
@@ -274,6 +295,8 @@ if ( BUILD_STATIC_LIBS )
 endif ( )
 
 # BTF:
+target_include_directories ( klu_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::BTF,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( KLU PRIVATE SuiteSparse::BTF )
     target_include_directories ( KLU PUBLIC
@@ -292,6 +315,8 @@ if ( KLU_HAS_CHOLMOD )
     # CHOLMOD:
     # link with CHOLMOD and its dependencies, both required and optional
     # CHOLMOD without CUDA
+    target_include_directories ( klu_cholmod_obj PRIVATE
+        "$<TARGET_PROPERTY:SuiteSparse::CHOLMOD,INTERFACE_INCLUDE_DIRECTORIES>" )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( KLU_CHOLMOD PRIVATE SuiteSparse::CHOLMOD )
     endif ( )
@@ -305,6 +330,8 @@ if ( KLU_HAS_CHOLMOD )
     endif ( )
 
     # klu:
+    target_include_directories ( klu_cholmod_obj PRIVATE
+        "$<TARGET_PROPERTY:KLU,INTERFACE_INCLUDE_DIRECTORIES>" )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( KLU_CHOLMOD PRIVATE KLU )
     endif ( )

--- a/LDL/CMakeLists.txt
+++ b/LDL/CMakeLists.txt
@@ -42,7 +42,6 @@ include ( SuiteSparsePolicy )
 # find library dependencies
 #-------------------------------------------------------------------------------
 
-
 if ( NOT SUITESPARSE_ROOT_CMAKELISTS )
     find_package ( SuiteSparse_config 7.7.0
         PATHS ${CMAKE_SOURCE_DIR}/../SuiteSparse_config/build NO_DEFAULT_PATH )
@@ -71,19 +70,20 @@ configure_file ( "Config/ldl_version.tex.in"
     NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
-# include directories
+# object library
 #-------------------------------------------------------------------------------
 
-include_directories ( Source Include )
+file ( GLOB LDL_SOURCES "Source/*.c" )
+
+add_library ( ldl_obj OBJECT ${LDL_SOURCES} )
+target_include_directories ( ldl_obj PRIVATE Source Include )
 
 #-------------------------------------------------------------------------------
 # dynamic ldl library properties
 #-------------------------------------------------------------------------------
 
-file ( GLOB LDL_SOURCES "Source/*.c" )
-
 if ( BUILD_SHARED_LIBS )
-    add_library ( LDL SHARED ${LDL_SOURCES} )
+    add_library ( LDL SHARED $<TARGET_OBJECTS:ldl_obj> )
 
     set_target_properties ( LDL PROPERTIES
         VERSION ${LDL_VERSION_MAJOR}.${LDL_VERSION_MINOR}.${LDL_VERSION_SUB}
@@ -108,7 +108,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( LDL_static STATIC ${LDL_SOURCES} )
+    add_library ( LDL_static STATIC $<TARGET_OBJECTS:ldl_obj> )
 
     set_target_properties ( LDL_static PROPERTIES
         C_STANDARD 11
@@ -134,6 +134,8 @@ endif ( )
 # add the library dependencies
 #-------------------------------------------------------------------------------
 
+target_include_directories ( ldl_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_include_directories ( LDL PUBLIC
         "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -129,16 +129,21 @@ configure_file ( "Config/paru_version.tex.in"
     "${PROJECT_SOURCE_DIR}/Doc/paru_version.tex"
     NEWLINE_STYLE LF )
 
-include_directories ( Source Include )
+#-------------------------------------------------------------------------------
+# object library
+#-------------------------------------------------------------------------------
+
+file ( GLOB PARU_SOURCES "Source/*.cpp" )
+
+add_library ( paru_obj OBJECT ${PARU_SOURCES} )
+target_include_directories ( paru_obj PRIVATE Source Include )
 
 #-------------------------------------------------------------------------------
 # dynamic paru library properties
 #-------------------------------------------------------------------------------
 
-file ( GLOB PARU_SOURCES "Source/*.cpp" )
-
 if ( BUILD_SHARED_LIBS )
-    add_library ( ParU SHARED ${PARU_SOURCES} )
+    add_library ( ParU SHARED $<TARGET_OBJECTS:paru_obj> )
 
     set_target_properties ( ParU PROPERTIES
         VERSION ${PARU_VERSION_MAJOR}.${PARU_VERSION_MINOR}.${PARU_VERSION_UPDATE}
@@ -163,7 +168,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( ParU_static STATIC ${PARU_SOURCES} )
+    add_library ( ParU_static STATIC $<TARGET_OBJECTS:paru_obj> )
 
     set_target_properties ( ParU_static PROPERTIES
         CXX_STANDARD 11
@@ -195,12 +200,7 @@ if (( NOT PARU_HAS_OPENMP ) OR
     # Some parallelization levels don't work correctly with GCC on Windows or
     # Mac (because of emuTLS?). Omit them.  See the user guide for details.
     message ( STATUS "ParU frontal tree tasking: sequential")
-    if ( BUILD_SHARED_LIBS )
-        target_compile_definitions (ParU PRIVATE PARU_1TASK )
-    endif ( )
-    if ( BUILD_STATIC_LIBS )
-        target_compile_definitions (ParU_static PRIVATE PARU_1TASK )
-    endif ( )
+    target_compile_definitions (paru_obj PRIVATE PARU_1TASK )
 else ( )
     message ( STATUS "ParU frontal tree tasking: parallel")
 endif ( )
@@ -210,6 +210,8 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 # suitesparseconfig:
+target_include_directories ( paru_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( ParU PRIVATE SuiteSparse::SuiteSparseConfig )
     target_include_directories ( ParU PUBLIC
@@ -224,6 +226,8 @@ if ( BUILD_STATIC_LIBS )
 endif ( )
 
 # umfpack:
+target_include_directories ( paru_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::UMFPACK,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( ParU PRIVATE SuiteSparse::UMFPACK )
     target_include_directories ( ParU PUBLIC
@@ -238,6 +242,8 @@ if ( BUILD_STATIC_LIBS )
 endif ( )
 
 # cholmod:
+target_include_directories ( paru_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::CHOLMOD,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_include_directories ( ParU PUBLIC
         "$<TARGET_PROPERTY:SuiteSparse::CHOLMOD,INTERFACE_INCLUDE_DIRECTORIES>" )
@@ -252,6 +258,7 @@ if ( PARU_HAS_OPENMP )
     message ( STATUS "OpenMP C++ libraries:    ${OpenMP_CXX_LIBRARIES} ")
     message ( STATUS "OpenMP C++ include:      ${OpenMP_CXX_INCLUDE_DIRS} ")
     message ( STATUS "OpenMP C++ flags:        ${OpenMP_CXX_FLAGS} ")
+    target_include_directories ( paru_obj PRIVATE OpenMP::OpenMP_CXX )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( ParU PRIVATE OpenMP::OpenMP_CXX )
     endif ( )
@@ -275,14 +282,13 @@ endif ( )
 # BLAS:
 message ( STATUS "BLAS libraries:      ${BLAS_LIBRARIES} ")
 message ( STATUS "BLAS linker flags:   ${BLAS_LINKER_FLAGS} ")
+target_include_directories ( paru_obj PRIVATE ${BLAS_INCLUDE_DIRS} )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( ParU PRIVATE ${BLAS_LIBRARIES} )
-    target_include_directories ( ParU PRIVATE ${BLAS_INCLUDE_DIRS} )
 endif ( )
 if ( BUILD_STATIC_LIBS )
     list ( APPEND PARU_STATIC_LIBS ${BLAS_LIBRARIES} )
     target_link_libraries ( ParU_static PUBLIC ${BLAS_LIBRARIES} )
-    target_include_directories ( ParU_static PRIVATE ${BLAS_INCLUDE_DIRS} )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/RBio/CMakeLists.txt
+++ b/RBio/CMakeLists.txt
@@ -59,19 +59,20 @@ configure_file ( "Config/RBio.h.in"
     NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
-# include directories
+# object library
 #-------------------------------------------------------------------------------
 
-include_directories ( Source Include )
+file ( GLOB RBIO_SOURCES "Source/*.c" )
+
+add_library ( rbio_obj OBJECT ${RBIO_SOURCES} )
+target_include_directories ( rbio_obj PRIVATE Source Include )
 
 #-------------------------------------------------------------------------------
 # dynamic rbio library properties
 #-------------------------------------------------------------------------------
 
-file ( GLOB RBIO_SOURCES "Source/*.c" )
-
 if ( BUILD_SHARED_LIBS )
-    add_library ( RBio SHARED ${RBIO_SOURCES} )
+    add_library ( RBio SHARED $<TARGET_OBJECTS:rbio_obj> )
 
     set_target_properties ( RBio PROPERTIES
         VERSION ${RBIO_VERSION_MAJOR}.${RBIO_VERSION_MINOR}.${RBIO_VERSION_SUB}
@@ -96,7 +97,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( RBio_static STATIC ${RBIO_SOURCES} )
+    add_library ( RBio_static STATIC $<TARGET_OBJECTS:rbio_obj> )
 
     set_target_properties ( RBio_static PROPERTIES
         C_STANDARD 11
@@ -123,6 +124,8 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 # SuiteSparseConfig:
+target_include_directories ( rbio_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( RBio PRIVATE SuiteSparse::SuiteSparseConfig )
     target_include_directories ( RBio PUBLIC

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -108,10 +108,13 @@ configure_file ( "Config/SPEX_version.tex.in"
     NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
-# include directories
+# object library
 #-------------------------------------------------------------------------------
 
-include_directories ( Include
+file ( GLOB SPEX_SOURCES "SPEX*/Source/*.c" )
+
+add_library ( spex_obj OBJECT ${SPEX_SOURCES} )
+target_include_directories ( spex_obj PRIVATE Include
     SPEX_Backslash/Source SPEX_Cholesky/Source SPEX_LU/Source
     SPEX_Utilities/Source
     ${SUITESPARSE_CONFIG_INCLUDE_DIR}
@@ -122,10 +125,8 @@ include_directories ( Include
 # dynamic spex library properties
 #-------------------------------------------------------------------------------
 
-file ( GLOB SPEX_SOURCES "SPEX*/Source/*.c" )
-
 if ( BUILD_SHARED_LIBS )
-    add_library ( SPEX SHARED ${SPEX_SOURCES} )
+    add_library ( SPEX SHARED $<TARGET_OBJECTS:spex_obj> )
 
     set_target_properties ( SPEX PROPERTIES
         VERSION ${SPEX_VERSION_MAJOR}.${SPEX_VERSION_MINOR}.${SPEX_VERSION_SUB}
@@ -150,7 +151,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( SPEX_static STATIC ${SPEX_SOURCES} )
+    add_library ( SPEX_static STATIC $<TARGET_OBJECTS:spex_obj> )
 
     set_target_properties ( SPEX_static PROPERTIES
         C_STANDARD 11
@@ -177,6 +178,8 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 # SuiteSparseConfig:
+target_include_directories ( spex_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( SPEX PRIVATE SuiteSparse::SuiteSparseConfig )
     target_include_directories ( SPEX PUBLIC
@@ -191,6 +194,8 @@ if ( BUILD_STATIC_LIBS )
 endif ( )
 
 # AMD:
+target_include_directories ( spex_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::AMD,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( SPEX PRIVATE SuiteSparse::AMD )
 endif ( )
@@ -203,6 +208,8 @@ if ( BUILD_STATIC_LIBS )
 endif ( )
 
 # COLAMD:
+target_include_directories ( spex_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::COLAMD,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( SPEX PRIVATE SuiteSparse::COLAMD )
 endif ( )
@@ -215,6 +222,7 @@ if ( BUILD_STATIC_LIBS )
 endif ( )
 
 # MPFR:
+target_include_directories ( spex_obj  SYSTEM AFTER PRIVATE ${MPFR_INCLUDE_DIR} )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( SPEX PRIVATE ${MPFR_LIBRARIES} )
     target_include_directories ( SPEX SYSTEM AFTER PUBLIC ${MPFR_INCLUDE_DIR} )
@@ -227,6 +235,7 @@ endif ( )
 
 # GMP:
 # must occur after MPFR
+target_include_directories ( spex_obj  SYSTEM AFTER PRIVATE ${GMP_INCLUDE_DIR} )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( SPEX PRIVATE ${GMP_LIBRARIES} )
     target_include_directories ( SPEX SYSTEM AFTER PUBLIC ${GMP_INCLUDE_DIR} )
@@ -242,6 +251,7 @@ if ( SPEX_HAS_OPENMP )
     message ( STATUS "OpenMP C libraries:      ${OpenMP_C_LIBRARIES}" )
     message ( STATUS "OpenMP C include:        ${OpenMP_C_INCLUDE_DIRS}" )
     message ( STATUS "OpenMP C flags:          ${OpenMP_C_FLAGS}" )
+    target_link_libraries ( spex_obj PRIVATE OpenMP::OpenMP_C )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( SPEX PRIVATE OpenMP::OpenMP_C )
     endif ( )
@@ -439,6 +449,9 @@ if ( SPEX_HAS_PYTHON )
 
     file ( GLOB SPEX_PYTHON_SOURCES "Python/SPEXpy/Source/*.c" )
     add_library ( spexpython SHARED ${SPEX_PYTHON_SOURCES} )
+
+    target_include_directories ( spexpython PRIVATE
+        SPEX_Cholesky/Source SPEX_Utilities/Source )
 
     set_target_properties ( spexpython PROPERTIES
         VERSION ${SPEX_VERSION_MAJOR}.${SPEX_VERSION_MINOR}.${SPEX_VERSION_SUB}

--- a/SPQR/CMakeLists.txt
+++ b/SPQR/CMakeLists.txt
@@ -96,13 +96,20 @@ configure_file ( "Config/spqr_version.tex.in"
     NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
-# dynamic spqr library properties
+# object library
 #-------------------------------------------------------------------------------
 
 file ( GLOB SPQR_SOURCES "Source/spqr_*.cpp" "Source/SuiteSparseQR*.cpp" )
 
+add_library ( spqr_obj OBJECT ${SPQR_SOURCES} )
+target_include_directories ( spqr_obj PRIVATE Source Include )
+
+#-------------------------------------------------------------------------------
+# dynamic spqr library properties
+#-------------------------------------------------------------------------------
+
 if ( BUILD_SHARED_LIBS )
-    add_library ( SPQR SHARED ${SPQR_SOURCES} )
+    add_library ( SPQR SHARED $<TARGET_OBJECTS:spqr_obj> )
 
     set_target_properties ( SPQR PROPERTIES
         VERSION ${SPQR_VERSION_MAJOR}.${SPQR_VERSION_MINOR}.${SPQR_VERSION_SUB}
@@ -119,7 +126,6 @@ if ( BUILD_SHARED_LIBS )
     endif ( )
 
     target_include_directories ( SPQR 
-        PRIVATE Source Include
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 endif ( )
@@ -129,7 +135,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( SPQR_static STATIC ${SPQR_SOURCES} )
+    add_library ( SPQR_static STATIC $<TARGET_OBJECTS:spqr_obj> )
 
     set_target_properties ( SPQR_static PROPERTIES
         CXX_STANDARD 11
@@ -148,7 +154,6 @@ if ( BUILD_STATIC_LIBS )
     endif ( )
 
     target_include_directories ( SPQR_static 
-        PRIVATE Source Include
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
                   $<INSTALL_INTERFACE:${SUITESPARSE_INCLUDEDIR}> )
 endif ( )
@@ -158,6 +163,8 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 # SuiteSparseConfig:
+target_include_directories ( spqr_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( SPQR PRIVATE SuiteSparse::SuiteSparseConfig )
 endif ( )
@@ -171,6 +178,8 @@ endif ( )
 
 # CHOLMOD:
 # link with CHOLMOD and its dependencies
+target_include_directories ( spqr_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::CHOLMOD,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( SPQR PRIVATE SuiteSparse::CHOLMOD )
 endif ( )
@@ -183,6 +192,8 @@ if ( BUILD_STATIC_LIBS )
 endif ( )
 
 if ( SPQR_HAS_CUDA )
+    target_link_libraries ( spqr_obj PRIVATE GPUQREngine GPURuntime )
+    target_compile_definitions ( spqr_obj PRIVATE "SPQR_HAS_CUDA" )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( SPQR PRIVATE GPUQREngine GPURuntime )
         target_compile_definitions ( SPQR PUBLIC "SPQR_HAS_CUDA" )
@@ -215,28 +226,26 @@ endif ( )
 message ( STATUS "LAPACK libraries:    ${LAPACK_LIBRARIES} ")
 message ( STATUS "LAPACK include:      ${LAPACK_INCLUDE_DIRS} ")
 message ( STATUS "LAPACK linker flags: ${LAPACK_LINKER_FLAGS} ")
+target_include_directories ( spqr_obj PRIVATE ${LAPACK_INCLUDE_DIR} )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( SPQR PRIVATE ${LAPACK_LIBRARIES} )
-    target_include_directories ( SPQR PRIVATE ${LAPACK_INCLUDE_DIR} )
 endif ( )
 if ( BUILD_STATIC_LIBS )
     list ( APPEND SPQR_STATIC_LIBS ${LAPACK_LIBRARIES} )
     target_link_libraries ( SPQR_static PUBLIC ${LAPACK_LIBRARIES} )
-    target_include_directories ( SPQR_static PRIVATE ${LAPACK_INCLUDE_DIR} )
 endif ( )
 
 # BLAS:
 message ( STATUS "BLAS libraries:      ${BLAS_LIBRARIES} ")
 message ( STATUS "BLAS include:        ${BLAS_INCLUDE_DIRS} ")
 message ( STATUS "BLAS linker flags:   ${BLAS_LINKER_FLAGS} ")
+target_include_directories ( spqr_obj PRIVATE ${BLAS_INCLUDE_DIRS} )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( SPQR PRIVATE ${BLAS_LIBRARIES} )
-    target_include_directories ( SPQR PRIVATE ${BLAS_INCLUDE_DIRS} )
 endif ( )
 if ( BUILD_STATIC_LIBS )
     list ( APPEND SPQR_STATIC_LIBS ${BLAS_LIBRARIES} )
     target_link_libraries ( SPQR_static PUBLIC ${BLAS_LIBRARIES} )
-    target_include_directories ( SPQR_static PRIVATE ${BLAS_INCLUDE_DIRS} )
 endif ( )
 
 #-------------------------------------------------------------------------------

--- a/SPQR/GPUQREngine/CMakeLists.txt
+++ b/SPQR/GPUQREngine/CMakeLists.txt
@@ -65,6 +65,8 @@ configure_file ( "Config/GPUQREngine.hpp.in"
     NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
+# object library
+#-------------------------------------------------------------------------------
 
 file ( GLOB GPUQRENGINE_SOURCES "Source/*.cpp"
     "Source/*.cu"
@@ -76,12 +78,25 @@ file ( GLOB GPUQRENGINE_SOURCES "Source/*.cpp"
 set ( GPUQRENGINE_INCLUDES Include Include/Kernel
     Include/Kernel/Apply Include/Kernel/Assemble Include/Kernel/Factorize )
 
+add_library ( gpuqrengine_obj OBJECT ${GPUQRENGINE_SOURCES} )
+target_include_directories ( gpuqrengine_obj PRIVATE ${GPUQRENGINE_INCLUDES} )
+
+target_compile_definitions ( gpuqrengine_obj PRIVATE "SPQR_HAS_CUDA" )
+
+target_include_directories ( gpuqrengine_obj PRIVATE
+    "$<TARGET_PROPERTY:gpuruntime_obj,INTERFACE_INCLUDE_DIRECTORIES>"
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
+
+set_target_properties ( gpuqrengine_obj PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON )
+
 #-------------------------------------------------------------------------------
 # dynamic gpuqrengine library properties
 #-------------------------------------------------------------------------------
 
 if ( BUILD_SHARED_LIBS )
-    add_library ( GPUQREngine SHARED ${GPUQRENGINE_SOURCES} )
+    add_library ( GPUQREngine SHARED $<TARGET_OBJECTS:gpuqrengine_obj> )
 
     set_target_properties ( GPUQREngine PROPERTIES
         VERSION ${SPQR_VERSION_MAJOR}.${SPQR_VERSION_MINOR}.${SPQR_VERSION_SUB}
@@ -91,9 +106,6 @@ if ( BUILD_SHARED_LIBS )
         SOVERSION ${SPQR_VERSION_MAJOR}
         PUBLIC_HEADER "Include/GPUQREngine.hpp"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
-
-    target_include_directories ( GPUQREngine PRIVATE
-        ${GPUQRENGINE_INCLUDES} )
 
     target_link_libraries ( GPUQREngine PRIVATE
         GPURuntime SuiteSparse::SuiteSparseConfig )
@@ -105,7 +117,6 @@ if ( BUILD_SHARED_LIBS )
         CUDA_RUNTIME_LIBRARY Static )
     target_link_libraries ( GPUQREngine PRIVATE
         CUDA::nvrtc CUDA::cudart_static CUDA::cublas )
-    target_compile_definitions ( GPUQREngine PRIVATE "SPQR_HAS_CUDA" )
 
     target_include_directories ( GPUQREngine
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
@@ -117,7 +128,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( GPUQREngine_static STATIC ${GPUQRENGINE_SOURCES} )
+    add_library ( GPUQREngine_static STATIC $<TARGET_OBJECTS:gpuqrengine_obj> )
 
     set_target_properties ( GPUQREngine_static PROPERTIES
         CXX_STANDARD 17
@@ -129,10 +140,6 @@ if ( BUILD_STATIC_LIBS )
         set_target_properties ( GPUQREngine_static PROPERTIES
             OUTPUT_NAME gpuqrengine_static )
     endif ( )
-
-    target_include_directories ( GPUQREngine_static PRIVATE
-        ${CUDAToolkit_INCLUDE_DIRS}
-        ${GPUQRENGINE_INCLUDES} )
 
     target_link_libraries ( GPUQREngine_static PRIVATE GPURuntime_static )
 
@@ -148,7 +155,6 @@ if ( BUILD_STATIC_LIBS )
         CUDA_RESOLVE_DEVICE_SYMBOLS ON
         CUDA_RUNTIME_LIBRARY Static )
     target_link_libraries ( GPUQREngine_static PRIVATE CUDA::nvrtc CUDA::cudart_static )
-    target_compile_definitions ( GPUQREngine_static PRIVATE "SPQR_HAS_CUDA" )
     # FIXME: Ok to hardcode CUDA library names like this?
     set ( GPUQRENGINE_STATIC_LIBS "-L${CUDAToolkit_LIBRARY_DIR} -lcuda -lcudart_static" )
     if ( TARGET CUDA::cublas_static )

--- a/SPQR/GPURuntime/CMakeLists.txt
+++ b/SPQR/GPURuntime/CMakeLists.txt
@@ -43,19 +43,29 @@ configure_file ( "Config/SuiteSparse_GPURuntime.hpp.in"
     NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
+# object library
+#-------------------------------------------------------------------------------
 
 file ( GLOB SUITESPARSE_GPURUNTIME_SOURCES "Source/*.cpp" )
 
 set ( SUITESPARSE_GPURUNTIME_INCLUDES Include )
 
-include_directories ( ${SUITESPARSE_GPURUNTIME_INCLUDES} ${CUDAToolkit_INCLUDE_DIRS} )
+add_library ( gpuruntime_obj OBJECT ${SUITESPARSE_GPURUNTIME_SOURCES} )
+target_include_directories ( gpuruntime_obj PUBLIC
+    ${SUITESPARSE_GPURUNTIME_INCLUDES}
+    ${CUDAToolkit_INCLUDE_DIRS} )
+
+target_compile_definitions ( gpuruntime_obj PRIVATE "SPQR_HAS_CUDA" )
+
+target_include_directories ( gpuruntime_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 
 #-------------------------------------------------------------------------------
 # dynamic suitesparse_gpuruntime library properties
 #-------------------------------------------------------------------------------
 
 if ( BUILD_SHARED_LIBS )
-    add_library ( GPURuntime SHARED ${SUITESPARSE_GPURUNTIME_SOURCES} )
+    add_library ( GPURuntime SHARED $<TARGET_OBJECTS:gpuruntime_obj> )
 
     set_target_properties ( GPURuntime PROPERTIES
         VERSION ${SPQR_VERSION_MAJOR}.${SPQR_VERSION_MINOR}.${SPQR_VERSION_SUB}
@@ -66,10 +76,6 @@ if ( BUILD_SHARED_LIBS )
         PUBLIC_HEADER "Include/SuiteSparse_GPURuntime.hpp"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
-    target_include_directories ( GPURuntime PRIVATE
-        ${CUDAToolkit_INCLUDE_DIRS}
-        ${SUITESPARSE_GPURUNTIME_INCLUDES} )
-
     target_link_libraries ( GPURuntime PRIVATE SuiteSparse::SuiteSparseConfig )
 
     set_target_properties ( GPURuntime PROPERTIES
@@ -78,7 +84,6 @@ if ( BUILD_SHARED_LIBS )
         CUDA_RUNTIME_LIBRARY Static )
     target_link_libraries ( GPURuntime PRIVATE
         CUDA::nvrtc CUDA::cudart_static CUDA::cublas )
-    target_compile_definitions ( GPURuntime PRIVATE "SPQR_HAS_CUDA" )
 
     target_include_directories ( GPURuntime 
         INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Include>
@@ -90,7 +95,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( GPURuntime_static STATIC ${SUITESPARSE_GPURUNTIME_SOURCES} )
+    add_library ( GPURuntime_static STATIC $<TARGET_OBJECTS:gpuruntime_obj> )
 
     set_target_properties ( GPURuntime_static PROPERTIES
         CXX_STANDARD 17
@@ -103,10 +108,6 @@ if ( BUILD_STATIC_LIBS )
             OUTPUT_NAME suitesparse_gpuruntime_static )
     endif ( )
 
-    target_include_directories ( GPURuntime_static PRIVATE
-        ${CUDAToolkit_INCLUDE_DIRS}
-        ${SUITESPARSE_GPURUNTIME_INCLUDES} )
-
     if ( TARGET SuiteSparse::SuiteSparseConfig_static )
         target_link_libraries ( GPURuntime_static PRIVATE SuiteSparse::SuiteSparseConfig_static )
     else ( )
@@ -118,7 +119,6 @@ if ( BUILD_STATIC_LIBS )
         CUDA_SEPARABLE_COMPILATION ON
         CUDA_RUNTIME_LIBRARY Static )
     target_link_libraries ( GPURuntime_static PRIVATE CUDA::nvrtc CUDA::cudart_static )
-    target_compile_definitions ( GPURuntime_static PRIVATE "SPQR_HAS_CUDA" )
     # FIXME: Ok to hardcode CUDA library names like this?
     set ( GPURUNTIME_STATIC_LIBS "-L${CUDAToolkit_LIBRARY_DIR} -lcuda -lcudart_static" )
     if ( TARGET CUDA::cublas_static )

--- a/SPQR/SPQRGPU/CMakeLists.txt
+++ b/SPQR/SPQRGPU/CMakeLists.txt
@@ -26,18 +26,16 @@ message ( STATUS "C++ flags for CUDA:  ${CMAKE_CXX_FLAGS}" )
 
 file ( GLOB SPQR_CUDA_SOURCES "spqrgpu_*.cpp" )
 
-if ( BUILD_SHARED_LIBS )
-    target_sources ( SPQR PRIVATE ${SPQR_CUDA_SOURCES} )
-endif ( )
+target_sources ( spqr_obj PRIVATE ${SPQR_CUDA_SOURCES} )
 
-if ( BUILD_STATIC_LIBS )
-    target_sources ( SPQR_static PRIVATE ${SPQR_CUDA_SOURCES} )
-endif ( )
+set_target_properties ( spqr_obj PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    CUDA_SEPARABLE_COMPILATION ON )
+target_compile_definitions ( spqr_obj PRIVATE "SPQR_HAS_CUDA" )
 
 if ( BUILD_SHARED_LIBS )
     set_target_properties ( SPQR PROPERTIES POSITION_INDEPENDENT_CODE ON )
     set_target_properties ( SPQR PROPERTIES CUDA_SEPARABLE_COMPILATION ON )
-    target_compile_definitions ( SPQR PRIVATE "SPQR_HAS_CUDA" )
 
     target_link_libraries ( SPQR PRIVATE
         CUDA::nvrtc CUDA::cudart_static CUDA::cublas )
@@ -46,7 +44,6 @@ endif ( )
 if ( BUILD_STATIC_LIBS )
     set_target_properties ( SPQR_static PROPERTIES CUDA_SEPARABLE_COMPILATION ON )
     set_target_properties ( SPQR_static PROPERTIES POSITION_INDEPENDENT_CODE ON )
-    target_compile_definitions ( SPQR_static PRIVATE "SPQR_HAS_CUDA" )
 
     target_link_libraries ( SPQR_static PRIVATE
         CUDA::nvrtc CUDA::cudart_static CUDA::cublas )

--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -142,13 +142,24 @@ configure_file ( "Config/README.md.in"
     NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
-# dynamic SuiteSparseConfig library properties
+# object library
 #-------------------------------------------------------------------------------
 
 file ( GLOB SUITESPARSECONFIG_SOURCES "*.c" )
 
+add_library ( suitesparseconfig_obj OBJECT ${SUITESPARSECONFIG_SOURCES} )
+
+set_target_properties ( suitesparseconfig_obj PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    C_STANDARD 11
+    C_STANDARD_REQUIRED ON )
+
+#-------------------------------------------------------------------------------
+# dynamic SuiteSparseConfig library properties
+#-------------------------------------------------------------------------------
+
 if ( BUILD_SHARED_LIBS )
-    add_library ( SuiteSparseConfig SHARED ${SUITESPARSECONFIG_SOURCES} )
+    add_library ( SuiteSparseConfig SHARED $<TARGET_OBJECTS:suitesparseconfig_obj> )
 
     set_target_properties ( SuiteSparseConfig PROPERTIES
         VERSION ${SUITESPARSE_VERSION_MAJOR}.${SUITESPARSE_VERSION_MINOR}.${SUITESPARSE_VERSION_SUB}
@@ -173,7 +184,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( SuiteSparseConfig_static STATIC ${SUITESPARSECONFIG_SOURCES} )
+    add_library ( SuiteSparseConfig_static STATIC $<TARGET_OBJECTS:suitesparseconfig_obj> )
 
     set_target_properties ( SuiteSparseConfig_static PROPERTIES
         C_STANDARD 11
@@ -217,6 +228,7 @@ if ( SUITESPARSE_CONFIG_HAS_OPENMP )
     message ( STATUS "OpenMP C libraries:      ${OpenMP_C_LIBRARIES} ")
     message ( STATUS "OpenMP C include:        ${OpenMP_C_INCLUDE_DIRS} ")
     message ( STATUS "OpenMP C flags:          ${OpenMP_C_FLAGS} ")
+    target_link_libraries ( suitesparseconfig_obj PRIVATE OpenMP::OpenMP_C )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( SuiteSparseConfig PRIVATE OpenMP::OpenMP_C )
         target_include_directories ( SuiteSparseConfig SYSTEM AFTER INTERFACE

--- a/UMFPACK/CMakeLists.txt
+++ b/UMFPACK/CMakeLists.txt
@@ -112,19 +112,20 @@ configure_file ( "Config/umfpack_version.tex.in"
     NEWLINE_STYLE LF )
 
 #-------------------------------------------------------------------------------
-# include directories
+# object library
 #-------------------------------------------------------------------------------
 
-include_directories ( Source Include )
+file ( GLOB UMFPACK_SOURCES "Source2/*.c" )
+
+add_library ( umfpack_obj OBJECT ${UMFPACK_SOURCES} )
+target_include_directories ( umfpack_obj PRIVATE  Source Include )
 
 #-------------------------------------------------------------------------------
 # dynamic umfpack library properties
 #-------------------------------------------------------------------------------
 
-file ( GLOB UMFPACK_SOURCES "Source2/*.c" )
-
 if ( BUILD_SHARED_LIBS )
-    add_library ( UMFPACK SHARED ${UMFPACK_SOURCES} )
+    add_library ( UMFPACK SHARED $<TARGET_OBJECTS:umfpack_obj> )
 
     set_target_properties ( UMFPACK PROPERTIES
         VERSION ${UMFPACK_VERSION_MAJOR}.${UMFPACK_VERSION_MINOR}.${UMFPACK_VERSION_SUB}
@@ -149,7 +150,7 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( UMFPACK_static STATIC ${UMFPACK_SOURCES} )
+    add_library ( UMFPACK_static STATIC $<TARGET_OBJECTS:umfpack_obj> )
 
     set_target_properties ( UMFPACK_static PROPERTIES
         C_STANDARD 11
@@ -176,6 +177,8 @@ endif ( )
 #-------------------------------------------------------------------------------
 
 # SuiteSparseConfig:
+target_include_directories ( umfpack_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::SuiteSparseConfig,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( UMFPACK PRIVATE SuiteSparse::SuiteSparseConfig )
     target_include_directories ( UMFPACK PUBLIC
@@ -190,6 +193,8 @@ if ( BUILD_STATIC_LIBS )
 endif ( )
 
 # AMD:
+target_include_directories ( umfpack_obj PRIVATE
+    "$<TARGET_PROPERTY:SuiteSparse::AMD,INTERFACE_INCLUDE_DIRECTORIES>" )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( UMFPACK PRIVATE SuiteSparse::AMD )
     target_include_directories ( UMFPACK PUBLIC
@@ -206,6 +211,8 @@ endif ( )
 # CHOLMOD:
 if ( UMFPACK_HAS_CHOLMOD )
     # link with CHOLMOD and its dependencies, both required and optional
+    target_include_directories ( umfpack_obj PRIVATE
+        "$<TARGET_PROPERTY:SuiteSparse::CHOLMOD,INTERFACE_INCLUDE_DIRECTORIES>" )
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( UMFPACK PRIVATE SuiteSparse::CHOLMOD )
     endif ( )
@@ -219,12 +226,7 @@ if ( UMFPACK_HAS_CHOLMOD )
     endif ( )
 else ( )
     # tell UMFPACK that CHOLMOD is not available
-    if ( BUILD_SHARED_LIBS )
-        target_compile_definitions ( UMFPACK PRIVATE NCHOLMOD )
-    endif ( )
-    if ( BUILD_STATIC_LIBS )
-        target_compile_definitions ( UMFPACK_static PRIVATE NCHOLMOD )
-    endif ( )
+    target_compile_definitions ( umfpack_obj PRIVATE NCHOLMOD )
 endif ( )
 
 # libm:
@@ -244,14 +246,13 @@ endif ( )
 message ( STATUS "BLAS libraries:      ${BLAS_LIBRARIES}" )
 message ( STATUS "BLAS include:        ${BLAS_INCLUDE_DIRS}" )
 message ( STATUS "BLAS linker flags:   ${BLAS_LINKER_FLAGS}" )
+target_include_directories ( umfpack_obj PRIVATE ${BLAS_INCLUDE_DIRS} )
 if ( BUILD_SHARED_LIBS )
     target_link_libraries ( UMFPACK PRIVATE ${BLAS_LIBRARIES} )
-    target_include_directories ( UMFPACK PRIVATE ${BLAS_INCLUDE_DIRS} )
 endif ( )
 if ( BUILD_STATIC_LIBS )
     list ( APPEND UMFPACK_STATIC_LIBS ${BLAS_LIBRARIES} )
     target_link_libraries ( UMFPACK_static PUBLIC ${BLAS_LIBRARIES} )
-    target_include_directories ( UMFPACK_static PRIVATE ${BLAS_INCLUDE_DIRS} )
 endif ( )
 
 #-------------------------------------------------------------------------------
@@ -280,12 +281,7 @@ check_source_compiles ( C
     FAIL_REGEX "[wW]arning" )
 
 if ( HAVE_PRAGMA_GCC_IVDEP )
-    if ( BUILD_SHARED_LIBS )
-        target_compile_definitions ( UMFPACK PRIVATE "HAVE_PRAGMA_GCC_IVDEP" )
-    endif ( )
-    if ( BUILD_STATIC_LIBS )
-        target_compile_definitions ( UMFPACK_static PRIVATE "HAVE_PRAGMA_GCC_IVDEP" )
-    endif ( )
+    target_compile_definitions ( umfpack_obj PRIVATE "HAVE_PRAGMA_GCC_IVDEP" )
     set ( _pragma_found ON )
 endif ( )
 
@@ -304,17 +300,9 @@ if ( NOT _pragma_found )
         # Clang is very verbose if a hint for vectorization cannot be performed.
         # Disable the respective warning.
         check_c_compiler_flag ( "-Wno-pass-failed" HAVE_NO_PASS_FAILED )
-        if ( BUILD_SHARED_LIBS )
-            target_compile_definitions ( UMFPACK PRIVATE "HAVE_PRAGMA_CLANG_LOOP_VECTORIZE" )
-            if ( HAVE_NO_PASS_FAILED )
-                target_compile_options ( UMFPACK PRIVATE "-Wno-pass-failed" )
-            endif ( )
-        endif ( )
-        if ( BUILD_STATIC_LIBS )
-            target_compile_definitions ( UMFPACK_static PRIVATE "HAVE_PRAGMA_CLANG_LOOP_VECTORIZE" )
-            if ( HAVE_NO_PASS_FAILED )
-                target_compile_options ( UMFPACK_static PRIVATE "-Wno-pass-failed" )
-            endif ( )
+        target_compile_definitions ( umfpack_obj PRIVATE "HAVE_PRAGMA_CLANG_LOOP_VECTORIZE" )
+        if ( HAVE_NO_PASS_FAILED )
+            target_compile_options ( umfpack_obj PRIVATE "-Wno-pass-failed" )
         endif ( )
         set ( _pragma_found ON )
     endif ( )
@@ -332,12 +320,7 @@ if ( NOT _pragma_found )
         FAIL_REGEX "[wW]arning" )
 
     if ( HAVE_PRAGMA_IVDEP )
-        if ( BUILD_SHARED_LIBS )
-            target_compile_definitions ( UMFPACK PRIVATE "HAVE_PRAGMA_IVDEP" )
-        endif ( )
-        if ( BUILD_STATIC_LIBS )
-            target_compile_definitions ( UMFPACK_static PRIVATE "HAVE_PRAGMA_IVDEP" )
-        endif ( )
+        target_compile_definitions ( umfpack_obj PRIVATE "HAVE_PRAGMA_IVDEP" )
         set ( _pragma_found ON )
     endif ( )
 endif ( )
@@ -354,12 +337,7 @@ if ( NOT _pragma_found )
         FAIL_REGEX "[wW]arning" )
 
     if ( HAVE_PRAGMA_LOOP_IVDEP )
-        if ( BUILD_SHARED_LIBS )
-            target_compile_definitions ( UMFPACK PRIVATE "HAVE_PRAGMA_LOOP_IVDEP" )
-        endif ( )
-        if ( BUILD_STATIC_LIBS )
-            target_compile_definitions ( UMFPACK_static PRIVATE "HAVE_PRAGMA_LOOP_IVDEP" )
-        endif ( )
+        target_compile_definitions ( umfpack_obj PRIVATE "HAVE_PRAGMA_LOOP_IVDEP" )
         set ( _pragma_found ON )
     endif ( )
 endif ( )
@@ -378,12 +356,7 @@ if ( NOT _pragma_found )
         FAIL_REGEX "[wW]arning" )
 
     if ( HAVE_PRAGMA_GCC_NOVECTOR )
-        if ( BUILD_SHARED_LIBS )
-            target_compile_definitions ( UMFPACK PRIVATE "HAVE_PRAGMA_GCC_NOVECTOR" )
-        endif ( )
-        if ( BUILD_STATIC_LIBS )
-            target_compile_definitions ( UMFPACK_static PRIVATE "HAVE_PRAGMA_GCC_NOVECTOR" )
-        endif ( )
+        target_compile_definitions ( umfpack_obj PRIVATE "HAVE_PRAGMA_GCC_NOVECTOR" )
         set ( _pragma_found ON )
     endif ( )
 endif ( )
@@ -400,12 +373,7 @@ if ( NOT _pragma_found )
         FAIL_REGEX "[wW]arning" )
 
     if ( HAVE_PRAGMA_NOVECTOR )
-        if ( BUILD_SHARED_LIBS )
-            target_compile_definitions ( UMFPACK PRIVATE "HAVE_PRAGMA_NOVECTOR" )
-        endif ( )
-        if ( BUILD_STATIC_LIBS )
-            target_compile_definitions ( UMFPACK_static PRIVATE "HAVE_PRAGMA_NOVECTOR" )
-        endif ( )
+        target_compile_definitions ( umfpack_obj PRIVATE "HAVE_PRAGMA_NOVECTOR" )
         set ( _pragma_found ON )
     endif ( )
 endif ( )
@@ -422,12 +390,7 @@ if ( NOT _pragma_found )
         FAIL_REGEX "[wW]arning" )
 
     if ( HAVE_PRAGMA_LOOP_NO_VECTOR )
-        if ( BUILD_SHARED_LIBS )
-            target_compile_definitions ( UMFPACK PRIVATE "HAVE_PRAGMA_LOOP_NO_VECTOR" )
-        endif ( )
-        if ( BUILD_STATIC_LIBS )
-            target_compile_definitions ( UMFPACK_static PRIVATE "HAVE_PRAGMA_LOOP_NO_VECTOR" )
-        endif ( )
+        target_compile_definitions ( umfpack_obj PRIVATE "HAVE_PRAGMA_LOOP_NO_VECTOR" )
         set ( _pragma_found ON )
     endif ( )
 endif ( )


### PR DESCRIPTION
Avoid building all objects twice (for the shared and the static library), effectively reducing the build time approximately by a factor of two.

Something similar could probably be done for most of the SuiteSparse libraries (including GraphBLAS). So, build time could probably be reduced by a lot (when building shared and static libraries).