### PR TITLE
Read BSP text back with the class it was written as

### DIFF
--- a/MATLAB_Tools/SuiteSparseCollection/ssbsp_check_problem.m
+++ b/MATLAB_Tools/SuiteSparseCollection/ssbsp_check_problem.m
@@ -83,13 +83,16 @@ ok = ischar (value) || iscellstr (value) || ...
 
 function check_text_dataset (bspfile, name, expected, label)
 
+% A text component is stored so that its MATLAB class survives: a char matrix
+% becomes a fixed-length HDF5 string dataset and a cellstr a variable-length
+% one.  Both classes therefore come back exactly, and the comparison here is
+% exact as well.
 dataset = ['/' name] ;
 try
-    actual = h5read (bspfile, dataset) ;
+    actual = binsparse_read_string_dataset (bspfile, dataset) ;
 catch me
     error ('missing text dataset %s for %s: %s', dataset, label, me.message) ;
 end
-actual = h5_text_to_cellstr (actual) ;
 expected = expected_text (expected) ;
 if (~isequal (actual, expected))
     error ('text mismatch for %s', label) ;
@@ -98,44 +101,22 @@ end
 
 function value = expected_text (value)
 
+% Map the value onto the two classes the writer stores, char and cellstr.
 if (ischar (value))
-    if (isempty (value) && size (value, 1) == 0)
-        value = {''} ;
-    else
-        chars = value ;
-        value = cell (size (chars, 1), 1) ;
-        for k = 1:size (chars, 1)
-            value{k} = chars (k, :) ;
-        end
-    end
+    return
 elseif (iscellstr (value))
     value = value (:) ;
+    for k = 1:numel (value)
+        value{k} = reshape (char (value{k}), 1, [ ]) ;
+    end
 elseif (exist ('isstring', 'builtin') && isstring (value))
-    value = cellstr (value (:)) ;
+    if (isscalar (value))
+        value = char (value) ;
+    else
+        value = cellstr (value (:)) ;
+    end
 else
     error ('unexpected text type') ;
-end
-value = normalize_text_cells (value) ;
-
-
-function value = h5_text_to_cellstr (value)
-
-if (iscell (value))
-    value = value (:) ;
-elseif (ischar (value))
-    value = expected_text (value) ;
-elseif (exist ('isstring', 'builtin') && isstring (value))
-    value = cellstr (value (:)) ;
-else
-    error ('unexpected HDF5 text type') ;
-end
-value = normalize_text_cells (value) ;
-
-
-function value = normalize_text_cells (value)
-
-for k = 1:numel (value)
-    value{k} = reshape (char (value{k}), 1, [ ]) ;
 end
 
 

--- a/MATLAB_Tools/SuiteSparseCollection/ssexport.m
+++ b/MATLAB_Tools/SuiteSparseCollection/ssexport.m
@@ -79,6 +79,11 @@ if (any (strcmp (formats, 'BSP')))
                 ['checking BSP output requires binsparse_to_ssmc_problem ' ...
                  'on the path']) ;
         end
+        if (exist ('binsparse_read_string_dataset', 'file') ~= 3)
+            error ('SuiteSparse:ssexport:MissingBinsparseStringReader', ...
+                ['checking BSP output requires the ' ...
+                 'binsparse_read_string_dataset MEX function']) ;
+        end
     end
 end
 

--- a/MATLAB_Tools/SuiteSparseCollection/ssread.m
+++ b/MATLAB_Tools/SuiteSparseCollection/ssread.m
@@ -55,8 +55,9 @@ function Problem = ssread (directory, tmp)
 % can be read by MATLAB (via ssread) and a non-MATLAB program (the MM, RB, or
 % Binsparse versions of the collection).
 %
-% Reading Binsparse output requires binsparse_read and
-% binsparse_to_ssmc_problem from the Binsparse MATLAB bindings.
+% Reading Binsparse output requires binsparse_read,
+% binsparse_read_string_dataset, and binsparse_to_ssmc_problem from the
+% Binsparse MATLAB bindings.
 %
 % See also sswrite, mread, mwrite, RBread, ssget, untar, tempdir.
 
@@ -462,6 +463,10 @@ if (isempty (which ('binsparse_to_ssmc_problem')))
     error ('SuiteSparse:ssread:MissingBinsparseConverter', ...
         'BSP input requires binsparse_to_ssmc_problem') ;
 end
+if (exist ('binsparse_read_string_dataset', 'file') ~= 3)
+    error ('SuiteSparse:ssread:MissingBinsparseStringReader', ...
+        'BSP input requires the binsparse_read_string_dataset MEX function') ;
+end
 
 try
     descriptor_text = h5readatt (bspfile, '/', 'binsparse') ;
@@ -493,7 +498,7 @@ for k = 1:numel (info.Datasets)
     if (any (strcmp (component, reserved)))
         continue
     end
-    value = h5read (bspfile, ['/' component]) ;
+    value = binsparse_read_string_dataset (bspfile, ['/' component]) ;
     bsp_problem = add_bsp_component (bsp_problem, component, value) ;
 end
 

--- a/MATLAB_Tools/SuiteSparseCollection/sswrite.m
+++ b/MATLAB_Tools/SuiteSparseCollection/sswrite.m
@@ -128,7 +128,9 @@ function sswrite (Problem, Master, arg3, arg4)
 % The primary matrix, explicit zero pattern, b, x, and numeric aux matrices are
 % written to a single Binsparse HDF5 file, with a .bsp.h5 extension.  Aux char
 % arrays and cell arrays of strings are written as root-level HDF5 string
-% datasets.  The file is placed directly in its group directory as
+% datasets: a char array as a fixed-length dataset whose width is the array's
+% own, and a cell array of strings as a variable-length one, so that ssread can
+% tell the two apart.  The file is placed directly in its group directory as
 % Master/Group/Name.bsp.h5.  BSP output requires the Binsparse MATLAB bindings
 % on the MATLAB path.
 %


### PR DESCRIPTION
This PR stores string aux data using either a fixed-sized dataset or a 1D dataset of variable-length strings, depending on the Matlab type.  This should fix the round-trip so that `isequal(...)` always resolves to true.