### PR TITLE
CI: Overhaul build matrix for Ubuntu runners and work around issue with Clang

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,7 +138,7 @@ jobs:
             printf "   \033[0;32m==>\033[0m Building library \033[0;32m${lib}\033[0m\n"
             echo "::group::Configure $lib"
             cd ${GITHUB_WORKSPACE}/${lib}/build
-            cmake -DCMAKE_BUILD_TYPE="Release" \
+            cmake -DCMAKE_BUILD_TYPE=${{ matrix.compiler == 'clang' && 'Debug' || 'Release' }} \
                   -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}" \
                   -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
                   -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
@@ -160,7 +160,7 @@ jobs:
                   ..
             echo "::endgroup::"
             echo "::group::Build $lib"
-            cmake --build . --config Release
+            cmake --build .
             echo "::endgroup::"
           done
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,62 +32,42 @@ jobs:
       fail-fast: false
 
       matrix:
-        compiler: [gcc, clang]
-        cuda: [with, without]
+        compiler: [gcc]
+        cuda: [with]
         openmp: [with]
         link: [both]
         include:
           - compiler: gcc
-            compiler-pkgs: "g++ gcc"
-            cc: "gcc"
-            cxx: "g++"
-          - compiler: clang
-            compiler-pkgs: "clang libomp-dev"
-            cc: "clang"
-            cxx: "clang++"
-          # Clang seems to generally require less cache size (smaller object files?).
+            cuda: with
+            openmp: with
+            link: both
           - compiler: gcc
-            ccache-max: 600M
+            cuda: without
+            openmp: with
+            link: both
           - compiler: clang
-            ccache-max: 500M
-          - cuda: with
-            cuda-pkgs: "nvidia-cuda-dev nvidia-cuda-toolkit"
-            cuda-cmake-flags:
-              -DSUITESPARSE_USE_CUDA=ON
-              -DSUITESPARSE_USE_STRICT=ON
-              -DCUDAToolkit_INCLUDE_DIRS="/usr/include"
-              -DCMAKE_CUDA_COMPILER_LAUNCHER="ccache"
+            cuda: with
+            openmp: with
+            link: both
+          - compiler: clang
+            cuda: without
+            openmp: with
+            link: both
           - compiler: gcc
-            compiler-pkgs: "g++ gcc"
-            cc: "gcc"
-            cxx: "g++"
-            ccache-max: 600M
             cuda: without
             openmp: without
-            openmp-cmake-flags: "-DSUITESPARSE_USE_OPENMP=OFF"
+            link: both
           - compiler: gcc
-            compiler-pkgs: "g++ gcc"
-            cc: "gcc"
-            cxx: "g++"
-            ccache-max: 600M
             cuda: with
-            cuda-pkgs: "nvidia-cuda-dev nvidia-cuda-toolkit"
-            cuda-cmake-flags:
-              -DSUITESPARSE_USE_CUDA=ON
-              -DSUITESPARSE_USE_STRICT=ON
-              -DCUDAToolkit_INCLUDE_DIRS="/usr/include"
-              -DCMAKE_CUDA_COMPILER_LAUNCHER="ccache"
             openmp: with
             link: static
             # "Fake" a cross-compilation to exercise that build system path
-            link-cmake-flags:
-              -DBUILD_SHARED_LIBS=OFF
-              -DBUILD_STATIC_LIBS=ON
+            extra-cmake-flags:
               -DCMAKE_SYSTEM_NAME="Linux"
 
     env:
-      CC: ${{ matrix.cc }}
-      CXX: ${{ matrix.cxx }}
+      CC: ${{ matrix.compiler == 'gcc' && 'gcc' || 'clang' }}
+      CXX: ${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}
 
     steps:
       - name: get CPU information
@@ -97,14 +77,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: install dependencies
-        env:
-          COMPILER_PKGS: ${{ matrix.compiler-pkgs }}
-          CUDA_PKGS: ${{ matrix.cuda-pkgs }}
         run: |
           sudo apt -qq update
-          sudo apt install -y ${COMPILER_PKGS} autoconf automake ccache cmake \
+          sudo apt install -y \
+            ${{ matrix.compiler == 'gcc' && 'g++ gcc' || 'clang' }} \
+            ${{ matrix.compiler == 'clang' &&  matrix.openmp == 'with' && 'libomp-dev' || '' }} \
+            autoconf automake ccache cmake \
             dvipng gfortran libgmp-dev liblapack-dev libmpfr-dev valgrind \
-            libopenblas-dev ${CUDA_PKGS}
+            libopenblas-dev \
+            ${{ matrix.cuda == 'with' && 'nvidia-cuda-dev nvidia-cuda-toolkit' || '' }}
 
       - name: prepare ccache
         # create key with human readable timestamp
@@ -144,7 +125,8 @@ jobs:
           CCACHE_MAX: ${{ matrix.ccache-max }}
         run: |
           test -d ~/.ccache || mkdir ~/.ccache
-          echo "max_size = $CCACHE_MAX" >> ~/.ccache/ccache.conf
+          # Clang seems to generally require less cache size (smaller object files?).
+          echo "max_size = ${{ matrix.compiler == 'gcc' && '600M' || '500M' }}" >> ~/.ccache/ccache.conf
           echo "compression = true" >> ~/.ccache/ccache.conf
           ccache -s
           echo "/usr/lib/ccache" >> $GITHUB_PATH
@@ -164,9 +146,17 @@ jobs:
                   -DBLA_VENDOR="OpenBLAS" \
                   -DSUITESPARSE_DEMOS=OFF \
                   -DBUILD_TESTING=OFF \
-                  ${{ matrix.cuda-cmake-flags }} \
-                  ${{ matrix.openmp-cmake-flags }} \
-                  ${{ matrix.link-cmake-flags }} \
+                  ${{ matrix.cuda == 'with'
+                    && '-DSUITESPARSE_USE_CUDA=ON \
+                        -DSUITESPARSE_USE_STRICT=ON \
+                        -DCUDAToolkit_INCLUDE_DIRS="/usr/include" \
+                        -DCMAKE_CUDA_COMPILER_LAUNCHER="ccache"'
+                    || '-DSUITESPARSE_USE_CUDA=OFF' }} \
+                  -DSUITESPARSE_USE_OPENMP=${{ matrix.openmp == 'without' && 'OFF' || 'ON' }} \
+                  ${{ matrix.link == 'static'
+                    && '-DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON'
+                    || '' }} \
+                  ${{ matrix.extra-cmake-flags }} \
                   ..
             echo "::endgroup::"
             echo "::group::Build $lib"
@@ -214,8 +204,15 @@ jobs:
           cmake \
             -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/lib/cmake" \
             -DBLA_VENDOR="OpenBLAS" \
-            ${{ matrix.cuda-cmake-flags }} \
-            ${{ matrix.link-cmake-flags }} \
+            ${{ matrix.cuda == 'with'
+              && '-DSUITESPARSE_USE_CUDA=ON \
+                  -DSUITESPARSE_USE_STRICT=ON \
+                  -DCUDAToolkit_INCLUDE_DIRS="/usr/include" \
+                  -DCMAKE_CUDA_COMPILER_LAUNCHER="ccache"'
+              || '' }} \
+            ${{ matrix.link == 'static'
+              && '-DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON'
+              || '' }} \
             ..
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Building example\n"

--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -133,7 +133,7 @@ jobs:
       - name: configure
         run: |
           mkdir -p ${GITHUB_WORKSPACE}/build && cd ${GITHUB_WORKSPACE}/build
-          cmake -DCMAKE_BUILD_TYPE="Release" \
+          cmake -DCMAKE_BUILD_TYPE=${{ matrix.compiler == 'clang' && 'Debug' || 'Release' }} \
                 -DCMAKE_INSTALL_PREFIX=".." \
                 -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
                 -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \

--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -30,50 +30,29 @@ jobs:
       fail-fast: false
 
       matrix:
-        compiler: [gcc, clang]
-        cuda: [with, without]
+        compiler: [gcc]
+        cuda: [with]
         link: [both]
         include:
           - compiler: gcc
-            compiler-pkgs: "g++ gcc"
-            cc: "gcc"
-            cxx: "g++"
-          - compiler: clang
-            compiler-pkgs: "clang libomp-dev"
-            cc: "clang"
-            cxx: "clang++"
-          # Clang seems to generally require less cache size (smaller object files?).
-          - compiler: gcc
-            ccache-max: 600M
-          - compiler: clang
-            ccache-max: 500M
-          - cuda: with
-            cuda-pkgs: "nvidia-cuda-dev nvidia-cuda-toolkit"
-            cuda-cmake-flags:
-              -DSUITESPARSE_USE_CUDA=ON
-              -DSUITESPARSE_USE_STRICT=ON
-              -DCUDAToolkit_INCLUDE_DIRS="/usr/include"
-              -DCMAKE_CUDA_COMPILER_LAUNCHER="ccache"
-          - compiler: gcc
-            compiler-pkgs: "g++ gcc"
-            cc: "gcc"
-            cxx: "g++"
-            ccache-max: 600M
             cuda: with
-            cuda-pkgs: "nvidia-cuda-dev nvidia-cuda-toolkit"
-            cuda-cmake-flags:
-              -DSUITESPARSE_USE_CUDA=ON
-              -DSUITESPARSE_USE_STRICT=ON
-              -DCUDAToolkit_INCLUDE_DIRS="/usr/include"
-              -DCMAKE_CUDA_COMPILER_LAUNCHER="ccache"
+            link: both
+          - compiler: gcc
+            cuda: without
+            link: both
+          - compiler: clang
+            cuda: with
+            link: both
+          - compiler: clang
+            cuda: without
+            link: both
+          - compiler: gcc
+            cuda: with
             link: static
-            link-cmake-flags:
-              -DBUILD_SHARED_LIBS=OFF
-              -DBUILD_STATIC_LIBS=ON
 
     env:
-      CC: ${{ matrix.cc }}
-      CXX: ${{ matrix.cxx }}
+      CC: ${{ matrix.compiler == 'gcc' && 'gcc' || 'clang' }}
+      CXX: ${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}
 
     steps:
       - name: get CPU information
@@ -83,14 +62,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: install dependencies
-        env:
-          COMPILER_PKGS: ${{ matrix.compiler-pkgs }}
-          CUDA_PKGS: ${{ matrix.cuda-pkgs }}
         run: |
           sudo apt -qq update
-          sudo apt install -y ${COMPILER_PKGS} autoconf automake ccache cmake \
+          sudo apt install -y \
+            ${{ matrix.compiler == 'gcc' && 'g++ gcc' || 'clang' }} \
+            ${{ matrix.compiler == 'clang' && 'libomp-dev' || '' }} \
+            autoconf automake ccache cmake \
             dvipng gfortran libgmp-dev liblapack-dev libmpfr-dev \
-            libopenblas-dev ${CUDA_PKGS}
+            libopenblas-dev \
+            ${{ matrix.cuda == 'with' && 'nvidia-cuda-dev nvidia-cuda-toolkit' || '' }}
 
       - name: prepare ccache
         # create key with human readable timestamp
@@ -126,11 +106,10 @@ jobs:
           sudo mv ./libpthread.a /usr/lib/x86_64-linux-gnu/libpthread.a
 
       - name: configure ccache
-        env:
-          CCACHE_MAX: ${{ matrix.ccache-max }}
         run: |
           test -d ~/.ccache || mkdir ~/.ccache
-          echo "max_size = $CCACHE_MAX" >> ~/.ccache/ccache.conf
+          # Clang seems to generally require less cache size (smaller object files?).
+          echo "max_size = ${{ matrix.compiler == 'gcc' && '600M' || '500M' }}" >> ~/.ccache/ccache.conf
           echo "compression = true" >> ~/.ccache/ccache.conf
           ccache -s
           echo "/usr/lib/ccache" >> $GITHUB_PATH
@@ -162,8 +141,15 @@ jobs:
                 -DBLA_VENDOR="OpenBLAS" \
                 -DSUITESPARSE_DEMOS=OFF \
                 -DBUILD_TESTING=OFF \
-                ${{ matrix.cuda-cmake-flags }} \
-                ${{ matrix.link-cmake-flags }} \
+                ${{ matrix.cuda == 'with'
+                  && '-DSUITESPARSE_USE_CUDA=ON \
+                      -DSUITESPARSE_USE_STRICT=ON \
+                      -DCUDAToolkit_INCLUDE_DIRS="/usr/include" \
+                      -DCMAKE_CUDA_COMPILER_LAUNCHER="ccache"'
+                  || '' }} \
+                ${{ matrix.link == 'static'
+                  && '-DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON'
+                  || '' }} \
                 ..
 
       - name: build libraries
@@ -213,8 +199,15 @@ jobs:
           cmake \
             -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/lib/cmake" \
             -DBLA_VENDOR="OpenBLAS" \
-            ${{ matrix.cuda-cmake-flags }} \
-            ${{ matrix.link-cmake-flags }} \
+            ${{ matrix.cuda == 'with'
+              && '-DSUITESPARSE_USE_CUDA=ON \
+                  -DSUITESPARSE_USE_STRICT=ON \
+                  -DCUDAToolkit_INCLUDE_DIRS="/usr/include" \
+                  -DCMAKE_CUDA_COMPILER_LAUNCHER="ccache"'
+              || '' }} \
+            ${{ matrix.link == 'static'
+              && '-DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON'
+              || '' }} \
             ..
           echo "::endgroup::"
           printf "::group::\033[0;32m==>\033[0m Building example\n"

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -573,15 +573,9 @@ endif ( )
 
 # CHOLMOD_CUDA
 if ( CHOLMOD_HAS_CUDA )
-#   cmake now configures cholmod.h with "#define CHOLMOD_HAS_CUDA" if CHOLMOD is
-#   being compiled with CUDA, so the -DCHOLMOD_HAS_CUDA flag is no longer needed.
-#   if ( BUILD_SHARED_LIBS )
-#       target_compile_definitions ( CHOLMOD PUBLIC "CHOLMOD_HAS_CUDA" )
-#   endif ( )
-#   set ( CHOLMOD_CFLAGS "${CHOLMOD_CFLAGS} -DCHOLMOD_HAS_CUDA" )
-#   if ( BUILD_STATIC_LIBS )
-#       target_compile_definitions ( CHOLMOD_static PUBLIC "CHOLMOD_HAS_CUDA" )
-#   endif ( )
+    if ( NOT CHOLMOD_HAS_OPENMP )
+      message ( FATAL_ERROR "CHOLMOD_CUDA requires OpenMP. But it has been disabled, or no working OpenMP could be found." )
+    endif ()
     if ( BUILD_SHARED_LIBS )
         target_link_libraries ( CHOLMOD PRIVATE CUDA::nvrtc CUDA::cudart_static CUDA::cublas )
         target_include_directories ( CHOLMOD INTERFACE

--- a/GraphBLAS/Demo/Program/grow_demo.c
+++ b/GraphBLAS/Demo/Program/grow_demo.c
@@ -19,8 +19,8 @@
 #include "import_test.c"
 #include "read_matrix.c"
 
-#include "omp.h"
 #if defined ( _OPENMP )
+#include <omp.h>
 #define WALLCLOCK omp_get_wtime ( )
 #else
 #define WALLCLOCK 0

--- a/GraphBLAS/Demo/Program/wathen_demo.c
+++ b/GraphBLAS/Demo/Program/wathen_demo.c
@@ -16,7 +16,7 @@
 #include "simple_rand.c"
 #include "wathen.c"
 #ifdef _OPENMP
-#include "omp.h"
+#include <omp.h>
 #endif
 
 // macro used by OK(...) to free workspace if an error occurs


### PR DESCRIPTION
The complexity of the build matrix for the Ubuntu runners grew to a level which made it very difficult to understand which set of runners will be started with which configuration.

Overhaul the build matrix settings by moving most of its complexity to the build steps.
That should make it easier to potentially adjust the settings for one of the runners in the matrix in the future.


It looks like the stack is smashed at some point in GraphBLAS when using Clang as the compiler on Ubuntu with optimization level `-O3`.

It's currently unclear to me why that happens. But changing the build type to "Debug" (i.e., optimization level `-O0`) works around that issue.


While looking at the issue with Clang on Ubuntu, I came across a couple other (less related) changes which I think are sensible:
* One of the demos for GraphBLAS failed to build when no OpenMP implementation was installed on the build host.
* Building failed late when CUDA was enabled but OpenMP wasn't available.

