### PR TITLE
Replacing emulation with cross-compilation in the build-arch-emu.yaml workflow to speed up SuiteSparse builds

### DIFF
--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -46,12 +46,6 @@ jobs:
             ccache-max: 60M
             extra-build-libs: ":GraphBLAS:LAGraph"
             extra-check-libs: ":GraphBLAS:LAGraph"
-          - arch: ppc64le
-            ccache-max: 28M
-          - arch: s390x
-            ccache-max: 28M
-          - arch: riscv64
-            ccache-max: 28M
           - arch: loongarch64
             ccache-max: 30M
 

--- a/.github/workflows/build-arch-emu.yaml
+++ b/.github/workflows/build-arch-emu.yaml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         # For available CPU architectures, see:
         # https://github.com/marketplace/actions/setup-alpine-linux-environment
-        arch: [x86, armv7, ppc64le, s390x, riscv64, loongarch64]
+        arch: [x86, armv7, loongarch64]
         include:
           - arch: x86
             ccache-max: 64M

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -52,10 +52,10 @@ jobs:
     name: cross-compile (${{ matrix.arch }})
 
     env:
-      CC: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && "clang" || "${{ matrix.target-triple }}-gcc" }}
-      CXX: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && "clang++" || "${{ matrix.target-triple }}-g++" }}
-      CFLAGS: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && "--target=${{ matrix.target-triple }}" }}
-      CXXFLAGS: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && "--target=${{ matrix.target-triple }}" }}
+      CC: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && 'clang' || ${{ matrix.target-triple }}-gcc }}
+      CXX: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && 'clang++' || ${{ matrix.target-triple }}-g++ }}
+      CFLAGS: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && --target=${{ matrix.target-triple }} }}
+      CXXFLAGS: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && --target=${{ matrix.target-triple }} }}
       FC: ${{ matrix.target-triple }}-gfortran
       LD_LIBRARY_PATH: "/usr/lib/${{ matrix.target-triple }}"
 

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -171,8 +171,8 @@ jobs:
 
       - name: build
         run: |
-          echo "clang --version"
-          clang --version
+          echo "${CC} --version"
+          ${CC} --version
           IFS=:
           for lib in ${BUILD_LIBS}; do
             printf "   \033[0;32m==>\033[0m Building library \033[0;32m${lib}\033[0m\n"

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -186,10 +186,8 @@ jobs:
 
       - name: build
         run: |
-          echo "${{ matrix.cc }} --version"
-          ${{ matrix.cc }} --version
-          echo "${{ matrix.cc }} -dumpmachine"
-          ${{ matrix.cc }} -dumpmachine
+          echo "clang --version"
+          clang --version
           IFS=:
           for lib in ${BUILD_LIBS}; do
             printf "   \033[0;32m==>\033[0m Building library \033[0;32m${lib}\033[0m\n"

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -76,8 +76,7 @@ jobs:
       CFLAGS: "--target=${{ matrix.target-triple }}"
       CXXFLAGS: "--target=${{ matrix.target-triple }}"
       FC: ${{ matrix.target-triple }}-gfortran-14
-      LD_LIBRARY_PATH: "/usr/${{ matrix.target-triple }}/lib"
-      LIBRARY_PATH: "/usr/${{ matrix.target-triple }}/lib"
+      LD_LIBRARY_PATH: "/usr/lib/${{ matrix.target-triple }}"
 
     steps:
       - name: get CPU information

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -52,10 +52,10 @@ jobs:
     name: cross-compile (${{ matrix.arch }})
 
     env:
-      CC: clang
-      CXX: clang++
-      CFLAGS: "--target=${{ matrix.target-triple }}"
-      CXXFLAGS: "--target=${{ matrix.target-triple }}"
+      CC: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && 'clang' || '${{ matrix.target-triple }}-gcc' }}
+      CXX: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && 'clang++' || '${{ matrix.target-triple }}-g++' }}
+      CFLAGS: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && '--target=${{ matrix.target-triple }}'}}
+      CXXFLAGS: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && '--target=${{ matrix.target-triple }}'}}
       FC: ${{ matrix.target-triple }}-gfortran
       LD_LIBRARY_PATH: "/usr/lib/${{ matrix.target-triple }}"
 

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -54,8 +54,8 @@ jobs:
     name: cross-compile (${{ matrix.arch }})
 
     env:
-      CC: ${{ matrix.arch == 'armhf' && 'arm-linux-gnueabihf-gcc' || matrix.arch == 'riscv64' && 'riscv64-linux-gnueabihf-gcc' || 'clang' }}
-      CXX: ${{ matrix.arch == 'armhf' && 'arm-linux-gnueabihf-g++' || matrix.arch == 'riscv64' && 'riscv64-linux-gnueabihf-g++' || 'clang++' }}
+      CC: ${{ matrix.arch == 'armhf' && 'arm-linux-gnueabihf-gcc' || matrix.arch == 'riscv64' && 'riscv64-linux-gnu-gcc' || 'clang' }}
+      CXX: ${{ matrix.arch == 'armhf' && 'arm-linux-gnueabihf-g++' || matrix.arch == 'riscv64' && 'riscv64-linux-gnu-g++' || 'clang++' }}
       CFLAGS: ${{ matrix.flags }}
       CXXFLAGS: ${{ matrix.flags }}
       FC: ${{ matrix.target-triple }}-gfortran

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -33,40 +33,20 @@ jobs:
       fail-fast: false
 
       matrix:
-        arch: [riscv64]
+        arch: [armhf, ppc64el, s390x, riscv64]
         include:
           - arch: armhf
             target-triple: arm-linux-gnueabihf
-            cross-toolchain: g++-14-arm-linux-gnueabihf
-            # fortran-cross-toolchain: gfortran-14-arm-linux-gnueabihf
-            # cc: "arm-linux-gnueabihf-gcc-9"
-            # cxx: "arm-linux-gnueabihf-g++-9"
-            # fc: "arm-linux-gnueabihf-gfortran-14"
             ccache-max: 64M
           - arch: ppc64el
             target-triple: powerpc64le-linux-gnu
-            cross-toolchain: g++-14-powerpc64le-linux-gnu
             add-libs: libquadmath0:ppc64el
-            # fortran-cross-toolchain: gfortran-14-powerpc64le-linux-gnu
-            # cc: "powerpc64le-linux-gnu-gcc-9"
-            # cxx: "powerpc64le-linux-gnu-g++-9"
-            # fc: "powerpc64le-linux-gnu-gfortran-14"
             ccache-max: 64M
           - arch: s390x
             target-triple: s390x-linux-gnu
-            cross-toolchain: g++-14-s390x-linux-gnu
-            # fortran-cross-toolchain: gfortran-14-s390x-linux-gnu
-            # cc: "s390x-linux-gnu-gcc-9"
-            # cxx: "s390x-linux-gnu-g++-9"
-            # fc: "s390x-linux-gnu-gfortran-14"
             ccache-max: 64M
           - arch: riscv64
             target-triple: riscv64-linux-gnu
-            cross-toolchain: g++-14-riscv64-linux-gnu
-            fortran-cross-toolchain: gfortran-14-riscv64-linux-gnu
-            # cc: "riscv64-linux-gnu-gcc-9"
-            # cxx: "riscv64-linux-gnu-g++-9"
-            # fc: "riscv64-linux-gnu-gfortran-14"
             ccache-max: 64M
 
     name: cross-compile (${{ matrix.arch }})
@@ -76,7 +56,7 @@ jobs:
       CXX: clang++
       CFLAGS: "--target=${{ matrix.target-triple }}"
       CXXFLAGS: "--target=${{ matrix.target-triple }}"
-      FC: ${{ matrix.target-triple }}-gfortran-14
+      FC: ${{ matrix.target-triple }}-gfortran
       LD_LIBRARY_PATH: "/usr/lib/${{ matrix.target-triple }}"
 
     steps:
@@ -104,7 +84,7 @@ jobs:
       - name: install cross-toolchain
         run: |
           echo "::group::Install cross-toolchain for ${{ matrix.arch }}"
-          sudo apt -y install clang ${{ matrix.cross-toolchain }} gfortran-14-${{ matrix.target-triple }}
+          sudo apt -y install clang g++-${{ matrix.target-triple }} gfortran-${{ matrix.target-triple }}
           echo "::endgroup::"
 
       - name: configure Multiarch

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -1,0 +1,321 @@
+name: cross-compile
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - '**/dev2'
+      - '**/*dev2'
+  pull_request:
+
+concurrency: ci-cross-compile-${{ github.ref }}
+
+env:
+  # string with name of libraries to be built
+  BUILD_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:ParU:RBio:SPQR:SPEX:GraphBLAS:LAGraph"
+  # string with name of libraries to be checked
+  CHECK_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CSparse:CXSparse:LDL:KLU:UMFPACK:ParU:RBio:SPQR:SPEX:GraphBLAS:LAGraph"
+  # string with name of libraries that are installed
+  INSTALLED_LIBS: "SuiteSparse_config:Mongoose:AMD:BTF:CAMD:CCOLAMD:COLAMD:CHOLMOD:CXSparse:LDL:KLU:UMFPACK:ParU:RBio:SPQR:SPEX:GraphBLAS:LAGraph"
+
+
+jobs:
+
+  cross-compile:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        # Use bash shell as default
+        shell: bash
+
+    strategy:
+      # Allow other runners in the matrix to continue if some fail
+      fail-fast: false
+
+      matrix:
+        arch: [amd64, armhf, ppc64el, s390x, riscv64]
+        include:
+          - arch: amd64
+            cc: gcc
+            ccache-max: 64M
+          - arch: armhf
+            target_system: arm-linux-gnueabihf
+            cross-toolchain: g++-9-arm-linux-gnueabihf
+            fortran-cross-toolchain: gfortran-10-arm-linux-gnueabihf
+            cc: "arm-linux-gnueabihf-gcc-9"
+            cxx: "arm-linux-gnueabihf-g++-9"
+            fc: "arm-linux-gnueabihf-gfortran-10"
+            ccache-max: 64M
+          - arch: ppc64el
+            target_system: powerpc64le-linux-gnu
+            cross-toolchain: g++-9-powerpc64le-linux-gnu 
+            fortran-cross-toolchain: gfortran-10-powerpc64le-linux-gnu
+            cc: "powerpc64le-linux-gnu-gcc-9"
+            cxx: "powerpc64le-linux-gnu-g++-9"
+            fc: "powerpc64le-linux-gnu-gfortran-10"
+            ccache-max: 64M
+          - arch: s390x
+            target_system: s390x-linux-gnu
+            cross-toolchain: g++-9-s390x-linux-gnu 
+            fortran-cross-toolchain: gfortran-10-s390x-linux-gnu
+            cc: "s390x-linux-gnu-gcc-9"
+            cxx: "s390x-linux-gnu-g++-9"
+            fc: "s390x-linux-gnu-gfortran-10"
+            ccache-max: 64M
+          - arch: riscv64
+            target_system: riscv64-linux-gnu
+            cross-toolchain: g++-9-riscv64-linux-gnu 
+            fortran-cross-toolchain: gfortran-10-riscv64-linux-gnu
+            cc: "riscv64-linux-gnu-gcc-9"
+            cxx: "riscv64-linux-gnu-g++-9"
+            fc: "riscv64-linux-gnu-gfortran-10"
+            ccache-max: 64M
+
+    name: cross-compile (${{ matrix.arch }})
+
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+      FC: ${{ matrix.fc }}
+      LD_LIBRARY_PATH: "/usr/${{ matrix.target_system }}/lib"
+      LIBRARY_PATH: "/usr/${{ matrix.target_system }}/lib"
+
+    steps:
+      - name: get CPU information
+        run: lscpu
+
+      - name: install some aux utilities
+        run: |
+          echo "::group::Install cross-toolchain for ${{ matrix.arch }}"
+          sudo apt -y install \
+            cmake \
+            make \
+            ccache \
+            automake \
+            libtool \
+            qemu-user-binfmt
+          echo "::endgroup::"
+
+      - name: checkout repository
+        uses: actions/checkout@v4
+
+      - name: install cross-toolchain
+        run: |
+          if [[ ${{ matrix.arch }} != 'amd64' ]]; then
+            echo "::group::Install cross-toolchain for ${{ matrix.arch }}"
+            sudo apt -y install ${{ matrix.cross-toolchain }} ${{ matrix.fortran-cross-toolchain }}
+            echo "::endgroup::"
+          else
+            echo "Target architecture is ${{ matrix.arch }}, cross-compilation isn't required, cross-toolchain installation isn't required."
+          fi
+
+      - name: configure Multiarch
+        # deb822-style format is a new format supported by apt itself since version 1.1:
+        # https://manpages.ubuntu.com/manpages/noble/man5/sources.list.5.html
+        run: |
+          if [[ ${{ matrix.arch }} != 'amd64' ]]; then
+            sudo dpkg --add-architecture ${{ matrix.arch }}
+            sudo bash -c 'cat - >/etc/apt/sources.list.d/ubuntu.sources' <<-EOF
+          	Types: deb
+          	URIs: http://archive.ubuntu.com/ubuntu/
+          	Suites: noble noble-updates noble-backports
+          	Components: main restricted universe multiverse
+          	Architectures: amd64
+          	Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          	
+          	Types: deb
+          	URIs: http://security.ubuntu.com/ubuntu/
+          	Suites: noble-security
+          	Components: main restricted universe multiverse
+          	Architectures: amd64
+          	Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          	
+          	Types: deb
+          	URIs: http://ports.ubuntu.com/ubuntu-ports/
+          	Suites: noble noble-updates noble-backports
+          	Components: main restricted universe multiverse
+          	Architectures: ${{ matrix.arch }}
+          	Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          	
+          	Types: deb
+          	URIs: http://security.ports.ubuntu.com/ubuntu-ports/
+          	Suites: noble-security
+          	Components: main restricted universe multiverse
+          	Architectures: ${{ matrix.arch }}
+          	Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          	
+          	EOF
+            echo "::group::Updating package indexes with new indexes for ${{ matrix.arch }} packages"
+            sudo apt update
+            echo "::endgroup::"
+          else
+            echo "Target architecture is ${{ matrix.arch }}, Multiarch configuration isn't required."
+          fi
+
+      - name: install cross-dependencies (using Multiarch)
+        run: |
+          echo "::group::Installing dependencies for target arch ${{ matrix.arch }}"
+          sudo apt -y install \
+            libopenblas-openmp-dev:${{ matrix.arch }} \
+            libmpfr-dev:${{ matrix.arch }}
+          echo "::endgroup::"
+
+      - name: prepare ccache
+        # create key with human readable timestamp
+        # used in action/cache/restore and action/cache/save steps
+        id: ccache-prepare
+        run: |
+          echo "key=ccache:cross-compile:${{ matrix.arch }}:${{ github.ref }}:$(date +"%Y-%m-%d_%H-%M-%S"):${{ github.sha }}" >> $GITHUB_OUTPUT
+
+      - name: restore ccache
+        # setup the GitHub cache used to maintain the ccache from one job to the next
+        uses: actions/cache/restore@v4
+        with:
+          # location of the ccache of the chroot in the root file system
+          path: /home/runner/.ccache
+          key: ${{ steps.ccache-prepare.outputs.key }}
+          # Prefer caches from the same branch. Fall back to caches from the dev branch.
+          restore-keys: |
+            ccache:cross-compile:${{ matrix.arch }}:${{ github.ref }}
+            ccache:cross-compile:${{ matrix.arch }}
+
+      - name: configure ccache
+        env:
+          CCACHE_MAX: ${{ matrix.ccache-max }}
+        run: |
+          test -d ~/.ccache || mkdir ~/.ccache
+          echo "max_size = $CCACHE_MAX" >> ~/.ccache/ccache.conf
+          echo "compression = true" >> ~/.ccache/ccache.conf
+          ccache -s
+
+          which ccache
+          # echo "/usr/lib/ccache" >> $GITHUB_PATH
+
+      - name: build
+        run: |
+          echo "${{ matrix.cc }} --version"
+          ${{ matrix.cc }} --version
+          echo "${{ matrix.cc }} -dumpmachine"
+          ${{ matrix.cc }} -dumpmachine
+          IFS=:
+          for lib in ${BUILD_LIBS}; do
+            printf "   \033[0;32m==>\033[0m Building library \033[0;32m${lib}\033[0m\n"
+            echo "::group::Configure $lib"
+            cd ${GITHUB_WORKSPACE}/${lib}/build
+            PKG_CONFIG_PATH=/usr/lib/${{ matrix.target_system }}/pkgconfig/ \
+            cmake -DCMAKE_BUILD_TYPE="Release" \
+                  -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}" \
+                  -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
+                  -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
+                  -DCMAKE_Fortran_COMPILER_LAUNCHER="ccache" \
+                  -DBUILD_SHARED_LIBS=ON \
+                  -DBUILD_STATIC_LIBS=OFF \
+                  -DBLA_VENDOR="Generic" \
+                  -DGRAPHBLAS_COMPACT=ON \
+                  -DSUITESPARSE_DEMOS=OFF \
+                  -DBUILD_TESTING=OFF \
+                  ..
+            echo "::endgroup::"
+            echo "::group::Build $lib"
+            cmake --build . --config Release
+            echo "::endgroup::"
+          done
+
+      - name: check
+        timeout-minutes: 60
+        run: |
+          IFS=':'
+          for lib in ${CHECK_LIBS}; do
+            printf "::group::   \033[0;32m==>\033[0m Checking library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/${lib}
+            make demos CMAKE_OPTIONS="-DSUITESPARSE_DEMOS=ON -DBUILD_TESTING=ON"
+            echo "::endgroup::"
+          done
+
+      - name: ccache status
+        continue-on-error: true
+        run: ccache -s
+
+      - name: save ccache
+        # Save the cache after we are done (successfully) building
+        # This helps to retain the ccache even if the subsequent steps are failing
+        uses: actions/cache/save@v4
+        with:
+          path: /home/runner/.ccache
+          key: ${{ steps.ccache-prepare.outputs.key }}
+
+      - name: install
+        run: |
+          IFS=':'
+          for lib in ${BUILD_LIBS}; do
+            printf "::group::\033[0;32m==>\033[0m Installing library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/${lib}/build
+            cmake --install .
+            echo "::endgroup::"
+          done
+
+      - name: build example using CMake
+        run: |
+          # function fmax (from libm) needs linker flags
+          export LDFLAGS="-Wl,--copy-dt-needed-entries"
+          cd ${GITHUB_WORKSPACE}/Example/build
+          printf "::group::\033[0;32m==>\033[0m Configuring example\n"
+          cmake \
+            -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/lib/cmake" \
+            -DBLA_VENDOR="Generic" \
+            ..
+          echo "::endgroup::"
+          printf "::group::\033[0;32m==>\033[0m Building example\n"
+          cmake --build .
+          echo "::endgroup::"
+          printf "::group::\033[0;32m==>\033[0m Executing example\n"
+          printf "\033[1;35m  C binary with shared libraries\033[0m\n"
+          ./my_demo
+          printf "\033[1;35m  C++ binary with shared libraries\033[0m\n"
+          ./my_cxx_demo
+          echo "::endgroup::"
+
+      - name: test Config
+        run: |
+          IFS=:
+          for lib in ${INSTALLED_LIBS}; do
+            printf "::group::   \033[0;32m==>\033[0m Building with Config.cmake with library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/TestConfig/${lib}
+            cd build
+            cmake \
+              -DCMAKE_PREFIX_PATH="${GITHUB_WORKSPACE}/lib/cmake" \
+              ..
+            cmake --build . --config Release
+            echo "::endgroup::"
+          done
+
+      - name: build example using autotools
+        run: |
+          cd ${GITHUB_WORKSPACE}/Example
+          printf "::group::\033[0;32m==>\033[0m Configuring example\n"
+          autoreconf -fi
+          mkdir build-autotools
+          cd build-autotools
+          PKG_CONFIG_PATH=${GITHUB_WORKSPACE}/lib/pkgconfig/ \
+            ../configure --enable-shared --disable-static
+          echo "::endgroup::"
+          printf "::group::\033[0;32m==>\033[0m Building example\n"
+          make all
+          echo "::endgroup::"
+          printf "::group::\033[0;32m==>\033[0m Executing example\n"
+          printf "\033[1;35m  C binary\033[0m\n"
+          LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/lib" ./my_demo
+          printf "\033[1;35m  C++ binary\033[0m\n"
+          LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/lib" ./my_cxx_demo
+          echo "::endgroup::"
+          IFS=:
+          for lib in ${INSTALLED_LIBS}; do
+            printf "::group::   \033[0;32m==>\033[0m Building test with library \033[0;32m${lib}\033[0m\n"
+            cd ${GITHUB_WORKSPACE}/TestConfig/${lib}
+            autoreconf -fi
+            mkdir build-autotools && cd build-autotools
+            PKG_CONFIG_PATH=${GITHUB_WORKSPACE}/lib/pkgconfig/ \
+              ../configure --enable-shared --disable-static
+            make all
+            echo "::endgroup::"
+          done

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -151,8 +151,7 @@ jobs:
           echo "::group::Installing dependencies for target arch ${{ matrix.arch }}"
           sudo apt -y install \
             libopenblas-openmp-dev:${{ matrix.arch }} \
-            libmpfr-dev:${{ matrix.arch }} \
-            libomp-dev:${{ matrix.arch }}
+            libmpfr-dev:${{ matrix.arch }}
           echo "::endgroup::"
 
       - name: prepare ccache

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -40,10 +40,12 @@ jobs:
             ccache-max: 64M
           - arch: ppc64el
             target-triple: powerpc64le-linux-gnu
+            flags: --target=powerpc64le-linux-gnu
             add-libs: libquadmath0:ppc64el
             ccache-max: 64M
           - arch: s390x
             target-triple: s390x-linux-gnu
+            flags: --target=s390x-linux-gnu
             ccache-max: 64M
           - arch: riscv64
             target-triple: riscv64-linux-gnu
@@ -52,10 +54,10 @@ jobs:
     name: cross-compile (${{ matrix.arch }})
 
     env:
-      CC: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && 'clang' || ${{ matrix.target-triple }}-gcc }}
-      CXX: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && 'clang++' || ${{ matrix.target-triple }}-g++ }}
-      CFLAGS: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && --target=${{ matrix.target-triple }} }}
-      CXXFLAGS: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && --target=${{ matrix.target-triple }} }}
+      CC: ${{ matrix.arch == 'armhf' && 'arm-linux-gnueabihf-gcc' || matrix.arch == 'riscv64' && 'riscv64-linux-gnueabihf-gcc' || 'clang' }}
+      CXX: ${{ matrix.arch == 'armhf' && 'arm-linux-gnueabihf-g++' || matrix.arch == 'riscv64' && 'riscv64-linux-gnueabihf-g++' || 'clang++' }}
+      CFLAGS: ${{ matrix.flags }}
+      CXXFLAGS: ${{ matrix.flags }}
       FC: ${{ matrix.target-triple }}-gfortran
       LD_LIBRARY_PATH: "/usr/lib/${{ matrix.target-triple }}"
 

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -46,6 +46,7 @@ jobs:
           - arch: ppc64el
             target-triple: powerpc64le-linux-gnu
             cross-toolchain: g++-14-powerpc64le-linux-gnu
+            add-libs: libquadmath0:ppc64el
             # fortran-cross-toolchain: gfortran-14-powerpc64le-linux-gnu
             # cc: "powerpc64le-linux-gnu-gcc-9"
             # cxx: "powerpc64le-linux-gnu-g++-9"
@@ -151,7 +152,8 @@ jobs:
           echo "::group::Installing dependencies for target arch ${{ matrix.arch }}"
           sudo apt -y install \
             libopenblas-openmp-dev:${{ matrix.arch }} \
-            libmpfr-dev:${{ matrix.arch }}
+            libmpfr-dev:${{ matrix.arch }} \
+            ${{ matrix.add-libs }}
           echo "::endgroup::"
 
       - name: prepare ccache

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -73,6 +73,8 @@ jobs:
     env:
       CC: clang
       CXX: clang++
+      CFLAGS: "--target=${{ matrix.target-triple }}"
+      CXXFLAGS: "--target=${{ matrix.target-triple }}"
       FC: ${{ matrix.target-triple }}-gfortran-14
       LD_LIBRARY_PATH: "/usr/${{ matrix.target-triple }}/lib"
       LIBRARY_PATH: "/usr/${{ matrix.target-triple }}/lib"
@@ -196,17 +198,9 @@ jobs:
             PKG_CONFIG_PATH=/usr/lib/${{ matrix.target-triple }}/pkgconfig/ \
             cmake -DCMAKE_BUILD_TYPE="Release" \
                   -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}" \
-                  -DCMAKE_C_COMPILER_TARGET=${{ matrix.target-triple }} \
-                  -DCMAKE_CXX_COMPILER_TARGET=${{ matrix.target-triple }} \
-                  -DCMAKE_Fortran_COMPILER_TARGET=${{ matrix.target-triple }} \
                   -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
                   -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
                   -DCMAKE_Fortran_COMPILER_LAUNCHER="ccache" \
-                  -DCMAKE_FIND_ROOT_PATH=/usr/${{ matrix.target-triple }} \
-                  -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER \
-                  -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
-                  -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
-                  -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ONLY \
                   -DBUILD_SHARED_LIBS=ON \
                   -DBUILD_STATIC_LIBS=OFF \
                   -DBLA_VENDOR="Generic" \

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -59,7 +59,6 @@ jobs:
       CFLAGS: ${{ matrix.flags }}
       CXXFLAGS: ${{ matrix.flags }}
       FC: ${{ matrix.target-triple }}-gfortran
-      LD_LIBRARY_PATH: "/usr/lib/${{ matrix.target-triple }}"
 
     steps:
       - name: get CPU information

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -152,7 +152,8 @@ jobs:
           echo "::group::Installing dependencies for target arch ${{ matrix.arch }}"
           sudo apt -y install \
             libopenblas-openmp-dev:${{ matrix.arch }} \
-            libmpfr-dev:${{ matrix.arch }}
+            libmpfr-dev:${{ matrix.arch }} \
+            libomp-dev:${{ matrix.arch }}
           echo "::endgroup::"
 
       - name: prepare ccache

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -52,10 +52,10 @@ jobs:
     name: cross-compile (${{ matrix.arch }})
 
     env:
-      CC: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && 'clang' || '${{ matrix.target-triple }}-gcc' }}
-      CXX: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && 'clang++' || '${{ matrix.target-triple }}-g++' }}
-      CFLAGS: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && '--target=${{ matrix.target-triple }}'}}
-      CXXFLAGS: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && '--target=${{ matrix.target-triple }}'}}
+      CC: ${{ (matrix.arch == "ppc64el" || matrix.arch == "s390x") && "clang" || "${{ matrix.target-triple }}-gcc" }}
+      CXX: ${{ (matrix.arch == "ppc64el" || matrix.arch == "s390x") && "clang++" || "${{ matrix.target-triple }}-g++" }}
+      CFLAGS: ${{ (matrix.arch == "ppc64el" || matrix.arch == "s390x") && "--target=${{ matrix.target-triple }}"}}
+      CXXFLAGS: ${{ (matrix.arch == "ppc64el" || matrix.arch == "s390x") && "--target=${{ matrix.target-triple }}"}}
       FC: ${{ matrix.target-triple }}-gfortran
       LD_LIBRARY_PATH: "/usr/lib/${{ matrix.target-triple }}"
 

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -52,10 +52,10 @@ jobs:
     name: cross-compile (${{ matrix.arch }})
 
     env:
-      CC: ${{ (matrix.arch == "ppc64el" || matrix.arch == "s390x") && "clang" || "${{ matrix.target-triple }}-gcc" }}
-      CXX: ${{ (matrix.arch == "ppc64el" || matrix.arch == "s390x") && "clang++" || "${{ matrix.target-triple }}-g++" }}
-      CFLAGS: ${{ (matrix.arch == "ppc64el" || matrix.arch == "s390x") && "--target=${{ matrix.target-triple }}"}}
-      CXXFLAGS: ${{ (matrix.arch == "ppc64el" || matrix.arch == "s390x") && "--target=${{ matrix.target-triple }}"}}
+      CC: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && "clang" || "${{ matrix.target-triple }}-gcc" }}
+      CXX: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && "clang++" || "${{ matrix.target-triple }}-g++" }}
+      CFLAGS: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && "--target=${{ matrix.target-triple }}" }}
+      CXXFLAGS: ${{ (matrix.arch == 'ppc64el' || matrix.arch == 's390x') && "--target=${{ matrix.target-triple }}" }}
       FC: ${{ matrix.target-triple }}-gfortran
       LD_LIBRARY_PATH: "/usr/lib/${{ matrix.target-triple }}"
 

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -37,7 +37,7 @@ jobs:
         include:
           - arch: armhf
             target-triple: arm-linux-gnueabihf
-            # cross-toolchain: g++-9-arm-linux-gnueabihf
+            cross-toolchain: g++-14-arm-linux-gnueabihf
             # fortran-cross-toolchain: gfortran-14-arm-linux-gnueabihf
             # cc: "arm-linux-gnueabihf-gcc-9"
             # cxx: "arm-linux-gnueabihf-g++-9"
@@ -45,7 +45,7 @@ jobs:
             ccache-max: 64M
           - arch: ppc64el
             target-triple: powerpc64le-linux-gnu
-            # cross-toolchain: g++-9-powerpc64le-linux-gnu 
+            cross-toolchain: g++-14-powerpc64le-linux-gnu
             # fortran-cross-toolchain: gfortran-14-powerpc64le-linux-gnu
             # cc: "powerpc64le-linux-gnu-gcc-9"
             # cxx: "powerpc64le-linux-gnu-g++-9"
@@ -53,7 +53,7 @@ jobs:
             ccache-max: 64M
           - arch: s390x
             target-triple: s390x-linux-gnu
-            # cross-toolchain: g++-9-s390x-linux-gnu 
+            cross-toolchain: g++-14-s390x-linux-gnu
             # fortran-cross-toolchain: gfortran-14-s390x-linux-gnu
             # cc: "s390x-linux-gnu-gcc-9"
             # cxx: "s390x-linux-gnu-g++-9"

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -21,7 +21,7 @@ env:
 jobs:
 
   cross-compile:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.arch == 'armhf' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
 
     defaults:
       run:
@@ -33,13 +33,15 @@ jobs:
       fail-fast: false
 
       matrix:
+        # List of architectures that are supported by Ubuntu:
+        # https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/reference/architectures/
         arch: [armhf, ppc64el, s390x, riscv64]
         include:
           - arch: armhf
             target-triple: arm-linux-gnueabihf
-            ccache-max: 64M
             cc: arm-linux-gnueabihf-gcc
             cxx: arm-linux-gnueabihf-g++
+            ccache-max: 64M
           - arch: ppc64el
             target-triple: powerpc64le-linux-gnu
             flags: --target=powerpc64le-linux-gnu
@@ -50,14 +52,14 @@ jobs:
           - arch: s390x
             target-triple: s390x-linux-gnu
             flags: --target=s390x-linux-gnu
-            ccache-max: 64M
             cc: clang
             cxx: clang++
+            ccache-max: 64M
           - arch: riscv64
             target-triple: riscv64-linux-gnu
-            ccache-max: 64M
             cc: riscv64-linux-gnu-gcc
             cxx: riscv64-linux-gnu-g++
+            ccache-max: 64M
 
     name: cross-compile (${{ matrix.arch }})
 
@@ -102,36 +104,58 @@ jobs:
         run: |
           sudo dpkg --add-architecture ${{ matrix.arch }}
           UBUNTU_CODENAME=$(cat /etc/os-release | grep ^UBUNTU_CODENAME | cut -d= -f2)
-          sudo bash -c 'cat - >/etc/apt/sources.list.d/ubuntu.sources' <<-EOF
-          	Types: deb
-          	URIs: http://archive.ubuntu.com/ubuntu/
-          	Suites: $UBUNTU_CODENAME $UBUNTU_CODENAME-updates $UBUNTU_CODENAME-backports
-          	Components: main restricted universe multiverse
-          	Architectures: amd64
-          	Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
-          	
-          	Types: deb
-          	URIs: http://security.ubuntu.com/ubuntu/
-          	Suites: $UBUNTU_CODENAME-security
-          	Components: main restricted universe multiverse
-          	Architectures: amd64
-          	Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
-          	
-          	Types: deb
-          	URIs: http://ports.ubuntu.com/ubuntu-ports/
-          	Suites: $UBUNTU_CODENAME $UBUNTU_CODENAME-updates $UBUNTU_CODENAME-backports
-          	Components: main restricted universe multiverse
-          	Architectures: ${{ matrix.arch }}
-          	Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
-          	
-          	Types: deb
-          	URIs: http://security.ports.ubuntu.com/ubuntu-ports/
-          	Suites: $UBUNTU_CODENAME-security
-          	Components: main restricted universe multiverse
-          	Architectures: ${{ matrix.arch }}
-          	Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
-          	
-          	EOF
+          case ${{ matrix.arch }} in
+            "armhf")
+              sudo bash -c 'cat - >/etc/apt/sources.list.d/ubuntu.sources' <<EOF
+          Types: deb
+          URIs: http://ports.ubuntu.com/ubuntu-ports/
+          Suites: $UBUNTU_CODENAME $UBUNTU_CODENAME-updates $UBUNTU_CODENAME-backports
+          Components: main restricted universe multiverse
+          Architectures: arm64 ${{ matrix.arch }}
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          
+          Types: deb
+          URIs: http://security.ports.ubuntu.com/ubuntu-ports/
+          Suites: $UBUNTU_CODENAME-security
+          Components: main restricted universe multiverse
+          Architectures: arm64 ${{ matrix.arch }}
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          
+          EOF
+              ;;
+                  *)
+              sudo bash -c 'cat - >/etc/apt/sources.list.d/ubuntu.sources' <<EOF
+          Types: deb
+          URIs: http://archive.ubuntu.com/ubuntu/
+          Suites: $UBUNTU_CODENAME $UBUNTU_CODENAME-updates $UBUNTU_CODENAME-backports
+          Components: main restricted universe multiverse
+          Architectures: amd64
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          
+          Types: deb
+          URIs: http://security.ubuntu.com/ubuntu/
+          Suites: $UBUNTU_CODENAME-security
+          Components: main restricted universe multiverse
+          Architectures: amd64
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          
+          Types: deb
+          URIs: http://ports.ubuntu.com/ubuntu-ports/
+          Suites: $UBUNTU_CODENAME $UBUNTU_CODENAME-updates $UBUNTU_CODENAME-backports
+          Components: main restricted universe multiverse
+          Architectures: ${{ matrix.arch }}
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          
+          Types: deb
+          URIs: http://security.ports.ubuntu.com/ubuntu-ports/
+          Suites: $UBUNTU_CODENAME-security
+          Components: main restricted universe multiverse
+          Architectures: ${{ matrix.arch }}
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          
+          EOF
+              ;;
+          esac
           echo "::group::Updating package indexes with new indexes for ${{ matrix.arch }} packages"
           sudo apt update
           echo "::endgroup::"

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        arch: [armhf, ppc64el, s390x, riscv64]
+        arch: [riscv64]
         include:
           - arch: armhf
             target-triple: arm-linux-gnueabihf
@@ -61,8 +61,8 @@ jobs:
             ccache-max: 64M
           - arch: riscv64
             target-triple: riscv64-linux-gnu
-            # cross-toolchain: g++-9-riscv64-linux-gnu 
-            # fortran-cross-toolchain: gfortran-14-riscv64-linux-gnu
+            cross-toolchain: g++-14-riscv64-linux-gnu
+            fortran-cross-toolchain: gfortran-14-riscv64-linux-gnu
             # cc: "riscv64-linux-gnu-gcc-9"
             # cxx: "riscv64-linux-gnu-g++-9"
             # fc: "riscv64-linux-gnu-gfortran-14"
@@ -71,8 +71,8 @@ jobs:
     name: cross-compile (${{ matrix.arch }})
 
     env:
-      CC: clang -target ${{ matrix.target-triple }}
-      CXX: clang++ -target ${{ matrix.target-triple }}
+      CC: clang
+      CXX: clang++
       FC: ${{ matrix.target-triple }}-gfortran-14
       LD_LIBRARY_PATH: "/usr/${{ matrix.target-triple }}/lib"
       LIBRARY_PATH: "/usr/${{ matrix.target-triple }}/lib"
@@ -102,7 +102,7 @@ jobs:
       - name: install cross-toolchain
         run: |
           echo "::group::Install cross-toolchain for ${{ matrix.arch }}"
-          sudo apt -y install clang gfortran-14-${{ matrix.target-triple }}
+          sudo apt -y install clang ${{ matrix.cross-toolchain }} gfortran-14-${{ matrix.target-triple }}
           echo "::endgroup::"
 
       - name: configure Multiarch
@@ -196,9 +196,17 @@ jobs:
             PKG_CONFIG_PATH=/usr/lib/${{ matrix.target-triple }}/pkgconfig/ \
             cmake -DCMAKE_BUILD_TYPE="Release" \
                   -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}" \
+                  -DCMAKE_C_COMPILER_TARGET=${{ matrix.target-triple }} \
+                  -DCMAKE_CXX_COMPILER_TARGET=${{ matrix.target-triple }} \
+                  -DCMAKE_Fortran_COMPILER_TARGET=${{ matrix.target-triple }} \
                   -DCMAKE_C_COMPILER_LAUNCHER="ccache" \
                   -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
                   -DCMAKE_Fortran_COMPILER_LAUNCHER="ccache" \
+                  -DCMAKE_FIND_ROOT_PATH=/usr/${{ matrix.target-triple }} \
+                  -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER \
+                  -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
+                  -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
+                  -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ONLY \
                   -DBUILD_SHARED_LIBS=ON \
                   -DBUILD_STATIC_LIBS=OFF \
                   -DBLA_VENDOR="Generic" \

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -33,11 +33,8 @@ jobs:
       fail-fast: false
 
       matrix:
-        arch: [amd64, armhf, ppc64el, s390x, riscv64]
+        arch: [armhf, ppc64el, s390x, riscv64]
         include:
-          - arch: amd64
-            cc: gcc
-            ccache-max: 64M
           - arch: armhf
             target_system: arm-linux-gnueabihf
             cross-toolchain: g++-9-arm-linux-gnueabihf
@@ -101,21 +98,16 @@ jobs:
 
       - name: install cross-toolchain
         run: |
-          if [[ ${{ matrix.arch }} != 'amd64' ]]; then
-            echo "::group::Install cross-toolchain for ${{ matrix.arch }}"
-            sudo apt -y install ${{ matrix.cross-toolchain }} ${{ matrix.fortran-cross-toolchain }}
-            echo "::endgroup::"
-          else
-            echo "Target architecture is ${{ matrix.arch }}, cross-compilation isn't required, cross-toolchain installation isn't required."
-          fi
+          echo "::group::Install cross-toolchain for ${{ matrix.arch }}"
+          sudo apt -y install ${{ matrix.cross-toolchain }} ${{ matrix.fortran-cross-toolchain }}
+          echo "::endgroup::"
 
       - name: configure Multiarch
         # deb822-style format is a new format supported by apt itself since version 1.1:
         # https://manpages.ubuntu.com/manpages/noble/man5/sources.list.5.html
         run: |
-          if [[ ${{ matrix.arch }} != 'amd64' ]]; then
-            sudo dpkg --add-architecture ${{ matrix.arch }}
-            sudo bash -c 'cat - >/etc/apt/sources.list.d/ubuntu.sources' <<-EOF
+          sudo dpkg --add-architecture ${{ matrix.arch }}
+          sudo bash -c 'cat - >/etc/apt/sources.list.d/ubuntu.sources' <<-EOF
           	Types: deb
           	URIs: http://archive.ubuntu.com/ubuntu/
           	Suites: noble noble-updates noble-backports
@@ -145,12 +137,9 @@ jobs:
           	Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
           	
           	EOF
-            echo "::group::Updating package indexes with new indexes for ${{ matrix.arch }} packages"
-            sudo apt update
-            echo "::endgroup::"
-          else
-            echo "Target architecture is ${{ matrix.arch }}, Multiarch configuration isn't required."
-          fi
+          echo "::group::Updating package indexes with new indexes for ${{ matrix.arch }} packages"
+          sudo apt update
+          echo "::endgroup::"
 
       - name: install cross-dependencies (using Multiarch)
         run: |

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -38,24 +38,32 @@ jobs:
           - arch: armhf
             target-triple: arm-linux-gnueabihf
             ccache-max: 64M
+            cc: arm-linux-gnueabihf-gcc
+            cxx: arm-linux-gnueabihf-g++
           - arch: ppc64el
             target-triple: powerpc64le-linux-gnu
             flags: --target=powerpc64le-linux-gnu
             add-libs: libquadmath0:ppc64el
+            cc: clang
+            cxx: clang++
             ccache-max: 64M
           - arch: s390x
             target-triple: s390x-linux-gnu
             flags: --target=s390x-linux-gnu
             ccache-max: 64M
+            cc: clang
+            cxx: clang++
           - arch: riscv64
             target-triple: riscv64-linux-gnu
             ccache-max: 64M
+            cc: riscv64-linux-gnu-gcc
+            cxx: riscv64-linux-gnu-g++
 
     name: cross-compile (${{ matrix.arch }})
 
     env:
-      CC: ${{ matrix.arch == 'armhf' && 'arm-linux-gnueabihf-gcc' || matrix.arch == 'riscv64' && 'riscv64-linux-gnu-gcc' || 'clang' }}
-      CXX: ${{ matrix.arch == 'armhf' && 'arm-linux-gnueabihf-g++' || matrix.arch == 'riscv64' && 'riscv64-linux-gnu-g++' || 'clang++' }}
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
       CFLAGS: ${{ matrix.flags }}
       CXXFLAGS: ${{ matrix.flags }}
       FC: ${{ matrix.target-triple }}-gfortran

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -36,46 +36,46 @@ jobs:
         arch: [armhf, ppc64el, s390x, riscv64]
         include:
           - arch: armhf
-            target_system: arm-linux-gnueabihf
-            cross-toolchain: g++-9-arm-linux-gnueabihf
-            fortran-cross-toolchain: gfortran-10-arm-linux-gnueabihf
-            cc: "arm-linux-gnueabihf-gcc-9"
-            cxx: "arm-linux-gnueabihf-g++-9"
-            fc: "arm-linux-gnueabihf-gfortran-10"
+            target-triple: arm-linux-gnueabihf
+            # cross-toolchain: g++-9-arm-linux-gnueabihf
+            # fortran-cross-toolchain: gfortran-14-arm-linux-gnueabihf
+            # cc: "arm-linux-gnueabihf-gcc-9"
+            # cxx: "arm-linux-gnueabihf-g++-9"
+            # fc: "arm-linux-gnueabihf-gfortran-14"
             ccache-max: 64M
           - arch: ppc64el
-            target_system: powerpc64le-linux-gnu
-            cross-toolchain: g++-9-powerpc64le-linux-gnu 
-            fortran-cross-toolchain: gfortran-10-powerpc64le-linux-gnu
-            cc: "powerpc64le-linux-gnu-gcc-9"
-            cxx: "powerpc64le-linux-gnu-g++-9"
-            fc: "powerpc64le-linux-gnu-gfortran-10"
+            target-triple: powerpc64le-linux-gnu
+            # cross-toolchain: g++-9-powerpc64le-linux-gnu 
+            # fortran-cross-toolchain: gfortran-14-powerpc64le-linux-gnu
+            # cc: "powerpc64le-linux-gnu-gcc-9"
+            # cxx: "powerpc64le-linux-gnu-g++-9"
+            # fc: "powerpc64le-linux-gnu-gfortran-14"
             ccache-max: 64M
           - arch: s390x
-            target_system: s390x-linux-gnu
-            cross-toolchain: g++-9-s390x-linux-gnu 
-            fortran-cross-toolchain: gfortran-10-s390x-linux-gnu
-            cc: "s390x-linux-gnu-gcc-9"
-            cxx: "s390x-linux-gnu-g++-9"
-            fc: "s390x-linux-gnu-gfortran-10"
+            target-triple: s390x-linux-gnu
+            # cross-toolchain: g++-9-s390x-linux-gnu 
+            # fortran-cross-toolchain: gfortran-14-s390x-linux-gnu
+            # cc: "s390x-linux-gnu-gcc-9"
+            # cxx: "s390x-linux-gnu-g++-9"
+            # fc: "s390x-linux-gnu-gfortran-14"
             ccache-max: 64M
           - arch: riscv64
-            target_system: riscv64-linux-gnu
-            cross-toolchain: g++-9-riscv64-linux-gnu 
-            fortran-cross-toolchain: gfortran-10-riscv64-linux-gnu
-            cc: "riscv64-linux-gnu-gcc-9"
-            cxx: "riscv64-linux-gnu-g++-9"
-            fc: "riscv64-linux-gnu-gfortran-10"
+            target-triple: riscv64-linux-gnu
+            # cross-toolchain: g++-9-riscv64-linux-gnu 
+            # fortran-cross-toolchain: gfortran-14-riscv64-linux-gnu
+            # cc: "riscv64-linux-gnu-gcc-9"
+            # cxx: "riscv64-linux-gnu-g++-9"
+            # fc: "riscv64-linux-gnu-gfortran-14"
             ccache-max: 64M
 
     name: cross-compile (${{ matrix.arch }})
 
     env:
-      CC: ${{ matrix.cc }}
-      CXX: ${{ matrix.cxx }}
-      FC: ${{ matrix.fc }}
-      LD_LIBRARY_PATH: "/usr/${{ matrix.target_system }}/lib"
-      LIBRARY_PATH: "/usr/${{ matrix.target_system }}/lib"
+      CC: clang -target ${{ matrix.target-triple }}
+      CXX: clang++ -target ${{ matrix.target-triple }}
+      FC: ${{ matrix.target-triple }}-gfortran-14
+      LD_LIBRARY_PATH: "/usr/${{ matrix.target-triple }}/lib"
+      LIBRARY_PATH: "/usr/${{ matrix.target-triple }}/lib"
 
     steps:
       - name: get CPU information
@@ -83,7 +83,10 @@ jobs:
 
       - name: install some aux utilities
         run: |
-          echo "::group::Install cross-toolchain for ${{ matrix.arch }}"
+          echo "::group::Update package indexes"
+          sudo apt update
+          echo "::endgroup::"
+          echo "::group::Install cmake make ccache automake libtool qemu-user-binfmt"
           sudo apt -y install \
             cmake \
             make \
@@ -99,7 +102,7 @@ jobs:
       - name: install cross-toolchain
         run: |
           echo "::group::Install cross-toolchain for ${{ matrix.arch }}"
-          sudo apt -y install ${{ matrix.cross-toolchain }} ${{ matrix.fortran-cross-toolchain }}
+          sudo apt -y install clang gfortran-14-${{ matrix.target-triple }}
           echo "::endgroup::"
 
       - name: configure Multiarch
@@ -192,7 +195,7 @@ jobs:
             printf "   \033[0;32m==>\033[0m Building library \033[0;32m${lib}\033[0m\n"
             echo "::group::Configure $lib"
             cd ${GITHUB_WORKSPACE}/${lib}/build
-            PKG_CONFIG_PATH=/usr/lib/${{ matrix.target_system }}/pkgconfig/ \
+            PKG_CONFIG_PATH=/usr/lib/${{ matrix.target-triple }}/pkgconfig/ \
             cmake -DCMAKE_BUILD_TYPE="Release" \
                   -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}" \
                   -DCMAKE_C_COMPILER_LAUNCHER="ccache" \

--- a/.github/workflows/cross-compile.yaml
+++ b/.github/workflows/cross-compile.yaml
@@ -107,31 +107,32 @@ jobs:
         # https://manpages.ubuntu.com/manpages/noble/man5/sources.list.5.html
         run: |
           sudo dpkg --add-architecture ${{ matrix.arch }}
+          UBUNTU_CODENAME=$(cat /etc/os-release | grep ^UBUNTU_CODENAME | cut -d= -f2)
           sudo bash -c 'cat - >/etc/apt/sources.list.d/ubuntu.sources' <<-EOF
           	Types: deb
           	URIs: http://archive.ubuntu.com/ubuntu/
-          	Suites: noble noble-updates noble-backports
+          	Suites: $UBUNTU_CODENAME $UBUNTU_CODENAME-updates $UBUNTU_CODENAME-backports
           	Components: main restricted universe multiverse
           	Architectures: amd64
           	Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
           	
           	Types: deb
           	URIs: http://security.ubuntu.com/ubuntu/
-          	Suites: noble-security
+          	Suites: $UBUNTU_CODENAME-security
           	Components: main restricted universe multiverse
           	Architectures: amd64
           	Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
           	
           	Types: deb
           	URIs: http://ports.ubuntu.com/ubuntu-ports/
-          	Suites: noble noble-updates noble-backports
+          	Suites: $UBUNTU_CODENAME $UBUNTU_CODENAME-updates $UBUNTU_CODENAME-backports
           	Components: main restricted universe multiverse
           	Architectures: ${{ matrix.arch }}
           	Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
           	
           	Types: deb
           	URIs: http://security.ports.ubuntu.com/ubuntu-ports/
-          	Suites: noble-security
+          	Suites: $UBUNTU_CODENAME-security
           	Components: main restricted universe multiverse
           	Architectures: ${{ matrix.arch }}
           	Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg


### PR DESCRIPTION
# SuiteSparse cross-compilation

## Supported architectures

All architectures for which SuiteSparse cross-dependencies exist in the Ubuntu repository are supported. Namely: 
* amd64
* armhf
* ppc64el
* s390x
* riscv64

## Results of replacing emulation with cross-compilation

Replacing emulation with cross-compilation gave a significant speedup in building SuiteSparse libraries for different architectures. The build is so fast that it is now possible to build absolutely all SuiteSparse libraries, including GraphBLAS and LAGraph, on different architectures. Already including GraphBLAS and LAGraph, it now takes only about 30 minutes to run build-arch-emu.yaml (now called 'cross-compile.yaml') workflow.

@DrTimothyAldenDavis also, the ability to build and test GraphBLAS and LAGraph may help you to solve the  RISCV testing problem for the following PR DrTimothyAldenDavis/GraphBLAS#381.

## Identified problem in LAGraph 

### Problem
By running the cross-compile.yaml workflow it was found that testing of LAGraph on **armhf** and **riscv64** architectures works correctly, but on the rest architectures **ppc64el** and **s390x** fails (see the result of the cross-compile.yaml [run](https://github.com/MigunovaAnastasia1/SuiteSparse-cross-compile/actions/runs/15065884178)).

### Localisation of the problem 
The identified problem was localised by a binary search (using the `git bisect` command) and found in the commit 1fd4ef8.
