### PR TITLE
CHOLMOD: Use CUDA as linker language if applicable

### DIFF
--- a/.github/workflows/root-cmakelists-msvc.yaml
+++ b/.github/workflows/root-cmakelists-msvc.yaml
@@ -23,7 +23,7 @@ jobs:
     # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
     runs-on: windows-latest
 
-    name: msvc (${{ matrix.cc }} ${{ matrix.openmp }} OpenMP, ${{ matrix.link }})
+    name: msvc (${{ matrix.cc }} ${{ matrix.openmp }} OpenMP ${{ matrix.cuda }} CUDA, ${{ matrix.link }})
 
     defaults:
       run:
@@ -36,23 +36,33 @@ jobs:
 
       matrix:
         openmp: [with]
+        cuda: [without]
         link: [both]
         cc: [cl]
         cxx: [cl]
         include:
           - openmp: with
+            cuda: with
+            link: both
+            cc: cl
+            cxx: cl
+          - openmp: with
+            cuda: without
             link: both
             cc: cl
             cxx: cl
           - openmp: without
+            cuda: without
             link: both
             cc: cl
             cxx: cl
           - openmp: with
+            cuda: without
             link: both
             cc: clang-cl
             cxx: clang-cl
           - openmp: with
+            cuda: without
             link: both
             cc: clang
             cxx: clang++

--- a/.github/workflows/root-cmakelists-msvc.yaml
+++ b/.github/workflows/root-cmakelists-msvc.yaml
@@ -47,6 +47,11 @@ jobs:
             cc: cl
             cxx: cl
           - openmp: with
+            cuda: with
+            link: static
+            cc: cl
+            cxx: cl
+          - openmp: with
             cuda: without
             link: both
             cc: cl

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -383,12 +383,16 @@ if ( BUILD_SHARED_LIBS )
         OUTPUT_NAME cholmod
         SOVERSION ${CHOLMOD_VERSION_MAJOR}
         PUBLIC_HEADER "Include/cholmod.h"
-        WINDOWS_EXPORT_ALL_SYMBOLS ON
-        LINKER_LANGUAGE C )
+        WINDOWS_EXPORT_ALL_SYMBOLS ON )
 
     if ( CHOLMOD_HAS_CUDA )
-        set_target_properties ( CHOLMOD PROPERTIES CUDA_SEPARABLE_COMPILATION ON )
-        set_target_properties ( CHOLMOD PROPERTIES POSITION_INDEPENDENT_CODE ON )
+        set_target_properties ( CHOLMOD PROPERTIES
+            POSITION_INDEPENDENT_CODE ON
+            CUDA_SEPARABLE_COMPILATION ON
+            LINKER_LANGUAGE CUDA )
+    else ( )
+        set_target_properties ( CHOLMOD PROPERTIES
+            LINKER_LANGUAGE C )
     endif ( )
 
     if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )
@@ -411,8 +415,7 @@ if ( BUILD_STATIC_LIBS )
         C_STANDARD 11
         C_STANDARD_REQUIRED ON
         OUTPUT_NAME cholmod
-        PUBLIC_HEADER "Include/cholmod.h"
-        LINKER_LANGUAGE C )
+        PUBLIC_HEADER "Include/cholmod.h" )
 
     if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
         set_target_properties ( CHOLMOD_static PROPERTIES
@@ -420,8 +423,13 @@ if ( BUILD_STATIC_LIBS )
     endif ( )
 
     if ( CHOLMOD_HAS_CUDA )
-        set_target_properties ( CHOLMOD_static PROPERTIES CUDA_SEPARABLE_COMPILATION on )
-        set_target_properties ( CHOLMOD_static PROPERTIES POSITION_INDEPENDENT_CODE on )
+        set_target_properties ( CHOLMOD_static PROPERTIES
+            POSITION_INDEPENDENT_CODE ON
+            CUDA_SEPARABLE_COMPILATION ON
+            LINKER_LANGUAGE CUDA )
+    else ( )
+        set_target_properties ( CHOLMOD_static PROPERTIES
+            LINKER_LANGUAGE C )
     endif ( )
 
     if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.25" )

--- a/CHOLMOD/CMakeLists.txt
+++ b/CHOLMOD/CMakeLists.txt
@@ -423,9 +423,15 @@ if ( BUILD_STATIC_LIBS )
     endif ( )
 
     if ( CHOLMOD_HAS_CUDA )
+        # Dependencies that are linking to this static library would need to
+        # use the CUDA compiler as the linker driver. Ideally, CMake would do
+        # that automatically. Until that is fixed in CMake, set the
+        # CUDA_RESOLVE_DEVICE_SYMBOLS property ON.
         set_target_properties ( CHOLMOD_static PROPERTIES
             POSITION_INDEPENDENT_CODE ON
             CUDA_SEPARABLE_COMPILATION ON
+            CUDA_RESOLVE_DEVICE_SYMBOLS ON
+            CUDA_RUNTIME_LIBRARY Static
             LINKER_LANGUAGE CUDA )
     else ( )
         set_target_properties ( CHOLMOD_static PROPERTIES


### PR DESCRIPTION
Use CUDA as the linker language if applicable while still avoiding Fortran as the linker language (see #799).

Addresses #929.

I seem to recall that there were CI runners that tested with CUDA using MSVC on Windows. It looks like there are none any more.
Also add one runner that tests building with CUDA on Windows (again?).