### PR TITLE
CI: Add Ubuntu on ARM runner to CI

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -35,14 +35,12 @@ jobs:
       matrix:
         # For available CPU architectures, see:
         # https://github.com/marketplace/actions/setup-alpine-linux-environment
-        arch: [x86, aarch64, armv7, ppc64le, s390x, riscv64]
+        arch: [x86, armv7, ppc64le, s390x, riscv64]
         include:
           - arch: x86
             ccache-max: 64M
             extra-build-libs: ":GraphBLAS:LAGraph"
             extra-check-libs: ":GraphBLAS:LAGraph"
-          - arch: aarch64
-            ccache-max: 28M
           - arch: armv7
             ccache-max: 25M
           - arch: ppc64le

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,19 +49,14 @@ jobs:
             openmp: with
             link: both
           - os: ubuntu-latest
-            compiler: clang
-            cuda: with
-            openmp: with
-            link: both
-          - os: ubuntu-latest
-            compiler: clang
-            cuda: without
-            openmp: with
-            link: both
-          - os: ubuntu-latest
             compiler: gcc
             cuda: without
             openmp: without
+            link: both
+          - os: ubuntu-latest
+            compiler: clang
+            cuda: with
+            openmp: with
             link: both
           - os: ubuntu-latest
             compiler: gcc

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,47 +23,59 @@ jobs:
   ubuntu:
     # For available GitHub-hosted runners, see:
     # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
-    name: ubuntu (${{ matrix.compiler }} ${{ matrix.cuda }} CUDA ${{ matrix.openmp }} OpenMP, ${{ matrix.link }})
+    name: ${{ matrix.os }} (${{ matrix.compiler }} ${{ matrix.cuda }} CUDA ${{ matrix.openmp }} OpenMP, ${{ matrix.link }})
 
     strategy:
       # Allow other runners in the matrix to continue if some fail
       fail-fast: false
 
       matrix:
+        os: [ubuntu-latest]
         compiler: [gcc]
         cuda: [with]
         openmp: [with]
         link: [both]
         include:
-          - compiler: gcc
+          - os: ubuntu-latest
+            compiler: gcc
             cuda: with
             openmp: with
             link: both
-          - compiler: gcc
+          - os: ubuntu-latest
+            compiler: gcc
             cuda: without
             openmp: with
             link: both
-          - compiler: clang
+          - os: ubuntu-latest
+            compiler: clang
             cuda: with
             openmp: with
             link: both
-          - compiler: clang
+          - os: ubuntu-latest
+            compiler: clang
             cuda: without
             openmp: with
             link: both
-          - compiler: gcc
+          - os: ubuntu-latest
+            compiler: gcc
             cuda: without
             openmp: without
             link: both
-          - compiler: gcc
+          - os: ubuntu-latest
+            compiler: gcc
             cuda: with
             openmp: with
             link: static
             # "Fake" a cross-compilation to exercise that build system path
             extra-cmake-flags:
               -DCMAKE_SYSTEM_NAME="Linux"
+          - os: ubuntu-24.04-arm
+            compiler: gcc
+            cuda: without
+            openmp: with
+            link: both
 
     env:
       CC: ${{ matrix.compiler == 'gcc' && 'gcc' || 'clang' }}
@@ -92,7 +104,7 @@ jobs:
         # used in action/cache/restore and action/cache/save steps
         id: ccache-prepare
         run: |
-          echo "key=ccache:ubuntu:${{ matrix.compiler }}:${{ matrix.cuda }}:${{ matrix.openmp }}:${{ matrix.link }}:${{ github.ref }}:$(date +"%Y-%m-%d_%H-%M-%S"):${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "key=ccache:${{ matrix.os }}:${{ matrix.compiler }}:${{ matrix.cuda }}:${{ matrix.openmp }}:${{ matrix.link }}:${{ github.ref }}:$(date +"%Y-%m-%d_%H-%M-%S"):${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - name: restore ccache
         # setup the GitHub cache used to maintain the ccache from one job to the next
@@ -102,8 +114,8 @@ jobs:
           key: ${{ steps.ccache-prepare.outputs.key }}
           # Prefer caches from the same branch. Fall back to caches from the dev branch.
           restore-keys: |
-            ccache:ubuntu:${{ matrix.compiler }}:${{ matrix.cuda }}:${{ matrix.openmp }}:${{ matrix.link }}:${{ github.ref }}
-            ccache:ubuntu:${{ matrix.compiler }}:${{ matrix.cuda }}:${{ matrix.openmp }}:${{ matrix.link }}:
+            ccache:${{ matrix.os }}:${{ matrix.compiler }}:${{ matrix.cuda }}:${{ matrix.openmp }}:${{ matrix.link }}:${{ github.ref }}
+            ccache:${{ matrix.os }}:${{ matrix.compiler }}:${{ matrix.cuda }}:${{ matrix.openmp }}:${{ matrix.link }}:
 
       - name: create empty libraries
         # This is to work around a bug in nvlink.
@@ -116,9 +128,9 @@ jobs:
           ar rcsv librt.a empty.o
           ar rcsv libpthread.a empty.o
           # overwrite system libraries with "valid" empty libraries
-          sudo mv ./libdl.a /usr/lib/x86_64-linux-gnu/libdl.a
-          sudo mv ./librt.a /usr/lib/x86_64-linux-gnu/librt.a
-          sudo mv ./libpthread.a /usr/lib/x86_64-linux-gnu/libpthread.a
+          sudo mv ./libdl.a /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libdl.a
+          sudo mv ./librt.a /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/librt.a
+          sudo mv ./libpthread.a /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libpthread.a
 
       - name: configure ccache
         env:

--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -48,10 +48,6 @@ jobs:
             cuda: with
             link: both
           - os: ubuntu-latest
-            compiler: clang
-            cuda: without
-            link: both
-          - os: ubuntu-latest
             compiler: gcc
             cuda: with
             link: static

--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -21,34 +21,44 @@ jobs:
   ubuntu:
     # For available GitHub-hosted runners, see:
     # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
-    name: ubuntu (${{ matrix.compiler }} ${{ matrix.cuda }} CUDA, ${{ matrix.link }})
+    name: ${{ matrix.os }} (${{ matrix.compiler }} ${{ matrix.cuda }} CUDA, ${{ matrix.link }})
 
     strategy:
       # Allow other runners in the matrix to continue if some fail
       fail-fast: false
 
       matrix:
+        os: [ubuntu-latest]
         compiler: [gcc]
         cuda: [with]
         link: [both]
         include:
-          - compiler: gcc
+          - os: ubuntu-latest
+            compiler: gcc
             cuda: with
             link: both
-          - compiler: gcc
+          - os: ubuntu-latest
+            compiler: gcc
             cuda: without
             link: both
-          - compiler: clang
+          - os: ubuntu-latest
+            compiler: clang
             cuda: with
             link: both
-          - compiler: clang
+          - os: ubuntu-latest
+            compiler: clang
             cuda: without
             link: both
-          - compiler: gcc
+          - os: ubuntu-latest
+            compiler: gcc
             cuda: with
             link: static
+          - os: ubuntu-24.04-arm
+            compiler: gcc
+            cuda: without
+            link: both
 
     env:
       CC: ${{ matrix.compiler == 'gcc' && 'gcc' || 'clang' }}
@@ -77,7 +87,7 @@ jobs:
         # used in action/cache/restore and action/cache/save steps
         id: ccache-prepare
         run: |
-          echo "key=ccache:ubuntu:root:${{ matrix.compiler }}:${{ matrix.cuda }}:${{ matrix.link }}:${{ github.ref }}:$(date +"%Y-%m-%d_%H-%M-%S"):${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "key=ccache:${{ matrix.os }}:root:${{ matrix.compiler }}:${{ matrix.cuda }}:${{ matrix.link }}:${{ github.ref }}:$(date +"%Y-%m-%d_%H-%M-%S"):${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - name: restore ccache
         # setup the GitHub cache used to maintain the ccache from one job to the next
@@ -87,8 +97,8 @@ jobs:
           key: ${{ steps.ccache-prepare.outputs.key }}
           # Prefer caches from the same branch. Fall back to caches from the dev branch.
           restore-keys: |
-            ccache:ubuntu:root:${{ matrix.compiler }}:${{ matrix.cuda }}:${{ matrix.link }}:${{ github.ref }}
-            ccache:ubuntu:root:${{ matrix.compiler }}:${{ matrix.cuda }}:${{ matrix.link }}
+            ccache:${{ matrix.os }}:root:${{ matrix.compiler }}:${{ matrix.cuda }}:${{ matrix.link }}:${{ github.ref }}
+            ccache:${{ matrix.os }}:root:${{ matrix.compiler }}:${{ matrix.cuda }}:${{ matrix.link }}
 
       - name: create empty libraries
         # This is to work around a bug in nvlink.
@@ -101,9 +111,9 @@ jobs:
           ar rcsv librt.a empty.o
           ar rcsv libpthread.a empty.o
           # overwrite system libraries with "valid" empty libraries
-          sudo mv ./libdl.a /usr/lib/x86_64-linux-gnu/libdl.a
-          sudo mv ./librt.a /usr/lib/x86_64-linux-gnu/librt.a
-          sudo mv ./libpthread.a /usr/lib/x86_64-linux-gnu/libpthread.a
+          sudo mv ./libdl.a /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libdl.a
+          sudo mv ./librt.a /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/librt.a
+          sudo mv ./libpthread.a /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/libpthread.a
 
       - name: configure ccache
         run: |


### PR DESCRIPTION
GitHub started hosting runners with Ubuntu on ARM64 processors for open source projects for free:
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Add one configuration that is using these runners to the build matrix.

According to their blog post, the arm64 runners are more efficient and potentially faster than the x86_64 runners. (But it is still in a preview phase and maybe it will take some time for them to better scale and balance the load.) If that turns out to be true, it should be easy to switch more configurations in that workflow (or the one using the root CMake file) to the arm64 runners (and maybe keep only one or two running on x86_64).

Since there is now the possibility to run tests for this target natively, remove that target from the build matrix of the workflow that emulates it with `qemu`.

There is an open PR for the Alpine action that would allow running the armv7 tests natively on aarch64. But it hasn't been merged yet:
https://github.com/jirutka/setup-alpine/pull/22
So, keep emulating armv7 on x86_64 for the time being.
