### PR TITLE
CI: Save the ccache even on build or test errors

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -129,6 +129,7 @@ jobs:
           # echo "/usr/lib/ccache" >> $GITHUB_PATH
 
       - name: build
+        id: build
         run: |
           echo "gcc --version"
           gcc --version
@@ -171,12 +172,14 @@ jobs:
           done
 
       - name: ccache status
+        if: always() && (steps.build.outcome != 'skipped')
         continue-on-error: true
         run: ccache -s
 
       - name: save ccache
-        # Save the cache after we are done (successfully) building
+        # Save the cache after we are done building
         # This helps to retain the ccache even if the subsequent steps are failing.
+        if: always() && (steps.build.outcome != 'skipped')
         uses: actions/cache/save@v4
         with:
           path: /home/runner/rootfs/alpine-latest-${{ matrix.arch }}/home/runner/.ccache

--- a/.github/workflows/build-mingw.yaml
+++ b/.github/workflows/build-mingw.yaml
@@ -124,6 +124,7 @@ jobs:
           ccache -s
 
       - name: build
+        id: build
         run: |
           IFS=':' read -r -a libs <<< "${BUILD_LIBS}"
           for lib in "${libs[@]}"; do
@@ -163,12 +164,14 @@ jobs:
           done
 
       - name: ccache status
+        if: always() && (steps.build.outcome != 'skipped')
         continue-on-error: true
         run: ccache -s
 
       - name: save ccache
-        # Save the cache after we are done (successfully) building
+        # Save the cache after we are done building
         # This helps to retain the ccache even if the subsequent steps are failing.
+        if: always() && (steps.build.outcome != 'skipped')
         uses: actions/cache/save@v4
         with:
           path: ${{ steps.ccache-prepare.outputs.ccachedir }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -140,6 +140,7 @@ jobs:
           echo "/usr/lib/ccache" >> $GITHUB_PATH
 
       - name: build
+        id: build
         run: |
           IFS=':' read -r -a libs <<< "${BUILD_LIBS}"
           for lib in "${libs[@]}"; do
@@ -184,12 +185,14 @@ jobs:
           done
 
       - name: ccache status
+        if: always() && (steps.build.outcome != 'skipped')
         continue-on-error: true
         run: ccache -s
 
       - name: save ccache
-        # Save the cache after we are done (successfully) building
+        # Save the cache after we are done building
         # This helps to retain the ccache even if the subsequent steps are failing.
+        if: always() && (steps.build.outcome != 'skipped')
         uses: actions/cache/save@v4
         with:
           path: ~/.ccache

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -83,6 +83,7 @@ jobs:
           ccache -s
 
       - name: build
+        id: build
         run: |
           IFS=':' read -r -a libs <<< "${BUILD_LIBS}"
           for lib in "${libs[@]}"; do
@@ -191,12 +192,14 @@ jobs:
           make demos
 
       - name: ccache status
+        if: always() && (steps.build.outcome != 'skipped')
         continue-on-error: true
         run: ccache -s
 
       - name: save ccache
-        # Save the cache after we are done (successfully) building
+        # Save the cache after we are done building
         # This helps to retain the ccache even if the subsequent steps are failing.
+        if: always() && (steps.build.outcome != 'skipped')
         uses: actions/cache/save@v4
         with:
           path: /Users/runner/Library/Caches/ccache

--- a/.github/workflows/root-cmakelists-msvc.yaml
+++ b/.github/workflows/root-cmakelists-msvc.yaml
@@ -234,6 +234,7 @@ jobs:
                 ..
 
       - name: build libraries
+        id: build
         run: |
           cd ${GITHUB_WORKSPACE}/build
           cmake --build . --config Release
@@ -251,12 +252,14 @@ jobs:
           # FIXME: How to run the demos without Makefile?
 
       - name: ccache status
+        if: always() && (steps.build.outcome != 'skipped')
         continue-on-error: true
         run: ${CCACHE} -s
 
       - name: save ccache
-        # Save the cache after we are done (successfully) building
+        # Save the cache after we are done building
         # This helps to retain the ccache even if the subsequent steps are failing.
+        if: always() && (steps.build.outcome != 'skipped')
         uses: actions/cache/save@v4
         with:
           path: ${{ steps.ccache-prepare.outputs.ccachedir }}

--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -160,6 +160,7 @@ jobs:
                 ..
 
       - name: build libraries
+        id: build
         run: |
           cd ${GITHUB_WORKSPACE}/build
           cmake --build .
@@ -177,12 +178,14 @@ jobs:
           # FIXME: How to run the demos without Makefile?
 
       - name: ccache status
+        if: always() && (steps.build.outcome != 'skipped')
         continue-on-error: true
         run: ccache -s
 
       - name: save ccache
-        # Save the cache after we are done (successfully) building.
+        # Save the cache after we are done building
         # This helps to retain the ccache even if the subsequent steps are failing.
+        if: always() && (steps.build.outcome != 'skipped')
         uses: actions/cache/save@v4
         with:
           path: ~/.ccache


### PR DESCRIPTION
That helps by speeding up the iterations if the CI is used to fix build or test errors.

Without the proposed changes, the ccache isn't saved on a build or test error, and the next iteration starts with an empty cache again (so, it is slow). 

With the proposed changes, the ccache is saved as long as the CI successfully starts the "build" step. So, the ccache is retained for the next iteration, and the build step will be faster.

