### PR TITLE
CI (alpine): Use Ubuntu on ARM runners for armv7

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         # For available CPU architectures, see:
         # https://github.com/marketplace/actions/setup-alpine-linux-environment
-        arch: [x86, armv7, ppc64le, s390x, riscv64]
+        arch: [x86, armv7, ppc64le, s390x, riscv64, loongarch64]
         include:
           - arch: x86
             ccache-max: 64M
@@ -52,6 +52,8 @@ jobs:
             ccache-max: 28M
           - arch: riscv64
             ccache-max: 28M
+          - arch: loongarch64
+            ccache-max: 30M
 
     name: alpine (${{ matrix.arch }})
 

--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -21,7 +21,8 @@ env:
 jobs:
 
   alpine:
-    runs-on: ubuntu-latest
+    # Run armv7 on aarch64 runners
+    runs-on: ${{ matrix.arch == 'armv7' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
 
     defaults:
       run:
@@ -42,7 +43,9 @@ jobs:
             extra-build-libs: ":GraphBLAS:LAGraph"
             extra-check-libs: ":GraphBLAS:LAGraph"
           - arch: armv7
-            ccache-max: 25M
+            ccache-max: 60M
+            extra-build-libs: ":GraphBLAS:LAGraph"
+            extra-check-libs: ":GraphBLAS:LAGraph"
           - arch: ppc64le
             ccache-max: 28M
           - arch: s390x
@@ -66,6 +69,9 @@ jobs:
         # shell: bash
         with:
           arch: ${{ matrix.arch }}
+          apk-tools-url: ${{ matrix.arch == 'armv7'
+              && 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/aarch64/apk.static#!sha256!27a975638ddc95a411c9f17c63383e335da9edf6bb7de2281d950c291a11f878'
+              || 'https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.7/x86_64/apk.static#!sha256!bdd044e0fd6cc388c5e571e1093efa5f35f7767cc5aa338b0a2576a429009a62' }}
           packages: >
             build-base
             ccache
@@ -81,6 +87,11 @@ jobs:
             automake
             libtool
           # ${{ matrix.arch != 'riscv64' && 'valgrind' || '' }}
+
+      - name: disable QEMU emulation
+        if: matrix.arch == 'armv7'
+        shell: bash
+        run: sudo update-binfmts --disable qemu-arm
 
       - name: get CPU information (emulated)
         run: lscpu


### PR DESCRIPTION
The armv7 architecture can run natively on the aarch64 CPUs of the GitHub-hosted Ubuntu on ARM runners which makes it a lot faster than emulation on an x86_64 CPU. That allows to also build GraphBLAS and LAGraph for that architecture in an acceptable amount of time now.

With thanks to @bgilbert for the instructions how to use the GitHub-hosted Ubuntu on ARM runners with the setup-alpine action.

Also, add a runner that emulates loongarch64 (supported since Alpine Linux 3.21).