### PR TITLE
CI: Build with default optimization level using Clang on Ubuntu

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -145,7 +145,7 @@ jobs:
             printf "   \033[0;32m==>\033[0m Building library \033[0;32m${lib}\033[0m\n"
             echo "::group::Configure $lib"
             cd ${GITHUB_WORKSPACE}/${lib}/build
-            cmake -DCMAKE_BUILD_TYPE=${{ matrix.compiler == 'clang' && 'Debug' || 'Release' }} \
+            cmake -DCMAKE_BUILD_TYPE='Release' \
                   -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}" \
                   -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
                   -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \

--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -139,7 +139,7 @@ jobs:
       - name: configure
         run: |
           mkdir -p ${GITHUB_WORKSPACE}/build && cd ${GITHUB_WORKSPACE}/build
-          cmake -DCMAKE_BUILD_TYPE=${{ matrix.compiler == 'clang' && 'Debug' || 'Release' }} \
+          cmake -DCMAKE_BUILD_TYPE='Release' \
                 -DCMAKE_INSTALL_PREFIX=".." \
                 -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
                 -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \


### PR DESCRIPTION
The CI runners that use Clang on Ubuntu were switched to the `BUILD_TYPE` "Debug" to work around an issue at higher optimization levels. That issue was addressed at a more granular level in ddc884ec9b9091ac4d01b3481922548a155c8d74.

Switch the `BUILD_TYPE` back to "Release" for all compilers.
