### PR TITLE
CMake: Adjust condition for changed name for static libraries.

### DIFF
--- a/AMD/CMakeLists.txt
+++ b/AMD/CMakeLists.txt
@@ -115,7 +115,7 @@ if ( BUILD_STATIC_LIBS )
         PUBLIC_HEADER "Include/amd.h"
         LINKER_LANGUAGE C )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( AMD_static PROPERTIES
             OUTPUT_NAME amd_static )
     endif ( )

--- a/BTF/CMakeLists.txt
+++ b/BTF/CMakeLists.txt
@@ -104,7 +104,7 @@ if ( BUILD_STATIC_LIBS )
         OUTPUT_NAME btf
         PUBLIC_HEADER "Include/btf.h" )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( BTF_static PROPERTIES
             OUTPUT_NAME btf_static )
     endif ( )

--- a/CAMD/CMakeLists.txt
+++ b/CAMD/CMakeLists.txt
@@ -107,7 +107,7 @@ if ( BUILD_STATIC_LIBS )
         OUTPUT_NAME camd
         PUBLIC_HEADER "Include/camd.h" )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( CAMD_static PROPERTIES
             OUTPUT_NAME camd_static )
     endif ( )

--- a/CCOLAMD/CMakeLists.txt
+++ b/CCOLAMD/CMakeLists.txt
@@ -104,7 +104,7 @@ if ( BUILD_STATIC_LIBS )
         C_STANDARD_REQUIRED ON
         PUBLIC_HEADER "Include/ccolamd.h" )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( CCOLAMD_static PROPERTIES
             OUTPUT_NAME ccolamd_static )
     endif ( )

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -414,7 +414,7 @@ if ( BUILD_STATIC_LIBS )
         PUBLIC_HEADER "Include/cholmod.h"
         LINKER_LANGUAGE C )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( CHOLMOD_static PROPERTIES
             OUTPUT_NAME cholmod_static )
     endif ( )

--- a/COLAMD/CMakeLists.txt
+++ b/COLAMD/CMakeLists.txt
@@ -104,7 +104,7 @@ if ( BUILD_STATIC_LIBS )
         C_STANDARD_REQUIRED ON
         PUBLIC_HEADER "Include/colamd.h" )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( COLAMD_static PROPERTIES
             OUTPUT_NAME colamd_static )
     endif ( )

--- a/CSparse/CMakeLists.txt
+++ b/CSparse/CMakeLists.txt
@@ -113,7 +113,7 @@ if ( BUILD_STATIC_LIBS )
         C_STANDARD_REQUIRED ON
         PUBLIC_HEADER "Include/cs.h" )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( csparse_static PROPERTIES
             OUTPUT_NAME csparse_static )
     endif ( )

--- a/CXSparse/CMakeLists.txt
+++ b/CXSparse/CMakeLists.txt
@@ -144,7 +144,7 @@ if ( BUILD_STATIC_LIBS )
         C_STANDARD_REQUIRED ON
         PUBLIC_HEADER "Include/cs.h" )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( CXSparse_static PROPERTIES
             OUTPUT_NAME cxsparse_static )
     endif ( )

--- a/Example/CMakeLists.txt
+++ b/Example/CMakeLists.txt
@@ -154,7 +154,7 @@ if ( BUILD_STATIC_LIBS )
         OUTPUT_NAME my
         SOVERSION ${MY_VERSION_MAJOR} )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( my_static PROPERTIES
             OUTPUT_NAME my_static )
     endif ( )
@@ -189,7 +189,7 @@ if ( BUILD_STATIC_LIBS )
         OUTPUT_NAME my_cxx
         SOVERSION ${MY_VERSION_MAJOR} )
 
-    if ( MSVC OR ("${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( my_cxx_static PROPERTIES
             OUTPUT_NAME my_cxx_static )
     endif ( )

--- a/GraphBLAS/CMakeLists.txt
+++ b/GraphBLAS/CMakeLists.txt
@@ -332,7 +332,7 @@ if ( BUILD_STATIC_LIBS )
         C_STANDARD_REQUIRED ON
         PUBLIC_HEADER "Include/GraphBLAS.h" )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( GraphBLAS_static PROPERTIES
             OUTPUT_NAME graphblas_static )
     endif ( )

--- a/KLU/CMakeLists.txt
+++ b/KLU/CMakeLists.txt
@@ -162,7 +162,7 @@ if ( BUILD_STATIC_LIBS )
         OUTPUT_NAME klu
         PUBLIC_HEADER "Include/klu.h" )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( KLU_static PROPERTIES
             OUTPUT_NAME klu_static )
     endif ( )
@@ -213,7 +213,7 @@ if ( KLU_HAS_CHOLMOD )
             OUTPUT_NAME klu_cholmod
             PUBLIC_HEADER "User/klu_cholmod.h" )
 
-        if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+        if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
             set_target_properties ( KLU_CHOLMOD_static PROPERTIES
                 OUTPUT_NAME klu_cholmod_static )
         endif ( )

--- a/LAGraph/experimental/CMakeLists.txt
+++ b/LAGraph/experimental/CMakeLists.txt
@@ -61,7 +61,7 @@ if ( BUILD_STATIC_LIBS )
         C_STANDARD 11
         PUBLIC_HEADER "include/LAGraphX.h" )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( LAGraphX_static PROPERTIES
             OUTPUT_NAME lagraphx_static )
     endif ( )

--- a/LAGraph/experimental/test/CMakeLists.txt
+++ b/LAGraph/experimental/test/CMakeLists.txt
@@ -62,7 +62,7 @@ if ( BUILD_STATIC_LIBS )
         C_STANDARD_REQUIRED ON
         C_STANDARD 11 )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( lagraphxtest_static PROPERTIES
             OUTPUT_NAME lagraphxtest_static )
     endif ( )

--- a/LAGraph/src/CMakeLists.txt
+++ b/LAGraph/src/CMakeLists.txt
@@ -63,7 +63,7 @@ if ( BUILD_STATIC_LIBS )
         C_STANDARD 11
         PUBLIC_HEADER "include/LAGraph.h" )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( LAGraph_static PROPERTIES
             OUTPUT_NAME lagraph_static )
     endif ( )

--- a/LAGraph/src/test/CMakeLists.txt
+++ b/LAGraph/src/test/CMakeLists.txt
@@ -64,7 +64,7 @@ if ( BUILD_STATIC_LIBS )
         C_STANDARD_REQUIRED ON
         C_STANDARD 11 )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( lagraphtest_static PROPERTIES
             OUTPUT_NAME lagraphtest_static )
     endif ( )

--- a/LDL/CMakeLists.txt
+++ b/LDL/CMakeLists.txt
@@ -116,7 +116,7 @@ if ( BUILD_STATIC_LIBS )
         OUTPUT_NAME ldl
         PUBLIC_HEADER "Include/ldl.h" )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( LDL_static PROPERTIES
             OUTPUT_NAME ldl_static )
     endif ( )

--- a/Mongoose/CMakeLists.txt
+++ b/Mongoose/CMakeLists.txt
@@ -205,7 +205,7 @@ if ( BUILD_STATIC_LIBS )
         OUTPUT_NAME suitesparse_mongoose
         PUBLIC_HEADER "Include/Mongoose.hpp" )
 
-    if ( MSVC OR ("${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( Mongoose_static PROPERTIES
             OUTPUT_NAME suitesparse_mongoose_static )
     endif ( )

--- a/ParU/CMakeLists.txt
+++ b/ParU/CMakeLists.txt
@@ -172,7 +172,7 @@ if ( BUILD_STATIC_LIBS )
         PUBLIC_HEADER "Include/ParU.h"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
-    if ( MSVC OR ("${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( ParU_static PROPERTIES
             OUTPUT_NAME ParU_static )
     endif ( )

--- a/RBio/CMakeLists.txt
+++ b/RBio/CMakeLists.txt
@@ -104,7 +104,7 @@ if ( BUILD_STATIC_LIBS )
         OUTPUT_NAME rbio
         PUBLIC_HEADER "Include/RBio.h" )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( RBio_static PROPERTIES
             OUTPUT_NAME rbio_static )
     endif ( )

--- a/SPEX/CMakeLists.txt
+++ b/SPEX/CMakeLists.txt
@@ -158,7 +158,7 @@ if ( BUILD_STATIC_LIBS )
         OUTPUT_NAME spex
         PUBLIC_HEADER "Include/SPEX.h" )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( SPEX_static PROPERTIES
             OUTPUT_NAME spex_static )
     endif ( )

--- a/SPQR/CMakeLists.txt
+++ b/SPQR/CMakeLists.txt
@@ -138,7 +138,7 @@ if ( BUILD_STATIC_LIBS )
         C_STANDARD_REQUIRED ON
         OUTPUT_NAME spqr )
 
-    if ( MSVC OR ("${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( SPQR_static PROPERTIES
             OUTPUT_NAME spqr_static )
     endif ( )

--- a/SPQR/GPUQREngine/CMakeLists.txt
+++ b/SPQR/GPUQREngine/CMakeLists.txt
@@ -125,7 +125,7 @@ if ( BUILD_STATIC_LIBS )
         OUTPUT_NAME gpuqrengine
         PUBLIC_HEADER "Include/GPUQREngine.hpp" )
 
-    if ( MSVC OR ("${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( GPUQREngine_static PROPERTIES
             OUTPUT_NAME gpuqrengine_static )
     endif ( )

--- a/SPQR/GPURuntime/CMakeLists.txt
+++ b/SPQR/GPURuntime/CMakeLists.txt
@@ -98,7 +98,7 @@ if ( BUILD_STATIC_LIBS )
         OUTPUT_NAME suitesparse_gpuruntime
         PUBLIC_HEADER "Include/SuiteSparse_GPURuntime.hpp" )
 
-    if ( MSVC OR ("${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( GPURuntime_static PROPERTIES
             OUTPUT_NAME suitesparse_gpuruntime_static )
     endif ( )

--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -181,7 +181,7 @@ if ( BUILD_STATIC_LIBS )
         OUTPUT_NAME suitesparseconfig
         PUBLIC_HEADER "SuiteSparse_config.h" )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( SuiteSparseConfig_static PROPERTIES
             OUTPUT_NAME suitesparseconfig_static )
     endif ( )

--- a/UMFPACK/CMakeLists.txt
+++ b/UMFPACK/CMakeLists.txt
@@ -157,7 +157,7 @@ if ( BUILD_STATIC_LIBS )
         OUTPUT_NAME umfpack
         PUBLIC_HEADER "Include/umfpack.h" )
 
-    if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
+    if ( CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX )
         set_target_properties ( UMFPACK_static PROPERTIES
             OUTPUT_NAME umfpack_static )
     endif ( )


### PR DESCRIPTION
MSVC-like compilers use the same default suffix for static libraries and import libraries.
Instead of checking whether a compiler is MSVC or simulates it, directly check whether these default suffices clash.

That potentially fixes issue #895. (And even in case it does not, the updated condition is much more to the point.)
