### PR TITLE
CSparse: Adjust letter-case of CMake target to other libraries.

### DIFF
--- a/.github/workflows/root-cmakelists-msvc.yaml
+++ b/.github/workflows/root-cmakelists-msvc.yaml
@@ -267,7 +267,8 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/build
           PATH="${GITHUB_WORKSPACE}/bin;${GITHUB_WORKSPACE}/dependencies/bin;C:/msys64/ucrt64/bin;${PATH}" \
-            ctest -C Release . || ctest -C Release . --rerun-failed --output-on-failure
+            ctest -C Release . --timeout 300 \
+              || ctest -C Release . --rerun-failed --output-on-failure --timeout 300
 
       - name: install
         run: |

--- a/.github/workflows/root-cmakelists-msvc.yaml
+++ b/.github/workflows/root-cmakelists-msvc.yaml
@@ -131,7 +131,7 @@ jobs:
         if: matrix.cuda == 'with'
         id: cuda-toolkit
         with:
-          cuda: '12.5.0'
+          cuda: '13.2.0'
           #See https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html#install-the-cuda-software
           method: 'local'
           # Do not cache the installer (~3 GiB). It doesn't speed up the

--- a/.github/workflows/root-cmakelists-msvc.yaml
+++ b/.github/workflows/root-cmakelists-msvc.yaml
@@ -275,7 +275,7 @@ jobs:
         run: |
           printf "\033[0;32m==>\033[0m Installing libraries\n"
           cd ${GITHUB_WORKSPACE}/build
-          cmake --install .
+          cmake --install . --config Release
 
       - name: build example
         run: |

--- a/.github/workflows/root-cmakelists-msvc.yaml
+++ b/.github/workflows/root-cmakelists-msvc.yaml
@@ -197,9 +197,7 @@ jobs:
           if [ ${{ matrix.cuda }} = 'with' ]; then
             _extra_config+=(-DCUDAToolkit_ROOT="$(cygpath -m "${{ steps.cuda-toolkit.outputs.CUDA_PATH }}")")
             _extra_config+=(-DCMAKE_CUDA_COMPILER="$(cygpath -m "${{ steps.cuda-toolkit.outputs.CUDA_PATH }}")/bin/nvcc.exe")
-            # MSVC 19.40 is still Visual Studio 2022.
-            # Suppress erroneous version check.
-            _extra_config+=(-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler)
+            _extra_config+=(-DSUITESPARSE_CUDA_ARCHITECTURES="75;80;86;89")
           fi
           if [[ ${{ matrix.cc }} == clang* ]]; then
             # Move away (old) clang/clang++ and clang-cl that would be in PATH

--- a/.github/workflows/root-cmakelists.yaml
+++ b/.github/workflows/root-cmakelists.yaml
@@ -146,6 +146,7 @@ jobs:
                 -DCMAKE_CXX_COMPILER_LAUNCHER="ccache" \
                 -DCMAKE_Fortran_COMPILER_LAUNCHER="ccache" \
                 -DBLA_VENDOR="OpenBLAS" \
+                "-DSUITESPARSE_ENABLE_PROJECTS=all;csparse" \
                 -DSUITESPARSE_DEMOS=OFF \
                 -DSUITESPARSE_USE_FORTRAN=ON \
                 -DBUILD_TESTING=OFF \

--- a/CSparse/CMakeLists.txt
+++ b/CSparse/CMakeLists.txt
@@ -32,7 +32,7 @@ message ( STATUS "Building CSparse version: v"
 # define the project
 #-------------------------------------------------------------------------------
 
-project ( csparse
+project ( CSparse
     VERSION "${CSPARSE_VERSION_MAJOR}.${CSPARSE_VERSION_MINOR}.${CSPARSE_VERSION_SUB}"
     LANGUAGES C )
 
@@ -83,38 +83,39 @@ set ( CMAKE_INCLUDE_CURRENT_DIR ON )
 include_directories ( Source Include )
 
 #-------------------------------------------------------------------------------
-# dynamic csparse library properties
+# dynamic CSparse library properties
 #-------------------------------------------------------------------------------
 
 file ( GLOB CSPARSE_SOURCES "Source/*.c" )
 
 if ( BUILD_SHARED_LIBS )
-    add_library ( csparse SHARED ${CSPARSE_SOURCES} )
+    add_library ( CSparse SHARED ${CSPARSE_SOURCES} )
 
-    set_target_properties ( csparse PROPERTIES
+    set_target_properties ( CSparse PROPERTIES
         VERSION ${CSPARSE_VERSION_MAJOR}.${CSPARSE_VERSION_MINOR}.${CSPARSE_VERSION_SUB}
         C_STANDARD 11
         C_STANDARD_REQUIRED ON
+        OUTPUT_NAME csparse
         SOVERSION ${CSPARSE_VERSION_MAJOR}
         PUBLIC_HEADER "Include/cs.h"
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
 endif ( )
 
 #-------------------------------------------------------------------------------
-# static csparse library properties
+# static CSparse library properties
 #-------------------------------------------------------------------------------
 
 if ( BUILD_STATIC_LIBS )
-    add_library ( csparse_static STATIC ${CSPARSE_SOURCES} )
+    add_library ( CSparse_static STATIC ${CSPARSE_SOURCES} )
 
-    set_target_properties ( csparse_static PROPERTIES
-        OUTPUT_NAME csparse
+    set_target_properties ( CSparse_static PROPERTIES
         C_STANDARD 11
         C_STANDARD_REQUIRED ON
+        OUTPUT_NAME csparse
         PUBLIC_HEADER "Include/cs.h" )
 
     if ( MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC") )
-        set_target_properties ( csparse_static PROPERTIES
+        set_target_properties ( CSparse_static PROPERTIES
             OUTPUT_NAME csparse_static )
     endif ( )
 endif ( )
@@ -126,11 +127,11 @@ endif ( )
 # libm:
 if ( NOT WIN32 )
     if ( BUILD_SHARED_LIBS )
-        target_link_libraries ( csparse PRIVATE m )
+        target_link_libraries ( CSparse PRIVATE m )
     endif ( )
     if ( BUILD_STATIC_LIBS )
         set ( CSPARSE_STATIC_LIBS "${CSPARSE_STATIC_LIBS} -lm" )
-        target_link_libraries ( csparse_static PUBLIC m )
+        target_link_libraries ( CSparse_static PUBLIC m )
     endif ( )
 endif ( )
 
@@ -174,12 +175,12 @@ add_executable ( cs_demo3 "Demo/cs_demo3.c" "Demo/cs_demo.c" )
 
 # Libraries required for Demo programs
 if ( BUILD_SHARED_LIBS )
-    target_link_libraries ( cs_demo1 PUBLIC csparse )
-    target_link_libraries ( cs_demo2 PUBLIC csparse )
-    target_link_libraries ( cs_demo3 PUBLIC csparse )
+    target_link_libraries ( cs_demo1 PUBLIC CSparse )
+    target_link_libraries ( cs_demo2 PUBLIC CSparse )
+    target_link_libraries ( cs_demo3 PUBLIC CSparse )
 else ( )
-    target_link_libraries ( cs_demo1 PUBLIC csparse_static )
-    target_link_libraries ( cs_demo2 PUBLIC csparse_static )
-    target_link_libraries ( cs_demo3 PUBLIC csparse_static )
+    target_link_libraries ( cs_demo1 PUBLIC CSparse_static )
+    target_link_libraries ( cs_demo2 PUBLIC CSparse_static )
+    target_link_libraries ( cs_demo3 PUBLIC CSparse_static )
 endif ( )
 

--- a/CSparse/CMakeLists.txt
+++ b/CSparse/CMakeLists.txt
@@ -169,18 +169,18 @@ endif ( )
 # Demo library and programs
 #-------------------------------------------------------------------------------
 
-add_executable ( cs_demo1 "Demo/cs_demo1.c" "Demo/cs_demo.c" )
-add_executable ( cs_demo2 "Demo/cs_demo2.c" "Demo/cs_demo.c" )
-add_executable ( cs_demo3 "Demo/cs_demo3.c" "Demo/cs_demo.c" )
+add_executable ( csparse_demo1 "Demo/cs_demo1.c" "Demo/cs_demo.c" )
+add_executable ( csparse_demo2 "Demo/cs_demo2.c" "Demo/cs_demo.c" )
+add_executable ( csparse_demo3 "Demo/cs_demo3.c" "Demo/cs_demo.c" )
 
 # Libraries required for Demo programs
 if ( BUILD_SHARED_LIBS )
-    target_link_libraries ( cs_demo1 PUBLIC CSparse )
-    target_link_libraries ( cs_demo2 PUBLIC CSparse )
-    target_link_libraries ( cs_demo3 PUBLIC CSparse )
+    target_link_libraries ( csparse_demo1 PUBLIC CSparse )
+    target_link_libraries ( csparse_demo2 PUBLIC CSparse )
+    target_link_libraries ( csparse_demo3 PUBLIC CSparse )
 else ( )
-    target_link_libraries ( cs_demo1 PUBLIC CSparse_static )
-    target_link_libraries ( cs_demo2 PUBLIC CSparse_static )
-    target_link_libraries ( cs_demo3 PUBLIC CSparse_static )
+    target_link_libraries ( csparse_demo1 PUBLIC CSparse_static )
+    target_link_libraries ( csparse_demo2 PUBLIC CSparse_static )
+    target_link_libraries ( csparse_demo3 PUBLIC CSparse_static )
 endif ( )
 

--- a/CSparse/Makefile
+++ b/CSparse/Makefile
@@ -52,17 +52,17 @@ all: library
 
 demos: library
 	( cd build && cmake $(CMAKE_OPTIONS) -DSUITESPARSE_DEMOS=1 .. && cmake --build . --config Release -j${JOBS} )
-	- ./build/cs_demo1 < ./Matrix/t1
-	- ./build/cs_demo2 < ./Matrix/t1
-	- ./build/cs_demo2 < ./Matrix/ash219
-	- ./build/cs_demo2 < ./Matrix/bcsstk01
-	- ./build/cs_demo2 < ./Matrix/fs_183_1
-	- ./build/cs_demo2 < ./Matrix/mbeacxc
-	- ./build/cs_demo2 < ./Matrix/west0067
-	- ./build/cs_demo2 < ./Matrix/lp_afiro
-	- ./build/cs_demo2 < ./Matrix/bcsstk16
-	- ./build/cs_demo3 < ./Matrix/bcsstk01
-	- ./build/cs_demo3 < ./Matrix/bcsstk16
+	- ./build/csparse_demo1 < ./Matrix/t1
+	- ./build/csparse_demo2 < ./Matrix/t1
+	- ./build/csparse_demo2 < ./Matrix/ash219
+	- ./build/csparse_demo2 < ./Matrix/bcsstk01
+	- ./build/csparse_demo2 < ./Matrix/fs_183_1
+	- ./build/csparse_demo2 < ./Matrix/mbeacxc
+	- ./build/csparse_demo2 < ./Matrix/west0067
+	- ./build/csparse_demo2 < ./Matrix/lp_afiro
+	- ./build/csparse_demo2 < ./Matrix/bcsstk16
+	- ./build/csparse_demo3 < ./Matrix/bcsstk01
+	- ./build/csparse_demo3 < ./Matrix/bcsstk16
 
 install:
 	- echo 'CSparse is not installed; use CXSparse instead'


### PR DESCRIPTION
The letter-case of the targets as they are used in the top-level CMakeLists.txt file didn't match the letter case in the CMakeLists.txt file for the CSparse library.

Use the letter-case of the targets in the top-level CMakeLists.txt file because it is more consistent with the letter-case of most other library targets (most importantly CXSparse).


Additionally, build the CSparse library as part of the CI using the root CMakeLists.txt file on Ubuntu.


Fixes #1041.
