### PR TITLE
Instruct dependabot to create pull-requests for the `dev2` branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    # all pull-requests should be opened for the dev2 branch
+    target-branch: "dev2"


### PR DESCRIPTION
The processes for the SuiteSparse repository are a bit unusual in that PRs should be opened against the `dev2` branch instead of against the default branch (`dev`).

Instruct dependabot to open the pull-requests for updates of actions in workflow files also against the `dev2` branch. (That might help to avoid merge conflicts when the two branches need to be consolidated inevitably at some point.)
