### PR TITLE
SPEX: MPFR and GMP dependencies

### DIFF
--- a/Example/CMakeLists.txt
+++ b/Example/CMakeLists.txt
@@ -107,10 +107,6 @@ find_package ( SPEX 3.2.3 REQUIRED )    # requires GMP and MPFR
 find_package ( SPQR 4.3.4 REQUIRED )
 find_package ( UMFPACK 6.3.5 REQUIRED )
 
-# for GMP and MPFR
-find_package ( MPFR 4.0.2 REQUIRED )    # from SPEX/cmake_modules
-find_package ( GMP 6.1.2 REQUIRED )     # from SPEX/cmake_modules
-
 #-------------------------------------------------------------------------------
 # configure files
 #-------------------------------------------------------------------------------
@@ -510,8 +506,8 @@ endif ( )
 # other libraries
 #-------------------------------------------------------------------------------
 
-# The "MY" library does not directly rely on the OpenMP, libm, BLAS, and
-# LAPACK, libraries.  However, if you wish to create a library that uses those
+# The "MY" library does not directly rely on the OpenMP, libm, BLAS, LAPACK,
+# MPFR, and GMP libraries.  However, if you wish to create a library that uses those
 # libraries, uncomment the corresponding section.  These direct dependencies
 # are left out of the MY CMakeLists.txt, as a test for the other SuiteSparse
 # cmake build system, to ensure that the libraries should be linked via the
@@ -572,8 +568,6 @@ if ( 0 )
     endif ( )
     include_directories ( ${LAPACK_INCLUDE_DIRS} )
 
-endif ( )
-
     # MPFR:
     message ( STATUS "MPFR library:        ${MPFR_LIBRARIES}" )
     if ( BUILD_SHARED_LIBS )
@@ -597,6 +591,8 @@ endif ( )
         target_link_libraries ( my_cxx_static PUBLIC ${GMP_STATIC} )
     endif ( )
     include_directories ( ${GMP_INCLUDE_DIR} )
+
+endif ( )
 
 #-------------------------------------------------------------------------------
 # installation location

--- a/SPEX/cmake_modules/FindGMP.cmake
+++ b/SPEX/cmake_modules/FindGMP.cmake
@@ -73,13 +73,6 @@ if ( NOT GMP_FOUND )
         PATH_SUFFIXES lib build
     )
 
-    # check if found
-    if ( GMP_LIBRARY MATCHES ".*NOTFOUND" OR GMP_INCLUDE_DIR MATCHES ".*NOTFOUND" )
-        set ( FOUND_IT false )
-    else ( )
-        set ( FOUND_IT true )
-    endif ( )
-
     # static gmp library
     if ( NOT MSVC )
         set ( save_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} )
@@ -105,7 +98,8 @@ if ( NOT GMP_FOUND )
     # look in the middle for 6.2.1 (/spackstuff/gmp-6.2.1-morestuff/libgmp.10.4.1)
     string ( REGEX MATCH "gmp-[0-9]+.[0-9]+.[0-9]+" GMP_VERSION1 ${GMP_LIBRARY} )
 
-    if ( NOT FOUND_IT )
+    if ( (GMP_LIBRARY MATCHES ".*NOTFOUND" AND GMP_STATIC MATCHES ".*NOTFOUND")
+         OR GMP_INCLUDE_DIR MATCHES ".*NOTFOUND" )
         # gmp has not been found
         set ( GMP_VERSION 0.0.0 )
         message ( WARNING "GMP not found")

--- a/SPEX/cmake_modules/FindMPFR.cmake
+++ b/SPEX/cmake_modules/FindMPFR.cmake
@@ -71,13 +71,6 @@ if ( NOT MPFR_FOUND )
         PATH_SUFFIXES lib build
     )
 
-    # check if found
-    if ( MPFR_LIBRARY MATCHES ".*NOTFOUND" OR MPFR_INCLUDE_DIR MATCHES ".*NOTFOUND" )
-        set ( FOUND_IT false )
-    else ( )
-        set ( FOUND_IT true )
-    endif ( )
-
     # static mpfr library
     if ( NOT MSVC )
         set ( save_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} )
@@ -105,7 +98,8 @@ if ( NOT MPFR_FOUND )
     # look in the middle for 4.1.0 (/spackstuff/mpfr-4.1.0-morestuff/libmpfr.10.4.1)
     string ( REGEX MATCH "mpfr-[0-9]+.[0-9]+.[0-9]+" MPFR_VERSION1 ${MPFR_LIBRARY} )
 
-    if ( NOT FOUND_IT )
+    if ( (MPFR_LIBRARY MATCHES ".*NOTFOUND" AND MPFR_STATIC MATCHES ".*NOTFOUND")
+         OR MPFR_INCLUDE_DIR MATCHES ".*NOTFOUND" )
         # mpfr has not been found
         set ( MPFR_VERSION 0.0.0 )
         message ( WARNING "MPFR not found")


### PR DESCRIPTION
The first commit adapts the Find modules for MPFR and GMP in SPEX to correctly handle if only static versions of these libraries can be found on the build host.

The second commit removes the explicit search for these libraries in the build rules of the example. They are already looked for in the CMake module that comes with the SPEX library.
(Fwiw, all CMake modules that are installed with SuiteSparse check for their respective dependencies - like OpenMP, BLAS, or LAPACK - automatically. MPFR or GMP aren't different in that respect.)
