### PR TITLE
disable cuda CI from root-cmakelists-msvc

### DIFF
--- a/.github/workflows/root-cmakelists-msvc.yaml
+++ b/.github/workflows/root-cmakelists-msvc.yaml
@@ -23,7 +23,9 @@ jobs:
     # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
     runs-on: windows-latest
 
-    name: msvc (${{ matrix.cc }} ${{ matrix.openmp }} OpenMP ${{ matrix.cuda }} CUDA, ${{ matrix.link }})
+#   cuda runners are timing out, as of Feb 25, 2025
+#   name: msvc (${{ matrix.cc }} ${{ matrix.openmp }} OpenMP ${{ matrix.cuda }} CUDA, ${{ matrix.link }})
+    name: msvc (${{ matrix.cc }} ${{ matrix.openmp }} OpenMP, ${{ matrix.link }})
 
     defaults:
       run:
@@ -36,38 +38,38 @@ jobs:
 
       matrix:
         openmp: [with]
-        cuda: [with]
+#       cuda: [with]
         link: [both]
         cc: [cl]
         cxx: [cl]
         include:
           - openmp: with
-            cuda: with
+#           cuda: with
             link: both
             cc: cl
             cxx: cl
           - openmp: with
-            cuda: without
+#           cuda: without
             link: both
             cc: cl
-            cxx: cl
+            cxx: clk
           - openmp: without
-            cuda: without
+#           cuda: without
             link: both
             cc: cl
             cxx: cl
           - openmp: with
-            cuda: with
+#           cuda: with
             link: static
             cc: cl
             cxx: cl
           - openmp: with
-            cuda: without
+#           cuda: without
             link: both
             cc: clang-cl
             cxx: clang-cl
           - openmp: with
-            cuda: without
+#           cuda: without
             link: both
             cc: clang
             cxx: clang++


### PR DESCRIPTION
As of about Feb 25, 2025, the cuda case for root-cmakelists-msvc is timing out after 6 hours.  It fails to download the cuda toolkit.  This error is not in SuiteSparse itself, so disable them for now.
