### PR TITLE
CI (MSVC): Build more configurations with `clang-cl`

### DIFF
--- a/.github/workflows/root-cmakelists-msvc.yaml
+++ b/.github/workflows/root-cmakelists-msvc.yaml
@@ -38,34 +38,34 @@ jobs:
         openmp: [with]
         cuda: [without]
         link: [both]
-        cc: [cl]
-        cxx: [cl]
+        cc: [clang-cl]
+        cxx: [clang-cl]
         include:
           - openmp: with
             cuda: with
             link: both
-            cc: cl
-            cxx: cl
+            cc: clang-cl
+            cxx: clang-cl
           - openmp: with
             cuda: with
             link: static
-            cc: cl
-            cxx: cl
-          - openmp: with
-            cuda: without
-            link: both
-            cc: cl
-            cxx: cl
+            cc: clang-cl
+            cxx: clang-cl
           - openmp: without
             cuda: without
             link: both
-            cc: cl
-            cxx: cl
+            cc: clang-cl
+            cxx: clang-cl
           - openmp: with
             cuda: without
             link: both
             cc: clang-cl
             cxx: clang-cl
+          - openmp: with
+            cuda: without
+            link: both
+            cc: cl
+            cxx: cl
           - openmp: with
             cuda: without
             link: both


### PR DESCRIPTION
Running the tests for LAGraph takes pretty long (approx. 30 minutes) if a compiler (like `cl` from MSVC) is used that only supports OpenMP 2.0.

Build more configurations for the MSVC target with LLVM `clang-cl` which supports OpenMP 5.1.

This depends on the changes from #952 which is needed to build LAGraph for a MSVC target.