### PR TITLE
Move away from deprecated environments of MSYS2

### DIFF
--- a/.github/workflows/build-mingw.yaml
+++ b/.github/workflows/build-mingw.yaml
@@ -35,12 +35,9 @@ jobs:
       fail-fast: false
 
       matrix:
-        msystem: [MINGW64, MINGW32, UCRT64, CLANG64, CLANGARM64]
+        msystem: [MINGW64, UCRT64, CLANG64, CLANGARM64]
         include:
           - msystem: MINGW64
-            os: windows-latest
-            f77-package: fc
-          - msystem: MINGW32
             os: windows-latest
             f77-package: fc
           - msystem: UCRT64

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -152,16 +152,18 @@ jobs:
 
           install: >-
             base-devel
-            mingw-w64-x86_64-autotools
-            mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-cc
-            mingw-w64-x86_64-fc
-            mingw-w64-x86_64-openblas
-            mingw-w64-x86_64-omp
-            mingw-w64-x86_64-gmp
-            mingw-w64-x86_64-mpfr
 
-          msystem: MINGW64
+          pacboy: >-
+            autotools:p
+            cmake:p
+            cc:p
+            fc:p
+            openblas:p
+            omp:p
+            gmp:p
+            mpfr:p
+
+          msystem: UCRT64
 
       - name: checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Some environments of MSYS2 have been deprecated.
Adjust the workflows for that.

That should be the remaining parts to close #1031.
