### PR TITLE
Support building SuiteSparse_config without BLAS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ endforeach ( )
 
 # CHOLMOD options affecting dependencies
 option ( CHOLMOD_CAMD "ON (default): use CAMD/CCOLAMD.  OFF: do not use CAMD/CCOLAMD" ON )
+option ( CHOLMOD_SUPERNODAL "ON (default): use Supernodal Module.  OFF: do not use Supernodal Module" ON )
 
 # KLU options affecting dependencies
 option ( KLU_USE_CHOLMOD "ON (default): use CHOLMOD in KLU.  OFF: do not use CHOLMOD in KLU" ON )
@@ -265,6 +266,19 @@ if ( CMAKE_VERSION VERSION_LESS 3.24 )
     endif ( )
 endif ( )
 
+
+# BLAS is only required for some sub-projects
+option ( SUITESPARSE_REQUIRE_BLAS "Must not be set to OFF if any SuiteSparse project requires BLAS functions" ON )
+
+if ( ("cholmod" IN_LIST SUITESPARSE_ENABLE_PROJECTS AND CHOLMOD_SUPERNODAL)
+        OR "paru" IN_LIST SUITESPARSE_ENABLE_PROJECTS
+        OR "spqr" IN_LIST SUITESPARSE_ENABLE_PROJECTS
+        OR "umfpack" IN_LIST SUITESPARSE_ENABLE_PROJECTS )
+    if ( NOT SUITESPARSE_REQUIRE_BLAS )
+        message ( FATAL_ERROR "SUITESPARSE_REQUIRE_BLAS must not be set to OFF when building CHOLMOD with SUPERNODAL, ParU, SPQR, or UMFPACK." )
+    endif ( )
+
+endif ( )
 
 #-------------------------------------------------------------------------------
 # include selected projects

--- a/SuiteSparse_config/CMakeLists.txt
+++ b/SuiteSparse_config/CMakeLists.txt
@@ -127,7 +127,19 @@ endif ( )
 # find the BLAS
 #-------------------------------------------------------------------------------
 
-include ( SuiteSparseBLAS )
+option ( SUITESPARSE_REQUIRE_BLAS "Must not be set to OFF if any SuiteSparse project requires BLAS functions" ON )
+
+if ( SUITESPARSE_REQUIRE_BLAS )
+    include ( SuiteSparseBLAS )
+else ( )
+    # It doesn't actually matter which Fortran integer size is selected here.
+    # But we might as well respect any user flags.
+    if ( SUITESPARSE_USE_64BIT_BLAS )
+        include ( SuiteSparseBLAS64 )
+    else ( )
+        include ( SuiteSparseBLAS32 )
+    endif ( )
+endif ( )
 
 #-------------------------------------------------------------------------------
 # configure files


### PR DESCRIPTION
BLAS is a dependency of SuiteSparse_config for some helper functions that can be used in other SuiteSparse libraries. If no SuiteSparse library that depends on BLAS is build, these helper functions are not used, and they are allowed to return anything in general without potential adverse side effects.

Add a new configuration flag `SUITESPARSE_REQUIRE_BLAS` that can be used to manually remove the requirement for a BLAS implementation when building SuiteSparse_config.

If a user sets `SUITESPARSE_REQUIRE_BLAS` to OFF and attempts to build a library that requires a BLAS library using the root `CMakeLists.txt` file, an error message is shown during configuration.

Fixes #934.

