### PR TITLE
CI (alpine): Install `lscpu` package.

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -84,7 +84,7 @@ jobs:
             mpfr-dev
             lapack-dev
             python3
-            util-linux-misc
+            lscpu
             autoconf
             automake
             libtool


### PR DESCRIPTION
It looks like the Alpine Linux packagers moved the `lscpu` tool out of the `util-linux-misc` package into its own separate package. Install that new package specifically now.
